### PR TITLE
Handle host remapping in get call

### DIFF
--- a/datadog_sync/model/host_tags.py
+++ b/datadog_sync/model/host_tags.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 from collections import defaultdict
-from typing import TYPE_CHECKING, Optional, List, Dict, cast
+from typing import TYPE_CHECKING, Optional, List, Dict
 
 from datadog_sync.utils.base_resource import BaseResource, ResourceConfig
 

--- a/datadog_sync/model/host_tags.py
+++ b/datadog_sync/model/host_tags.py
@@ -4,6 +4,7 @@
 # Copyright 2019 Datadog, Inc.
 
 from __future__ import annotations
+from collections import defaultdict
 from typing import TYPE_CHECKING, Optional, List, Dict, cast
 
 from datadog_sync.utils.base_resource import BaseResource, ResourceConfig
@@ -22,19 +23,21 @@ class HostTags(BaseResource):
     def get_resources(self, client: CustomClient) -> List[Dict]:
         resp = client.get(self.resource_config.base_path).json()
 
-        return list(resp["tags"].items())
+        import_hosts = defaultdict(list)
+        for tag, hosts in resp["tags"].items():
+            for host in hosts:
+                import_hosts[host].append(tag)
+
+        return [{k: v} for k, v in import_hosts.items()]
 
     def import_resource(self, _id: Optional[str] = None, resource: Optional[Dict] = None) -> None:
         if _id:
             return  # This should never occur. No resource depends on it.
 
-        resource = cast(dict, resource)
-        tag = resource[0]
-        hosts = resource[1]
-        for host in hosts:
-            if host not in self.resource_config.source_resources:
-                self.resource_config.source_resources[host] = []
-            self.resource_config.source_resources[host].append(tag)
+        host = list(resource.keys())[0]
+        tags = list(resource.values())[0]
+
+        self.resource_config.source_resources[host] = tags
 
     def pre_resource_action_hook(self, _id, resource: Dict) -> None:
         pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ console_scripts =
 tests =
     ddtrace==1.9.3
     black==23.1.0
-    pytest>=7.2.2
+    pytest==7.4.3
     pytest-black
     pytest-console-scripts
     pytest-recording


### PR DESCRIPTION
The PR moves remapping of {tag: [hosts]} -> {host: tags} from within import step to parent get_resources step. This helps unblock further refactoring work of extrapolating resource assignment to the state dict.