### PR TITLE
Fix Dependency Graph Unit Tests

### DIFF
--- a/tests/unit/test_resource_utils.py
+++ b/tests/unit/test_resource_utils.py
@@ -13,7 +13,7 @@ from datadog_sync.models import (
     LogsCustomPipelines,
     # IntegrationsAWS,
 )
-from datadog_sync.cli import get_import_order, get_resources, get_resources_dependency_graph
+from datadog_sync.cli import get_import_order
 
 
 def test_replace_one_level_key():


### PR DESCRIPTION
Remove hardcoded tests such as `expected_graph` and `expected_nbr_dependencies` and only check that all resources in the order_list are created before their dependencies.
