### PR TITLE
Added support for the "Not" Operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.devcontainer/
 
 # Spyder project settings
 .spyderproject
@@ -144,3 +145,5 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+config

--- a/.gitignore
+++ b/.gitignore
@@ -145,5 +145,3 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
-
-config

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Available keys:
 - `Name`: Attribute key to filter on. This can be any attribute represented in dot notation (such as `attributes.user_count`). [required]
 - `Value`: Regex to filter attribute value by. Note: special regex characters need to be escaped if filtering by raw string. [required]
 - `Operator`: Available operators are below. All invalid operator's default to `ExactMatch`.
-  - `Not`: Inverse of `ExactMatch`.
+  - `Not`: Match not equal to `Value`.
   - `SubString` (*Deprecated*): Sub string matching. (This operator will be removed in future releases. See [SubString and ExactMatch Deprecation](#substring-and-exactmatch-deprecation)  section.)
   - `ExactMatch` (*Deprecated*): Exact string match. (This operator will be removed in future releases. See [SubString and ExactMatch Deprecation](#substring-and-exactmatch-deprecation)  section.)
 

--- a/README.md
+++ b/README.md
@@ -2,16 +2,27 @@
 Datadog cli tool to sync resources across organizations.
 
 # Table of Contents
-- [Purpose](#purpose)
-- [Requirements](#requirements)
-- [Supported resources](#supported-resources)
-- [Installation](#Installation)
-- [Usage](#usage)
-  - [API URL](#api-url)
-  - [Filtering](#filtering)
-  - [Config File](#config-file)
-  - [Cleanup flag](#cleanup-flag)
-- [Best Practices](#best-practices)
+- [datadog-sync-cli](#datadog-sync-cli)
+- [Table of Contents](#table-of-contents)
+  - [Purpose](#purpose)
+  - [Requirements](#requirements)
+  - [Supported resources](#supported-resources)
+  - [Installation](#installation)
+    - [Installing from source](#installing-from-source)
+    - [Installing from Releases](#installing-from-releases)
+      - [MacOS and Linux](#macos-and-linux)
+      - [Windows](#windows)
+    - [Using docker and building the image](#using-docker-and-building-the-image)
+  - [Usage](#usage)
+      - [API URL](#api-url)
+      - [Filtering](#filtering)
+        - [Top resources level filtering](#top-resources-level-filtering)
+        - [Per resource level filtering](#per-resource-level-filtering)
+          - [SubString and ExactMatch Deprecation](#substring-and-exactmatch-deprecation)
+      - [Config file](#config-file)
+      - [Cleanup flag](#cleanup-flag)
+  - [Workflow](#workflow)
+  - [Best practices](#best-practices)
 
 ## Purpose
 
@@ -174,22 +185,24 @@ Available keys:
 - `Name`: Attribute key to filter on. This can be any attribute represented in dot notation (such as `attributes.user_count`). [required]
 - `Value`: Regex to filter attribute value by. Note: special regex characters need to be escaped if filtering by raw string. [required]
 - `Operator`: Available operators are below. All invalid operator's default to `ExactMatch`.
-  - `SubString`: Sub string matching. (This operator will be removed in future releases, for more information read the [SubString Deprecation Section](#substring-deprecation) below)
-  - `ExactMatch`: Exact string match.
+  - `SubString`: Sub string matching. (This operator will be removed in future releases, for more information read the [SubString Deprecation Section](#substring-and-exactmatch-deprecation) below)
+  - `ExactMatch`: Exact string match. (This operator will be removed in future releases, for more information read the [SubString Deprecation Section](#substring-and-exactmatch-deprecation) below)
   - `Not`: Inverse of `ExactMatch`.
 
 By default, if multiple filters are passed for the same resource, `OR` logic is applied to the filters. This behavior can be adjusted using the `--filter-operator` option.
 
-###### SubString Deprecation
+###### SubString and ExactMatch Deprecation
 
-In future releases the `SubString` Operator will be removed. What is planned is that when you use the `ExactMatch` operator, we will use that with regex directly. What this means is that you will still have the `SubString` behavior but will need to provide that in a regex form in the `Value` key. Below is an example:
+In future releases the `SubString` and `ExactMatch` Operator will be removed. This is because the `Value` key supports regex so both of these scenarios are covered by just writing the appropriate regex.  Below is an example:
 
-Let's take the scenario where you would like to filter for Monitors that have the substring `filter test` in the `name` attribute, below you can see the query before and after `SubString` is deprecated.
+Let's take the scenario where you would like to filter for Monitors that have the `filter test` in the `name` attribute, below you can see how you would filter for both `SubString` and `ExactMatch`:
 
-| Status | Command |
-| :-: | :-: |
-| Before `SubString` Deprecation | `--filter 'Type=monitors;Name=name;Value=filter test;Operator=SubString'` |
-| After `SubString` Deprecation | `--filter 'Type=monitors;Name=name;Value=.*filter test.*;Operator=ExactMatch'` |
+| Operator| Status | Command |
+| :-: | :-: | :-: |
+| SubString | Before  Deprecation | `--filter 'Type=monitors;Name=name;Value=filter test;Operator=SubString'` |
+| SubString | After Deprecation | `--filter 'Type=monitors;Name=name;Value=.*filter test.*` |
+| ExactMatch | Before  Deprecation | `--filter 'Type=monitors;Name=name;Value=filter test;Operator=ExactMatch'` |
+| ExactMatch | After Deprecation | `--filter 'Type=monitors;Name=name;Value=^filter test$` |
 
 #### Config file
 

--- a/README.md
+++ b/README.md
@@ -185,9 +185,9 @@ Available keys:
 - `Name`: Attribute key to filter on. This can be any attribute represented in dot notation (such as `attributes.user_count`). [required]
 - `Value`: Regex to filter attribute value by. Note: special regex characters need to be escaped if filtering by raw string. [required]
 - `Operator`: Available operators are below. All invalid operator's default to `ExactMatch`.
-  - `SubString`: Sub string matching. (This operator will be removed in future releases, for more information read the [SubString and ExactMatch Deprecation Section](#substring-and-exactmatch-deprecation) below)
-  - `ExactMatch`: Exact string match. (This operator will be removed in future releases, for more information read the [SubString and ExactMatch Deprecation Section](#substring-and-exactmatch-deprecation) below)
   - `Not`: Inverse of `ExactMatch`.
+  - `SubString` (*Deprecated*): Sub string matching. (This operator will be removed in future releases. See [SubString and ExactMatch Deprecation](#substring-and-exactmatch-deprecation)  section.)
+  - `ExactMatch` (*Deprecated*): Exact string match. (This operator will be removed in future releases. See [SubString and ExactMatch Deprecation](#substring-and-exactmatch-deprecation)  section.)
 
 By default, if multiple filters are passed for the same resource, `OR` logic is applied to the filters. This behavior can be adjusted using the `--filter-operator` option.
 

--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ Available keys:
 - `Name`: Attribute key to filter on. This can be any attribute represented in dot notation (such as `attributes.user_count`). [required]
 - `Value`: Regex to filter attribute value by. Note: special regex characters need to be escaped if filtering by raw string. [required]
 - `Operator`: Available operators are below. All invalid operator's default to `ExactMatch`.
-  - `SubString`: Sub string matching. (This operator will be removed in future releases, for more information read the [SubString Deprecation Section](#substring-and-exactmatch-deprecation) below)
-  - `ExactMatch`: Exact string match. (This operator will be removed in future releases, for more information read the [SubString Deprecation Section](#substring-and-exactmatch-deprecation) below)
+  - `SubString`: Sub string matching. (This operator will be removed in future releases, for more information read the [SubString and ExactMatch Deprecation Section](#substring-and-exactmatch-deprecation) below)
+  - `ExactMatch`: Exact string match. (This operator will be removed in future releases, for more information read the [SubString and ExactMatch Deprecation Section](#substring-and-exactmatch-deprecation) below)
   - `Not`: Inverse of `ExactMatch`.
 
 By default, if multiple filters are passed for the same resource, `OR` logic is applied to the filters. This behavior can be adjusted using the `--filter-operator` option.

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ By default, if multiple filters are passed for the same resource, `OR` logic is 
 
 In future releases the `SubString` and `ExactMatch` Operator will be removed. This is because the `Value` key supports regex so both of these scenarios are covered by just writing the appropriate regex.  Below is an example:
 
-Let's take the scenario where you would like to filter for Monitors that have the `filter test` in the `name` attribute, below you can see how you would filter for both `SubString` and `ExactMatch`:
+Let's take the scenario where you would like to filter for monitors that have the `filter test` in the `name` attribute:
 
 | Operator| Status | Command |
 | :-: | :-: | :-: |

--- a/README.md
+++ b/README.md
@@ -191,18 +191,18 @@ Available keys:
 
 By default, if multiple filters are passed for the same resource, `OR` logic is applied to the filters. This behavior can be adjusted using the `--filter-operator` option.
 
-###### SubString and ExactMatch Deprecation
+##### SubString and ExactMatch Deprecation
 
 In future releases the `SubString` and `ExactMatch` Operator will be removed. This is because the `Value` key supports regex so both of these scenarios are covered by just writing the appropriate regex.  Below is an example:
 
 Let's take the scenario where you would like to filter for monitors that have the `filter test` in the `name` attribute:
 
-| Operator| Status | Command |
-| :-: | :-: | :-: |
-| SubString | Before  Deprecation | `--filter 'Type=monitors;Name=name;Value=filter test;Operator=SubString'` |
-| Using `Value` | After Deprecation | `--filter 'Type=monitors;Name=name;Value=.*filter test.*` |
-| ExactMatch | Before  Deprecation | `--filter 'Type=monitors;Name=name;Value=filter test;Operator=ExactMatch'` |
-| Using Value | After Deprecation | `--filter 'Type=monitors;Name=name;Value=^filter test$` |
+| Operator | Command |
+| :-: | :-: |
+| `SubString` | `--filter 'Type=monitors;Name=name;Value=filter test;Operator=SubString'` |
+| Using `Value` | `--filter 'Type=monitors;Name=name;Value=.*filter test.*` |
+| `ExactMatch` | `--filter 'Type=monitors;Name=name;Value=filter test;Operator=ExactMatch'` |
+| Using `Value` | `--filter 'Type=monitors;Name=name;Value=^filter test$` |
 
 #### Config file
 

--- a/README.md
+++ b/README.md
@@ -174,10 +174,22 @@ Available keys:
 - `Name`: Attribute key to filter on. This can be any attribute represented in dot notation (such as `attributes.user_count`). [required]
 - `Value`: Regex to filter attribute value by. Note: special regex characters need to be escaped if filtering by raw string. [required]
 - `Operator`: Available operators are below. All invalid operator's default to `ExactMatch`.
-  - `SubString`: Sub string matching.
+  - `SubString`: Sub string matching. (This operator will be removed in future releases, for more information read the [SubString Deprecation Section](#substring-deprecation) below)
   - `ExactMatch`: Exact string match.
+  - `Not`: Inverse of `ExactMatch`.
 
 By default, if multiple filters are passed for the same resource, `OR` logic is applied to the filters. This behavior can be adjusted using the `--filter-operator` option.
+
+###### SubString Deprecation
+
+In future releases the `SubString` Operator will be removed. What is planned is that when you use the `ExactMatch` operator, we will use that with regex directly. What this means is that you will still have the `SubString` behavior but will need to provide that in a regex form in the `Value` key. Below is an example:
+
+Let's take the scenario where you would like to filter for Monitors that have the substring `filter test` in the `name` attribute, below you can see the query before and after `SubString` is deprecated.
+
+| Status | Command |
+| :-: | :-: |
+| Before `SubString` Deprecation | `--filter 'Type=monitors;Name=name;Value=filter test;Operator=SubString'` |
+| After `SubString` Deprecation | `--filter 'Type=monitors;Name=name;Value=.*filter test.*;Operator=ExactMatch'` |
 
 #### Config file
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Let's take the scenario where you would like to filter for monitors that have th
 | SubString | Before  Deprecation | `--filter 'Type=monitors;Name=name;Value=filter test;Operator=SubString'` |
 | Using `Value` | After Deprecation | `--filter 'Type=monitors;Name=name;Value=.*filter test.*` |
 | ExactMatch | Before  Deprecation | `--filter 'Type=monitors;Name=name;Value=filter test;Operator=ExactMatch'` |
-| ExactMatch | After Deprecation | `--filter 'Type=monitors;Name=name;Value=^filter test$` |
+| Using Value | After Deprecation | `--filter 'Type=monitors;Name=name;Value=^filter test$` |
 
 #### Config file
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Let's take the scenario where you would like to filter for monitors that have th
 | Operator| Status | Command |
 | :-: | :-: | :-: |
 | SubString | Before  Deprecation | `--filter 'Type=monitors;Name=name;Value=filter test;Operator=SubString'` |
-| SubString | After Deprecation | `--filter 'Type=monitors;Name=name;Value=.*filter test.*` |
+| Using `Value` | After Deprecation | `--filter 'Type=monitors;Name=name;Value=.*filter test.*` |
 | ExactMatch | Before  Deprecation | `--filter 'Type=monitors;Name=name;Value=filter test;Operator=ExactMatch'` |
 | ExactMatch | After Deprecation | `--filter 'Type=monitors;Name=name;Value=^filter test$` |
 

--- a/config
+++ b/config
@@ -1,0 +1,5 @@
+source_api_key="55091d809228529436d6c7c178896c75"
+source_app_key="e85d7a6ebb9fb6f6f7a1083060059d45d563c079"
+source_api_url="https://api.datadoghq.com"
+resources="monitors,dashboards"
+filter=['Type=monitors;Name=tags;Value=owner:aldrick;Operator=Not','Type=dashboards;Name=title;Value=Lab Dashboard;Operator=Not']

--- a/config
+++ b/config
@@ -1,5 +1,0 @@
-source_api_key="55091d809228529436d6c7c178896c75"
-source_app_key="e85d7a6ebb9fb6f6f7a1083060059d45d563c079"
-source_api_url="https://api.datadoghq.com"
-resources="monitors,dashboards"
-filter=['Type=monitors;Name=tags;Value=owner:aldrick;Operator=Not','Type=dashboards;Name=title;Value=Lab Dashboard;Operator=Not']

--- a/datadog_sync/model/downtime_schedules.py
+++ b/datadog_sync/model/downtime_schedules.py
@@ -26,7 +26,7 @@ class DowntimeSchedules(BaseResource):
             "attributes.status",
             "attributes.canceled",
             "relationships",
-            "attributes.schedule.current_downtime"
+            "attributes.schedule.current_downtime",
         ],
     )
     # Additional DowntimeSchedules specific attributes

--- a/datadog_sync/utils/filter.py
+++ b/datadog_sync/utils/filter.py
@@ -106,8 +106,9 @@ def process_filters(filter_list: List[str]) -> Dict[str, List[Filter]]:
                 updated as this behavior will be removed in the future. See the official README for more information"
             )
 
-        # Build and assign regex matcher to VALUE key
-        f_dict[FILTER_VALUE_KEY] = build_regex(f_dict)
+        # Build and assign regex matcher to VALUE key for the deprecated Operators
+        if f_dict[FILTER_OPERATOR_KEY].lower() != NOT_OPERATOR:
+            handle_deprecated_operator(f_dict)
 
         f_instance = Filter(
             f_dict[FILTER_TYPE_KEY].lower(),
@@ -123,17 +124,21 @@ def process_filters(filter_list: List[str]) -> Dict[str, List[Filter]]:
     return filters
 
 
-def build_regex(f_dict):
+def handle_deprecated_operator(f_dict):
     # We are keeping this for backwards compatiblity. In the future this will be removed as the user can already
     # acheive substring behavior using regex
 
-    if FILTER_OPERATOR_KEY in f_dict and f_dict[FILTER_OPERATOR_KEY].lower() == SUBSTRING_OPERATOR:
+    operator_lower = f_dict[FILTER_OPERATOR_KEY].lower()
+    reg_exp = f_dict[FILTER_VALUE_KEY]
+
+    if operator_lower == SUBSTRING_OPERATOR:
         reg_exp = f".*{f_dict[FILTER_VALUE_KEY]}.*"
         log.warning(
             "The Filter Operator `SubString` will be removed in future versions, please refer to the Best \
             Practices Section in our README.md for more information."
         )
-    else:
+
+    elif operator_lower == EXACT_MATCH_OPERATOR:
         reg_exp = f"^{f_dict[FILTER_VALUE_KEY]}$"
 
-    return reg_exp
+    f_dict[FILTER_VALUE_KEY] = reg_exp

--- a/datadog_sync/utils/filter.py
+++ b/datadog_sync/utils/filter.py
@@ -97,11 +97,12 @@ def process_filters(filter_list: List[str]) -> Dict[str, List[Filter]]:
         if invalid_filter:
             continue
 
-        # Build and assign regex matcher to VALUE key
-        f_dict[FILTER_VALUE_KEY] = build_regex(f_dict)
-
         if not f_dict.get(FILTER_OPERATOR_KEY):
             f_dict[FILTER_OPERATOR_KEY] = EXACT_MATCH_OPERATOR
+            log.warning("Defaulting the Filter Operator to `ExactMatch` will be removed in the future")
+
+        # Build and assign regex matcher to VALUE key
+        f_dict[FILTER_VALUE_KEY] = build_regex(f_dict)
 
         f_instance = Filter(
             f_dict[FILTER_TYPE_KEY].lower(),
@@ -118,8 +119,12 @@ def process_filters(filter_list: List[str]) -> Dict[str, List[Filter]]:
 
 
 def build_regex(f_dict):
+    # We are keeping this for backwards compatiblity. In the future this will be removed as the user can already 
+    # acheive substring behavior using regex
+
     if FILTER_OPERATOR_KEY in f_dict and f_dict[FILTER_OPERATOR_KEY].lower() == SUBSTRING_OPERATOR:
         reg_exp = f".*{f_dict[FILTER_VALUE_KEY]}.*"
+        log.warning("The Filter Operator `SubString` will be removed in future versions, please refer to the Best Practices Section in our README.md for more information.")
     else:
         reg_exp = f"^{f_dict[FILTER_VALUE_KEY]}$"
 

--- a/datadog_sync/utils/filter.py
+++ b/datadog_sync/utils/filter.py
@@ -97,8 +97,8 @@ def process_filters(filter_list: List[str]) -> Dict[str, List[Filter]]:
         if invalid_filter:
             continue
 
-        # We are setting ExactMatch as the default as this lines up with the future plans to use the Value Key
-        # directly as the regex for the filter
+        #  Default to EXACT_MATCH_OPERATOR for backward compatibility. This behavior will be removed in the
+        # future as it can already be achieved using regex in the Value.
         if not f_dict.get(FILTER_OPERATOR_KEY):
             f_dict[FILTER_OPERATOR_KEY] = EXACT_MATCH_OPERATOR
             log.warning(

--- a/datadog_sync/utils/filter.py
+++ b/datadog_sync/utils/filter.py
@@ -97,10 +97,14 @@ def process_filters(filter_list: List[str]) -> Dict[str, List[Filter]]:
         if invalid_filter:
             continue
 
-        # We are setting ExactMatch as the default as this lines up with the future plans to use the Value Key directly as the regex for the filter
+        # We are setting ExactMatch as the default as this lines up with the future plans to use the Value Key
+        # directly as the regex for the filter
         if not f_dict.get(FILTER_OPERATOR_KEY):
             f_dict[FILTER_OPERATOR_KEY] = EXACT_MATCH_OPERATOR
-            log.warning("Defaulting to filter Operator `ExactMatch'. Please ensure the filter Value provided is updated as this behavior will be removed in the future. See the official README for more information")
+            log.warning(
+                "Defaulting to filter Operator `ExactMatch'. Please ensure the filter Value provided is \
+                updated as this behavior will be removed in the future. See the official README for more information"
+            )
 
         # Build and assign regex matcher to VALUE key
         f_dict[FILTER_VALUE_KEY] = build_regex(f_dict)
@@ -120,13 +124,15 @@ def process_filters(filter_list: List[str]) -> Dict[str, List[Filter]]:
 
 
 def build_regex(f_dict):
-    # We are keeping this for backwards compatiblity. In the future this will be removed as the user can already 
+    # We are keeping this for backwards compatiblity. In the future this will be removed as the user can already
     # acheive substring behavior using regex
 
     if FILTER_OPERATOR_KEY in f_dict and f_dict[FILTER_OPERATOR_KEY].lower() == SUBSTRING_OPERATOR:
         reg_exp = f".*{f_dict[FILTER_VALUE_KEY]}.*"
-        log.warning("The Filter Operator `SubString` will be removed in future versions, please refer to the Best \
-            Practices Section in our README.md for more information.")
+        log.warning(
+            "The Filter Operator `SubString` will be removed in future versions, please refer to the Best \
+            Practices Section in our README.md for more information."
+        )
     else:
         reg_exp = f"^{f_dict[FILTER_VALUE_KEY]}$"
 

--- a/datadog_sync/utils/filter.py
+++ b/datadog_sync/utils/filter.py
@@ -124,7 +124,8 @@ def build_regex(f_dict):
 
     if FILTER_OPERATOR_KEY in f_dict and f_dict[FILTER_OPERATOR_KEY].lower() == SUBSTRING_OPERATOR:
         reg_exp = f".*{f_dict[FILTER_VALUE_KEY]}.*"
-        log.warning("The Filter Operator `SubString` will be removed in future versions, please refer to the Best Practices Section in our README.md for more information.")
+        log.warning("The Filter Operator `SubString` will be removed in future versions, please refer to the Best \
+            Practices Section in our README.md for more information.")
     else:
         reg_exp = f"^{f_dict[FILTER_VALUE_KEY]}$"
 

--- a/datadog_sync/utils/filter.py
+++ b/datadog_sync/utils/filter.py
@@ -107,7 +107,7 @@ def process_filters(filter_list: List[str]) -> Dict[str, List[Filter]]:
             )
 
         # Build and assign regex matcher to VALUE key for the deprecated Operators
-        if f_dict[FILTER_OPERATOR_KEY].lower() != NOT_OPERATOR:
+        if f_dict[FILTER_OPERATOR_KEY].lower() in [SUBSTRING_OPERATOR, EXACT_MATCH_OPERATOR]:
             handle_deprecated_operator(f_dict)
 
         f_instance = Filter(

--- a/datadog_sync/utils/filter.py
+++ b/datadog_sync/utils/filter.py
@@ -99,7 +99,7 @@ def process_filters(filter_list: List[str]) -> Dict[str, List[Filter]]:
 
         if not f_dict.get(FILTER_OPERATOR_KEY):
             f_dict[FILTER_OPERATOR_KEY] = EXACT_MATCH_OPERATOR
-            log.warning("Defaulting the Filter Operator to `ExactMatch` will be removed in the future")
+            log.warning("Defaulting to filter Operator `ExactMatch'. Please ensure the filter Value provided is updated as this behavior will be removed in the future. See the official README for more information")
 
         # Build and assign regex matcher to VALUE key
         f_dict[FILTER_VALUE_KEY] = build_regex(f_dict)

--- a/datadog_sync/utils/filter.py
+++ b/datadog_sync/utils/filter.py
@@ -97,6 +97,7 @@ def process_filters(filter_list: List[str]) -> Dict[str, List[Filter]]:
         if invalid_filter:
             continue
 
+        # We are setting ExactMatch as the default as this lines up with the future plans to use the Value Key directly as the regex for the filter
         if not f_dict.get(FILTER_OPERATOR_KEY):
             f_dict[FILTER_OPERATOR_KEY] = EXACT_MATCH_OPERATOR
             log.warning("Defaulting to filter Operator `ExactMatch'. Please ensure the filter Value provided is updated as this behavior will be removed in the future. See the official README for more information")

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -95,6 +95,12 @@ def test_filters_basic(_filter, r_type, r_obj, expected):
             ["Type=r_test_two;Name=test;Value=1;Operator=Not"],
             "r_test_two",
             {"test": ["attr", 123]},
+            False,
+        ),
+        (
+            ["Type=r_test_two;Name=test;Value=^1$;Operator=Not"],
+            "r_test_two",
+            {"test": ["attr", 123]},
             True,
         ),
     ],
@@ -173,7 +179,7 @@ def test_filters_numbers(_filter, r_type, r_obj, expected):
             ["Type=r_test;Name=test.nested.list;Value=123;Operator=Not"],
             "r_test",
             {"test": [{"nested": [{"list": 1234}]}]},
-            True,
+            False,
         ),
         (
             ["Type=r_test;Name=test.nested.list;Value=123;Operator=Not"],
@@ -191,10 +197,54 @@ def test_filters_numbers(_filter, r_type, r_obj, expected):
             ["Type=r_test;Name=test.nested;Value=123;Operator=Not"],
             "r_test",
             {"test": [{"nested": ["1234", "12345"]}]},
-            True,
+            False,
         ),
         (
             ["Type=r_test;Name=test.nested.deep;Value=sub;Operator=Not"],
+            "r_test",
+            {"test": [{"nested": {"deep": "substring"}}]},
+            False,
+        ),
+
+        # Not Operator with exact match regex
+        (
+            ["Type=r_test;Name=test.nested;Value=^123$;Operator=Not"],
+            "r_test",
+            {"test": [{"nested": 123}]},
+            False,
+        ),
+        (
+            ["Type=r_test;Name=test.nested.list;Value=^123$;Operator=Not"],
+            "r_test",
+            {"test": [{"nested": [{"list": 123}]}]},
+            False,
+        ),
+        (
+            ["Type=r_test;Name=test.nested.list;Value=^123$;Operator=Not"],
+            "r_test",
+            {"test": [{"nested": [{"list": 1234}]}]},
+            True,
+        ),
+        (
+            ["Type=r_test;Name=test.nested.list;Value=^123$;Operator=Not"],
+            "r_test",
+            {"test": [{"nested": [{"list": 1234}, {"list": 123}]}]},
+            False,
+        ),
+        (
+            ["Type=r_test;Name=test.nested;Value=^123$;Operator=Not"],
+            "r_test",
+            {"test": [{"nested": ["1234", "123"]}]},
+            False,
+        ),
+        (
+            ["Type=r_test;Name=test.nested;Value=^123$;Operator=Not"],
+            "r_test",
+            {"test": [{"nested": ["1234", "12345"]}]},
+            True,
+        ),
+        (
+            ["Type=r_test;Name=test.nested.deep;Value=^sub$;Operator=Not"],
             "r_test",
             {"test": [{"nested": {"deep": "substring"}}]},
             True,

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -10,27 +10,139 @@ from datadog_sync.utils.filter import process_filters
 
 
 @pytest.mark.parametrize(
+    # Test Inputs
     "_filter, r_type, r_obj, expected",
     [
-        (["Type=r_test;Name=attr;Value=exists;Operator=SubString"], "r_test", {"attr": "attr exists"}, True),
-        (["Type=r_test;Name=attr;Value=exists"], "r_test", {"test": "attr Exists"}, False),
-        (["Type=r_test_two;Name=test;Value=exists"], "r_test_two", {"test": ["attr", "exists"]}, True),
-        (["Type=r_test_two;Name=test;Value=exists"], "r_test_two", {"test": ["attr", "false"]}, False),
-        (["Type=r_test_two;Name=test;Value=1"], "r_test_two", {"test": ["attr", 1]}, True),
-        (["Type=r_test_two;Name=test;Value=1;Operator=NonExistent"], "r_test_two", {"test": ["attr", 1]}, True),
-        (["Type=r_test_two;Name=test;Value=1"], "r_test_two", {"test": ["attr", 123]}, False),
-        (["Type=r_test_two;Name=test;Value=1;Operator=SubString"], "r_test_two", {"test": ["attr", 123]}, True),
-        (["Type=r_test;Name=test.nested;Value=123"], "r_test", {"test": [{"nested": 123}]}, True),
-        (["Type=r_test;Name=test.nested.list;Value=123"], "r_test", {"test": [{"nested": [{"list": 123}]}]}, True),
-        (["Type=r_test;Name=test.nested.list;Value=123"], "r_test", {"test": [{"nested": [{"list": 1234}]}]}, False),
+        (
+            ["Type=r_test;Name=attr;Value=exists;Operator=SubString"],
+            "r_test",
+            {"attr": "attr exists"},
+            True,
+        ),
+        (
+            ["Type=r_test;Name=attr;Value=exists"],
+            "r_test",
+            {"test": "attr Exists"},
+            False,
+        ),
+        (
+            ["Type=r_test_two;Name=test;Value=exists"],
+            "r_test_two",
+            {"test": ["attr", "exists"]},
+            True,
+        ),
+        (
+            ["Type=r_test_two;Name=test;Value=exists"],
+            "r_test_two",
+            {"test": ["attr", "false"]},
+            False,
+        ),
+        # Not Operator (inverse result)
+        (
+            ["Type=r_test;Name=attr;Value=exists;Operator=Not"],
+            "r_test",
+            {"test": "attr Exists"},
+            True,
+        ),
+        (
+            ["Type=r_test_two;Name=test;Value=exists;Operator=Not"],
+            "r_test_two",
+            {"test": ["attr", "exists"]},
+            False,
+        ),
+        (
+            ["Type=r_test_two;Name=test;Value=exists;Operator=Not"],
+            "r_test_two",
+            {"test": ["attr", "false"]},
+            True,
+        ),
+    ],
+)
+def test_filters_basic(_filter, r_type, r_obj, expected):
+    assert filters_is_match_helper(_filter, r_type, r_obj, expected)
+
+
+@pytest.mark.parametrize(
+    # Test Inputs
+    "_filter, r_type, r_obj, expected",
+    [
+        (
+            ["Type=r_test_two;Name=test;Value=1;Operator=NonExistent"],
+            "r_test_two",
+            {"test": ["attr", 1]},
+            True,
+        ),
+        (
+            ["Type=r_test_two;Name=test;Value=1"],
+            "r_test_two",
+            {"test": ["attr", 123]},
+            False,
+        ),
+        (
+            ["Type=r_test_two;Name=test;Value=1;Operator=SubString"],
+            "r_test_two",
+            {"test": ["attr", 123]},
+            True,
+        ),
+        # Not Operator (inverse result)
+        (
+            ["Type=r_test_two;Name=test;Value=1;Operator=Not"],
+            "r_test_two",
+            {"test": ["attr", 1]},
+            False,
+        ),
+        (
+            ["Type=r_test_two;Name=test;Value=1;Operator=Not"],
+            "r_test_two",
+            {"test": ["attr", 123]},
+            True,
+        ),
+    ],
+)
+def test_filters_numbers(_filter, r_type, r_obj, expected):
+    assert filters_is_match_helper(_filter, r_type, r_obj, expected)
+
+
+@pytest.mark.parametrize(
+    # Test Inputs
+    "_filter, r_type, r_obj, expected",
+    [
+        (
+            ["Type=r_test;Name=test.nested;Value=123"],
+            "r_test",
+            {"test": [{"nested": 123}]},
+            True,
+        ),
+        (
+            ["Type=r_test;Name=test.nested.list;Value=123"],
+            "r_test",
+            {"test": [{"nested": [{"list": 123}]}]},
+            True,
+        ),
+        (
+            ["Type=r_test;Name=test.nested.list;Value=123"],
+            "r_test",
+            {"test": [{"nested": [{"list": 1234}]}]},
+            False,
+        ),
         (
             ["Type=r_test;Name=test.nested.list;Value=123"],
             "r_test",
             {"test": [{"nested": [{"list": 1234}, {"list": 123}]}]},
             True,
         ),
-        (["Type=r_test;Name=test.nested;Value=123"], "r_test", {"test": [{"nested": ["1234", "123"]}]}, True),
-        (["Type=r_test;Name=test.nested;Value=123"], "r_test", {"test": [{"nested": ["1234", "12345"]}]}, False),
+        (
+            ["Type=r_test;Name=test.nested;Value=123"],
+            "r_test",
+            {"test": [{"nested": ["1234", "123"]}]},
+            True,
+        ),
+        (
+            ["Type=r_test;Name=test.nested;Value=123"],
+            "r_test",
+            {"test": [{"nested": ["1234", "12345"]}]},
+            False,
+        ),
         (
             ["Type=r_test;Name=test.nested.deep;Value=sub;Operator=SubString"],
             "r_test",
@@ -43,13 +155,71 @@ from datadog_sync.utils.filter import process_filters
             {"test": [{"nested": {"deep": "substring"}}]},
             False,
         ),
-        (["Type=r_test;Name=test.non.exist;Value=sub;"], "r_test", {"test": []}, False),
+        # Not Operator (inverse result)
+        (
+            ["Type=r_test;Name=test.nested;Value=123;Operator=Not"],
+            "r_test",
+            {"test": [{"nested": 123}]},
+            False,
+        ),
+        (
+            ["Type=r_test;Name=test.nested.list;Value=123;Operator=Not"],
+            "r_test",
+            {"test": [{"nested": [{"list": 123}]}]},
+            False,
+        ),
+        (
+            ["Type=r_test;Name=test.nested.list;Value=123;Operator=Not"],
+            "r_test",
+            {"test": [{"nested": [{"list": 1234}]}]},
+            True,
+        ),
+        (
+            ["Type=r_test;Name=test.nested.list;Value=123;Operator=Not"],
+            "r_test",
+            {"test": [{"nested": [{"list": 1234}, {"list": 123}]}]},
+            False,
+        ),
+        (
+            ["Type=r_test;Name=test.nested;Value=123;Operator=Not"],
+            "r_test",
+            {"test": [{"nested": ["1234", "123"]}]},
+            False,
+        ),
+        (
+            ["Type=r_test;Name=test.nested;Value=123;Operator=Not"],
+            "r_test",
+            {"test": [{"nested": ["1234", "12345"]}]},
+            True,
+        ),
+        (
+            ["Type=r_test;Name=test.nested.deep;Value=sub;Operator=Not"],
+            "r_test",
+            {"test": [{"nested": {"deep": "substring"}}]},
+            True,
+        ),
     ],
 )
-def test_filters_is_match(_filter, r_type, r_obj, expected):
-    filters = process_filters(_filter)
+def test_filters_nested(_filter, r_type, r_obj, expected):
+    assert filters_is_match_helper(_filter, r_type, r_obj, expected)
 
-    assert filters[r_type][0].is_match(r_obj) == expected
+
+@pytest.mark.parametrize(
+    # Test Inputs
+    "_filter, r_type, r_obj, expected",
+    [
+        (["Type=r_test;Name=test.non.exist;Value=sub;"], "r_test", {"test": []}, False),
+        # Not Operator (inverse result)
+        (
+            ["Type=r_test;Name=test.non.exist;Value=sub;Operator=Not"],
+            "r_test",
+            {"test": []},
+            True,
+        ),
+    ],
+)
+def test_filters_empty(_filter, r_type, r_obj, expected):
+    assert filters_is_match_helper(_filter, r_type, r_obj, expected)
 
 
 @pytest.mark.parametrize(
@@ -134,3 +304,9 @@ def test_filters(config, _filter, r_type, r_obj, expected):
     resource = r_type(config)
 
     assert resource.filter(r_obj) == expected
+
+
+def filters_is_match_helper(_filter, r_type, r_obj, expected) -> bool:
+    filters = process_filters(_filter)
+
+    return filters[r_type][0].is_match(r_obj) == expected

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -155,6 +155,7 @@ def test_filters_numbers(_filter, r_type, r_obj, expected):
             {"test": [{"nested": {"deep": "substring"}}]},
             False,
         ),
+
         # Not Operator (inverse result)
         (
             ["Type=r_test;Name=test.nested;Value=123;Operator=Not"],


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).

### What does this PR do?

This PR adds support for the `Not` Operator when defining the filter for a particular resource. 

This was in response to question that was brought up by a Support Engineer where their client asked if the tool supported the the Not operation. This wasn't supported but was determined that it was a useful option to have.

### Description of the Change

The change for this was to basically, invert the boolean result that was generated when we compared the default regex (Exact Match) to the resource attribute.

### Alternate Designs

### Possible Drawbacks

### Verification Process

To verify that the change is working as intended, I manually made sure that when using the new operator, that I received the expected results. 

I also added additional tests that would confirm that the `Not` Operator was working as intended. I took all of the tests that verified the filtering behavior and then created inverse versions of them.

### Additional Notes

### Release Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
