### PR TITLE
Skip slo alert for monitors and fix default resource connections for type list

### DIFF
--- a/datadog_sync/model/monitors.py
+++ b/datadog_sync/model/monitors.py
@@ -37,7 +37,7 @@ class Monitors(BaseResource):
         return resp
 
     def import_resource(self, resource: Dict) -> None:
-        if resource["type"] == "synthetics alert":
+        if resource["type"] in ("synthetics alert", "slo alert"):
             return
 
         self.resource_config.source_resources[str(resource["id"])] = resource

--- a/datadog_sync/utils/base_resource.py
+++ b/datadog_sync/utils/base_resource.py
@@ -80,13 +80,23 @@ class BaseResource(abc.ABC):
     @abc.abstractmethod
     def connect_id(self, key: str, r_obj: Dict, resource_to_connect: str) -> None:
         resources = self.config.resources[resource_to_connect].resource_config.destination_resources
-        _id = str(r_obj[key])
-        if _id in resources:
-            # Cast resource id to str on int based on source type
-            type_attr = type(r_obj[key])
-            r_obj[key] = type_attr(resources[_id]["id"])
+        if isinstance(r_obj[key], list):
+            for i, v in enumerate(r_obj[key]):
+                _id = str(v)
+                if _id in resources:
+                    # Cast resource id to str or int based on source type
+                    type_attr = type(v)
+                    r_obj[key][i] = type_attr(resources[_id]["id"])
+                else:
+                    raise ResourceConnectionError(resource_to_connect, _id=_id)
         else:
-            raise ResourceConnectionError(resource_to_connect, _id=_id)
+            _id = str(r_obj[key])
+            if _id in resources:
+                # Cast resource id to str on int based on source type
+                type_attr = type(r_obj[key])
+                r_obj[key] = type_attr(resources[_id]["id"])
+            else:
+                raise ResourceConnectionError(resource_to_connect, _id=_id)
 
     def import_resources(self) -> None:
         # reset source resources obj


### PR DESCRIPTION
This pr contains 2 fixes
1) Skips monitor  type `slo alert` as it is not created directly via montiors endpoint
2) Fixes default resource connection when attribute is list of id's