### PR TITLE
Revert paginated endpoint changes

### DIFF
--- a/datadog_sync/utils/custom_client.py
+++ b/datadog_sync/utils/custom_client.py
@@ -100,10 +100,7 @@ def paginated_request(func):
         resources = []
         while remaining > 0:
             params = {"page[size]": page_size, "page[number]": page_number}
-            if kwargs.get("params"):
-                kwargs["params"].update(params)
-            else:
-                kwargs["params"] = params
+            kwargs["params"] = kwargs.get("params", {}).update(params)
 
             resp = func(*args, **kwargs)
             resp.raise_for_status()


### PR DESCRIPTION
Revert paginated endpoint changes. Since update method replaces the values, kwarg.params is always replaced by the new params.