### PR TITLE
Set default workers to 10

### DIFF
--- a/datadog_sync/utils/configuration.py
+++ b/datadog_sync/utils/configuration.py
@@ -70,7 +70,7 @@ def build_config(**kwargs: Any) -> Configuration:
     # Additional settings
     force_missing_dependencies = kwargs.get("force_missing_dependencies")
     skip_failed_resource_connections = kwargs.get("skip_failed_resource_connections")
-    max_workers = kwargs.get("max_workers")
+    max_workers = kwargs.get("max_workers", 10)
 
     # Initialize Configuration
     config = Configuration(


### PR DESCRIPTION
The default HTTP pool size is 10 so no need to get above that by default.