### PR TITLE
Add global mute flag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,10 @@ Options:
   --force-missing-dependencies                Force importing and syncing resources that
                                               could be potential dependencies to the
                                               requested resources. [sync only]
-  --create-global-downtime                    Schedule a downtime for monitors synced by
-                                              datadog-sync-cli. Scheduled downtime should be
-                                              manually removed after failover is complete.
+  --create-global-downtime                    Scheduled downtime is meant to be removed
+                                              during failover when user determines
+                                              monitors have enough telemetry to trigger
+                                              appropriately.
   --help                                      Show this message and exit.
 
 Commands:

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ Options:
   --force-missing-dependencies                Force importing and syncing resources that
                                               could be potential dependencies to the
                                               requested resources. [sync only]
+  --create-global-downtime                    Schedule a downtime for monitors synced by
+                                              datadog-sync-cli. Scheduled downtime should be
+                                              manually removed after failover is complete.
   --help                                      Show this message and exit.
 
 Commands:

--- a/datadog_sync/commands/sync.py
+++ b/datadog_sync/commands/sync.py
@@ -33,6 +33,15 @@ from datadog_sync.utils.configuration import build_config
     help="Force importing and syncing resources that could be potential dependencies to the requested resources.",
     cls=CustomOptionClass,
 )
+@option(
+    "--create-global-downtime",
+    required=False,
+    is_flag=True,
+    default=False,
+    help="Schedule a downtime for monitors synced by datadog-sync-cli. \
+        This should be manually removed after failover is complete.",
+    cls=CustomOptionClass,
+)
 def sync(**kwargs):
     """Sync Datadog resources to destination."""
     cfg = build_config(CMD_SYNC, **kwargs)

--- a/datadog_sync/commands/sync.py
+++ b/datadog_sync/commands/sync.py
@@ -39,7 +39,7 @@ from datadog_sync.utils.configuration import build_config
     is_flag=True,
     default=False,
     help="Schedule a downtime for monitors synced by datadog-sync-cli. \
-        This should be manually removed after failover is complete.",
+        Scheduled downtime should be manually removed after failover is complete.",
     cls=CustomOptionClass,
 )
 def sync(**kwargs):

--- a/datadog_sync/commands/sync.py
+++ b/datadog_sync/commands/sync.py
@@ -38,8 +38,8 @@ from datadog_sync.utils.configuration import build_config
     required=False,
     is_flag=True,
     default=False,
-    help="Schedule a downtime for monitors synced by datadog-sync-cli. \
-        Scheduled downtime should be manually removed after failover is complete.",
+    help="Scheduled downtime is meant to be removed during failover when "
+    "user determines monitors have enough telemetry to trigger appropriately.",
     cls=CustomOptionClass,
 )
 def sync(**kwargs):

--- a/datadog_sync/utils/configuration.py
+++ b/datadog_sync/utils/configuration.py
@@ -44,6 +44,7 @@ class Configuration(object):
     skip_failed_resource_connections: bool
     max_workers: int
     cleanup: int
+    create_global_downtime: bool
     resources: Dict[str, BaseResource] = field(default_factory=dict)
     resources_arg: List[str] = field(default_factory=list)
 
@@ -88,6 +89,7 @@ def build_config(cmd: str, **kwargs: Optional[Any]) -> Configuration:
     force_missing_dependencies = kwargs.get("force_missing_dependencies")
     skip_failed_resource_connections = kwargs.get("skip_failed_resource_connections")
     max_workers = kwargs.get("max_workers", 10)
+    create_global_downtime = kwargs.get("create_global_downtime")
 
     cleanup = kwargs.get("cleanup")
     if cleanup:
@@ -108,6 +110,7 @@ def build_config(cmd: str, **kwargs: Optional[Any]) -> Configuration:
         skip_failed_resource_connections=skip_failed_resource_connections,
         max_workers=max_workers,
         cleanup=cleanup,
+        create_global_downtime=create_global_downtime,
     )
 
     # Initialize resources

--- a/datadog_sync/utils/resource_utils.py
+++ b/datadog_sync/utils/resource_utils.py
@@ -97,8 +97,9 @@ def create_global_downtime(config: Configuration):
     payload = {
         "data": {
             "attributes": {
-                "message": "Downtime created by datadog-sync-cli to mute all monitors synced. \
-                    To be manually removed after failover is comeplete.",
+                "message": "Downtime created by datadog-sync-cli to mute all monitors synced. "
+                "To be manually removed during failover when monitors have enough telemetry"
+                "to trigger appropriately.",
                 "monitor_identifier": {"monitor_tags": DEFAULT_TAGS},
                 "scope": "*",
                 "schedule": {

--- a/datadog_sync/utils/resource_utils.py
+++ b/datadog_sync/utils/resource_utils.py
@@ -92,6 +92,37 @@ class DowntimeSchedulesDateOperator(BaseOperator):
         return False
 
 
+def create_global_downtime(config: Configuration):
+    """Create global downtime"""
+    payload = {
+        "data": {
+            "attributes": {
+                "message": "Downtime created by datadog-sync-cli to mute all monitors synced. \
+                    To be manually removed after failover is comeplete.",
+                "monitor_identifier": {"monitor_tags": DEFAULT_TAGS},
+                "scope": "*",
+                "schedule": {
+                    "start": None,
+                },
+            },
+            "type": "downtime",
+        }
+    }
+
+    try:
+        resp = config.destination_client.post(
+            config.resources["downtime_schedules"].resource_config.base_path, payload
+        ).json()
+        config.logger.info(f"Global downtime for datadog-sync-cli created successfully - {resp['data']['id']}")
+    except CustomClientHTTPError as e:
+        if e.status_code == 400 and "downtime being created is a duplicate" in str(e):
+            config.logger.info(f"Global downtime for datadog-sync-cli already exists: {str(e)}")
+        else:
+            config.logger.error(f"Error creating global downtime for datadog-sync-cli: {str(e)}")
+    except Exception as e:
+        config.logger.error(f"Error creating global downtime for datadog-sync-cli: {str(e)}")
+
+
 def find_attr(keys_list_str: str, resource_to_connect: str, r_obj: Any, connect_func: Callable) -> Optional[List[str]]:
     if not r_obj:
         return None

--- a/datadog_sync/utils/resources_handler.py
+++ b/datadog_sync/utils/resources_handler.py
@@ -19,6 +19,7 @@ from datadog_sync.utils.resource_utils import (
     ResourceConnectionError,
     SkipResource,
     check_diff,
+    create_global_downtime,
     dump_resources,
     prep_resource,
     thread_pool_executor,
@@ -88,6 +89,11 @@ class ResourcesHandler:
         # Run pre-apply hooks
         for resource_type in set(self.resources_manager.all_resources.values()):
             futures.append(parralel_executor.submit(self.config.resources[resource_type]._pre_apply_hook))
+
+        # Additional pre-apply actions
+        if self.config.create_global_downtime:
+            futures.append(parralel_executor.submit(create_global_downtime, self.config))
+
         wait(futures)
         for future in futures:
             try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,6 +132,7 @@ def config():
         force_missing_dependencies=False,
         skip_failed_resource_connections=True,
         cleanup=False,
+        create_global_downtime=False,
     )
 
     resources = init_resources(cfg)


### PR DESCRIPTION
Add a flag to create global downtime schedule during sync to avoid false positives. 

Supercedes: https://github.com/DataDog/datadog-sync-cli/pull/205