### PR TITLE
Handle existing metric tag configurations in destination

### DIFF
--- a/datadog_sync/model/metric_tag_configurations.py
+++ b/datadog_sync/model/metric_tag_configurations.py
@@ -31,11 +31,12 @@ class MetricTagConfigurations(BaseResource):
         pass
 
     def pre_apply_hook(self, resources: Dict[str, Dict]) -> Optional[list]:
-        pass
+        self.destination_metric_tag_configurations = self.get_destination_metric_tag_configuration()
+        return None
 
     def create_resource(self, _id: str, resource: Dict) -> None:
         if _id in self.destination_metric_tag_configurations:
-            self.resource_config.destination_resources[_id] = self.destination_metric_tag_configurations[resource[_id]]
+            self.resource_config.destination_resources[_id] = self.destination_metric_tag_configurations[_id]
             self.update_resource(_id, resource)
             return
 

--- a/tests/integration/resources/cassettes/test_metric_tag_configurations/TestMetricConfigurationResources.test_resource_import.yaml
+++ b/tests/integration/resources/cassettes/test_metric_tag_configurations/TestMetricConfigurationResources.test_resource_import.yaml
@@ -11,30 +11,39 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - datadog-sync-cli/0.0.1 (python 3.8.5; os darwin; arch x86_64)
+      - datadog-sync-cli/0.0.1 (python 3.9.10; os darwin; arch x86_64)
+      x-datadog-parent-id:
+      - '7650201046904542057'
+      x-datadog-sampling-priority:
+      - '1'
+      x-datadog-trace-id:
+      - '15720991990566239154'
     method: GET
     uri: https://api.datadoghq.com/api/v2/metrics?filter%5Bconfigured%5D=true
   response:
     body:
-      string: '{"data": [{"type": "manage_tags", "id": "test.metric.distribution.example",
-        "attributes": {"tags": ["datacenter", "app"], "include_percentiles": false,
-        "created_at": "2021-10-27T18:25:12.901720+00:00", "modified_at": "2021-10-27T18:33:34.966856+00:00",
-        "metric_type": "distribution"}}]}'
+      string: '{"data": [{"type": "manage_tags", "id": "test.metric.latency.nonexistent",
+        "attributes": {"tags": ["datacenter", "app"], "created_at": "2022-02-16T20:17:00.889433+00:00",
+        "modified_at": "2022-02-16T20:17:00.889433+00:00", "metric_type": "gauge",
+        "aggregations": [{"space": "avg", "time": "avg"}]}}, {"type": "manage_tags",
+        "id": "test.metric.distribution.example", "attributes": {"tags": ["check_id",
+        "check"], "include_percentiles": false, "created_at": "2021-10-27T18:25:12.901720+00:00",
+        "modified_at": "2021-11-01T17:30:23.846790+00:00", "metric_type": "distribution"}}]}'
     headers:
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Fri, 29 Oct 2021 17:19:12 GMT
+      - Wed, 16 Feb 2022 20:46:20 GMT
       Transfer-Encoding:
       - chunked
       cache-control:
       - no-cache
       content-length:
-      - '270'
+      - '540'
       content-security-policy:
-      - frame-ancestors 'self'; report-uri https://api.datadoghq.com/csp-report
+      - frame-ancestors 'self'; report-uri https://logs.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pube4f163c23bbf91c16b8f57f56af9fc58&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=site%3Adatadoghq.com
       pragma:
       - no-cache
       strict-transport-security:
@@ -47,12 +56,14 @@ interactions:
       - SAMEORIGIN
       x-ratelimit-limit:
       - '50'
+      x-ratelimit-name:
+      - manage_tags_api
       x-ratelimit-period:
       - '60'
       x-ratelimit-remaining:
       - '49'
       x-ratelimit-reset:
-      - '48'
+      - '40'
     status:
       code: 200
       message: OK

--- a/tests/integration/resources/cassettes/test_metric_tag_configurations/TestMetricConfigurationResources.test_resource_sync.yaml
+++ b/tests/integration/resources/cassettes/test_metric_tag_configurations/TestMetricConfigurationResources.test_resource_sync.yaml
@@ -1,7 +1,138 @@
 interactions:
 - request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - datadog-sync-cli/0.0.1 (python 3.9.10; os darwin; arch x86_64)
+      x-datadog-parent-id:
+      - '1586841844950341477'
+      x-datadog-sampling-priority:
+      - '1'
+      x-datadog-trace-id:
+      - '6469562126581628118'
+    method: GET
+    uri: https://api.datadoghq.eu/api/v2/metrics?filter%5Bconfigured%5D=true
+  response:
+    body:
+      string: '{"data": []}'
+    headers:
+      Alt-Svc:
+      - clear
+      Via:
+      - 1.1 google
+      cache-control:
+      - no-cache
+      content-length:
+      - '11'
+      content-security-policy:
+      - frame-ancestors 'self'; report-uri https://logs.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pube4f163c23bbf91c16b8f57f56af9fc58&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=site%3Adatadoghq.eu
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Feb 2022 20:46:20 GMT
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=15724800;
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ratelimit-limit:
+      - '50'
+      x-ratelimit-name:
+      - manage_tags_api
+      x-ratelimit-period:
+      - '60'
+      x-ratelimit-remaining:
+      - '46'
+      x-ratelimit-reset:
+      - '40'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"data": {"type": "manage_tags", "id": "test.metric.latency.nonexistent",
+      "attributes": {"tags": ["datacenter", "app"], "metric_type": "gauge", "aggregations":
+      [{"space": "avg", "time": "avg"}]}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '196'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - datadog-sync-cli/0.0.1 (python 3.9.10; os darwin; arch x86_64)
+      x-datadog-parent-id:
+      - '16943446163156031472'
+      x-datadog-sampling-priority:
+      - '1'
+      x-datadog-trace-id:
+      - '3659297663217551664'
+    method: POST
+    uri: https://api.datadoghq.eu/api/v2/metrics/test.metric.latency.nonexistent/tags
+  response:
+    body:
+      string: '{"data": {"type": "manage_tags", "id": "test.metric.latency.nonexistent",
+        "attributes": {"tags": ["datacenter", "app"], "created_at": "2022-02-16T20:21:00.534196+00:00",
+        "modified_at": "2022-02-16T20:46:20.983512+00:00", "metric_type": "gauge",
+        "aggregations": [{"space": "avg", "time": "avg"}]}}}'
+    headers:
+      Alt-Svc:
+      - clear
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 google
+      cache-control:
+      - no-cache
+      content-length:
+      - '278'
+      content-security-policy:
+      - frame-ancestors 'self'; report-uri https://logs.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pube4f163c23bbf91c16b8f57f56af9fc58&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=site%3Adatadoghq.eu
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Feb 2022 20:46:21 GMT
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=15724800;
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ratelimit-limit:
+      - '50'
+      x-ratelimit-name:
+      - manage_tags_api
+      x-ratelimit-period:
+      - '60'
+      x-ratelimit-remaining:
+      - '45'
+      x-ratelimit-reset:
+      - '40'
+    status:
+      code: 201
+      message: Created
+- request:
     body: '{"data": {"type": "manage_tags", "id": "test.metric.distribution.example",
-      "attributes": {"tags": ["datacenter", "app"], "include_percentiles": false,
+      "attributes": {"tags": ["check_id", "check"], "include_percentiles": false,
       "metric_type": "distribution"}}}'
     headers:
       Accept:
@@ -15,14 +146,20 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - datadog-sync-cli/0.0.1 (python 3.8.5; os darwin; arch x86_64)
+      - datadog-sync-cli/0.0.1 (python 3.9.10; os darwin; arch x86_64)
+      x-datadog-parent-id:
+      - '17484445330969234846'
+      x-datadog-sampling-priority:
+      - '1'
+      x-datadog-trace-id:
+      - '13246603441919946232'
     method: POST
     uri: https://api.datadoghq.eu/api/v2/metrics/test.metric.distribution.example/tags
   response:
     body:
       string: '{"data": {"type": "manage_tags", "id": "test.metric.distribution.example",
-        "attributes": {"tags": ["datacenter", "app"], "include_percentiles": false,
-        "created_at": "2021-10-27T18:28:53.198032+00:00", "modified_at": "2021-10-29T17:19:12.657787+00:00",
+        "attributes": {"tags": ["check_id", "check"], "include_percentiles": false,
+        "created_at": "2021-10-27T18:28:53.198032+00:00", "modified_at": "2022-02-16T20:46:21.310502+00:00",
         "metric_type": "distribution"}}}'
     headers:
       Alt-Svc:
@@ -36,11 +173,11 @@ interactions:
       content-length:
       - '268'
       content-security-policy:
-      - frame-ancestors 'self'; report-uri https://api.datadoghq.eu/csp-report
+      - frame-ancestors 'self'; report-uri https://logs.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pube4f163c23bbf91c16b8f57f56af9fc58&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=site%3Adatadoghq.eu
       content-type:
       - application/json
       date:
-      - Fri, 29 Oct 2021 17:19:12 GMT
+      - Wed, 16 Feb 2022 20:46:21 GMT
       pragma:
       - no-cache
       strict-transport-security:
@@ -49,18 +186,18 @@ interactions:
       - Accept-Encoding
       x-content-type-options:
       - nosniff
-      x-envoy-upstream-service-time:
-      - '150'
       x-frame-options:
       - SAMEORIGIN
       x-ratelimit-limit:
       - '50'
+      x-ratelimit-name:
+      - manage_tags_api
       x-ratelimit-period:
       - '60'
       x-ratelimit-remaining:
-      - '49'
+      - '44'
       x-ratelimit-reset:
-      - '48'
+      - '39'
     status:
       code: 201
       message: Created

--- a/tests/integration/resources/cassettes/test_metric_tag_configurations/TestMetricConfigurationResources.test_resource_update_sync.yaml
+++ b/tests/integration/resources/cassettes/test_metric_tag_configurations/TestMetricConfigurationResources.test_resource_update_sync.yaml
@@ -1,7 +1,148 @@
 interactions:
 - request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - datadog-sync-cli/0.0.1 (python 3.9.10; os darwin; arch x86_64)
+      x-datadog-parent-id:
+      - '9633626194525426686'
+      x-datadog-sampling-priority:
+      - '1'
+      x-datadog-trace-id:
+      - '2452982367266299629'
+    method: GET
+    uri: https://api.datadoghq.eu/api/v2/metrics?filter%5Bconfigured%5D=true
+  response:
+    body:
+      string: '{"data": [{"type": "manage_tags", "id": "test.metric.latency.nonexistent",
+        "attributes": {"tags": ["datacenter", "app"], "created_at": "2022-02-16T20:21:00.534196+00:00",
+        "modified_at": "2022-02-16T20:46:20.983512+00:00", "metric_type": "gauge",
+        "aggregations": [{"space": "avg", "time": "avg"}]}}, {"type": "manage_tags",
+        "id": "test.metric.distribution.example", "attributes": {"tags": ["check_id",
+        "check"], "include_percentiles": false, "created_at": "2021-10-27T18:28:53.198032+00:00",
+        "modified_at": "2022-02-16T20:46:21.310502+00:00", "metric_type": "distribution"}}]}'
+    headers:
+      Alt-Svc:
+      - clear
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 google
+      cache-control:
+      - no-cache
+      content-length:
+      - '540'
+      content-security-policy:
+      - frame-ancestors 'self'; report-uri https://logs.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pube4f163c23bbf91c16b8f57f56af9fc58&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=site%3Adatadoghq.eu
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Feb 2022 20:46:21 GMT
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=15724800;
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ratelimit-limit:
+      - '50'
+      x-ratelimit-name:
+      - manage_tags_api
+      x-ratelimit-period:
+      - '60'
+      x-ratelimit-remaining:
+      - '43'
+      x-ratelimit-reset:
+      - '39'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"data": {"type": "manage_tags", "id": "test.metric.latency.nonexistent",
+      "attributes": {"tags": ["datacenter", "app", "updated"], "aggregations": [{"space":
+      "avg", "time": "avg"}]}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '183'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - datadog-sync-cli/0.0.1 (python 3.9.10; os darwin; arch x86_64)
+      x-datadog-parent-id:
+      - '13186157855869745890'
+      x-datadog-sampling-priority:
+      - '1'
+      x-datadog-trace-id:
+      - '3772840949127160386'
+    method: PATCH
+    uri: https://api.datadoghq.eu/api/v2/metrics/test.metric.latency.nonexistent/tags
+  response:
+    body:
+      string: '{"data": {"type": "manage_tags", "id": "test.metric.latency.nonexistent",
+        "attributes": {"tags": ["datacenter", "app", "updated"], "created_at": "2022-02-16T20:21:00.534196+00:00",
+        "modified_at": "2022-02-16T20:46:21.840373+00:00", "metric_type": "gauge",
+        "aggregations": [{"space": "avg", "time": "avg"}]}}}'
+    headers:
+      Alt-Svc:
+      - clear
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 google
+      cache-control:
+      - no-cache
+      content-length:
+      - '288'
+      content-security-policy:
+      - frame-ancestors 'self'; report-uri https://logs.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pube4f163c23bbf91c16b8f57f56af9fc58&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=site%3Adatadoghq.eu
+      content-type:
+      - application/json
+      date:
+      - Wed, 16 Feb 2022 20:46:21 GMT
+      pragma:
+      - no-cache
+      strict-transport-security:
+      - max-age=15724800;
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ratelimit-limit:
+      - '50'
+      x-ratelimit-name:
+      - manage_tags_api
+      x-ratelimit-period:
+      - '60'
+      x-ratelimit-remaining:
+      - '42'
+      x-ratelimit-reset:
+      - '39'
+    status:
+      code: 200
+      message: OK
+- request:
     body: '{"data": {"type": "manage_tags", "id": "test.metric.distribution.example",
-      "attributes": {"tags": ["datacenter", "app", "updated"], "include_percentiles":
+      "attributes": {"tags": ["check_id", "check", "updated"], "include_percentiles":
       false}}}'
     headers:
       Accept:
@@ -15,14 +156,20 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - datadog-sync-cli/0.0.1 (python 3.8.5; os darwin; arch x86_64)
+      - datadog-sync-cli/0.0.1 (python 3.9.10; os darwin; arch x86_64)
+      x-datadog-parent-id:
+      - '17308714051521088428'
+      x-datadog-sampling-priority:
+      - '1'
+      x-datadog-trace-id:
+      - '11840769085188241970'
     method: PATCH
     uri: https://api.datadoghq.eu/api/v2/metrics/test.metric.distribution.example/tags
   response:
     body:
       string: '{"data": {"type": "manage_tags", "id": "test.metric.distribution.example",
-        "attributes": {"tags": ["datacenter", "app", "updated"], "include_percentiles":
-        false, "created_at": "2021-10-27T18:28:53.198032+00:00", "modified_at": "2021-10-29T17:19:13.036736+00:00",
+        "attributes": {"tags": ["check_id", "updated", "check"], "include_percentiles":
+        false, "created_at": "2021-10-27T18:28:53.198032+00:00", "modified_at": "2022-02-16T20:46:22.126137+00:00",
         "metric_type": "distribution"}}}'
     headers:
       Alt-Svc:
@@ -36,11 +183,11 @@ interactions:
       content-length:
       - '278'
       content-security-policy:
-      - frame-ancestors 'self'; report-uri https://api.datadoghq.eu/csp-report
+      - frame-ancestors 'self'; report-uri https://logs.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=pube4f163c23bbf91c16b8f57f56af9fc58&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=site%3Adatadoghq.eu
       content-type:
       - application/json
       date:
-      - Fri, 29 Oct 2021 17:19:13 GMT
+      - Wed, 16 Feb 2022 20:46:22 GMT
       pragma:
       - no-cache
       strict-transport-security:
@@ -53,12 +200,14 @@ interactions:
       - SAMEORIGIN
       x-ratelimit-limit:
       - '50'
+      x-ratelimit-name:
+      - manage_tags_api
       x-ratelimit-period:
       - '60'
       x-ratelimit-remaining:
-      - '48'
+      - '41'
       x-ratelimit-reset:
-      - '47'
+      - '38'
     status:
       code: 200
       message: OK


### PR DESCRIPTION
We need to import existing metric tag configurations first as duplicates are not allowed.