### PR TITLE
Bump python base image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:slim-buster@sha256:6fd99c1c6bac8abf9952cb797dc409ac92e8fbedd4d080211381a69c213b509b
+FROM python:3.11-slim-buster
 
 # Install CLI
 COPY . /datadog-sync-cli


### PR DESCRIPTION
closes: https://github.com/DataDog/datadog-sync-cli/issues/138