### PR TITLE
Ignore metadata field in notebooks

### DIFF
--- a/datadog_sync/model/notebooks.py
+++ b/datadog_sync/model/notebooks.py
@@ -15,7 +15,7 @@ class Notebooks(BaseResource):
     resource_config = ResourceConfig(
         resource_connections={},
         base_path="/api/v1/notebooks",
-        excluded_attributes=["id", "attributes.created", "attributes.modified", "attributes.author"],
+        excluded_attributes=["id", "attributes.created", "attributes.modified", "attributes.author", "attributes.metadata"],
     )
     # Additional Notebooks specific attributes
 


### PR DESCRIPTION
An `is_template` field was added to notebooks `create` endpoints (under MetadataSchema) , but is not returned in `get` endpoints, so we should exclude that field in our diff operations. 