### PR TITLE
Dump synthetics private location config data on create

### DIFF
--- a/datadog_sync/model/synthetics_private_locations.py
+++ b/datadog_sync/model/synthetics_private_locations.py
@@ -45,9 +45,9 @@ class SyntheticsPrivateLocations(BaseResource):
 
     def create_resource(self, _id: str, resource: Dict) -> None:
         destination_client = self.config.destination_client
-        resp = destination_client.post(self.resource_config.base_path, resource).json()["private_location"]
-
-        self.resource_config.destination_resources[_id] = resp
+        resp = destination_client.post(self.resource_config.base_path, resource).json()
+        self.resource_config.destination_resources[_id] = resp["private_location"]
+        self.resource_config.destination_resources[_id]["config"] = resp["config"]
 
     def update_resource(self, _id: str, resource: Dict) -> None:
         destination_client = self.config.destination_client

--- a/datadog_sync/model/synthetics_private_locations.py
+++ b/datadog_sync/model/synthetics_private_locations.py
@@ -18,7 +18,16 @@ class SyntheticsPrivateLocations(BaseResource):
     resource_type = "synthetics_private_locations"
     resource_config = ResourceConfig(
         base_path="/api/v1/synthetics/private-locations",
-        excluded_attributes=["id", "modifiedAt", "createdAt", "createdBy", "metadata", "secrets", "config"],
+        excluded_attributes=[
+            "id",
+            "modifiedAt",
+            "createdAt",
+            "createdBy",
+            "metadata",
+            "secrets",
+            "config",
+            "result_encryption",
+        ],
     )
     # Additional SyntheticsPrivateLocations specific attributes
     base_locations_path: str = "/api/v1/synthetics/locations"

--- a/datadog_sync/model/synthetics_private_locations.py
+++ b/datadog_sync/model/synthetics_private_locations.py
@@ -45,9 +45,12 @@ class SyntheticsPrivateLocations(BaseResource):
 
     def create_resource(self, _id: str, resource: Dict) -> None:
         destination_client = self.config.destination_client
+
         resp = destination_client.post(self.resource_config.base_path, resource).json()
+
         self.resource_config.destination_resources[_id] = resp["private_location"]
-        self.resource_config.destination_resources[_id]["config"] = resp["config"]
+        self.resource_config.destination_resources[_id]["config"] = resp.get("config")
+        self.resource_config.destination_resources[_id]["result_encryption"] = resp.get("result_encryption")
 
     def update_resource(self, _id: str, resource: Dict) -> None:
         destination_client = self.config.destination_client

--- a/datadog_sync/utils/custom_client.py
+++ b/datadog_sync/utils/custom_client.py
@@ -154,6 +154,7 @@ def remaining_func(idx, resp, page_size, page_number):
 def page_number_func(idx, page_size, page_number):
     return page_number + 1
 
+
 @dataclass
 class PaginationConfig(object):
     page_size: Optional[int] = 100


### PR DESCRIPTION
The config object is only returned on create and we need to save this to state since it is required to start private location workers