### PR TITLE
Handle when import `id` is changed during dependency resolution

### DIFF
--- a/datadog_sync/utils/base_resource.py
+++ b/datadog_sync/utils/base_resource.py
@@ -93,7 +93,7 @@ class BaseResource(abc.ABC):
     def import_resource(self, _id: Optional[str] = None, resource: Optional[Dict] = None) -> Tuple[str, Dict]:
         pass
 
-    def _import_resource(self, _id: Optional[str] = None, resource: Optional[Dict] = None) -> None:
+    def _import_resource(self, _id: Optional[str] = None, resource: Optional[Dict] = None) -> str:
         _id, r = self.import_resource(_id, resource)
 
         if self.resource_config.tagging_config is not None:
@@ -105,6 +105,7 @@ class BaseResource(abc.ABC):
                 )
 
         self.resource_config.source_resources[str(_id)] = r
+        return str(_id)
 
     @abc.abstractmethod
     def pre_resource_action_hook(self, _id, resource: Dict) -> None:

--- a/datadog_sync/utils/resources_handler.py
+++ b/datadog_sync/utils/resources_handler.py
@@ -292,7 +292,7 @@ class ResourcesHandler:
 
     def _force_missing_dep_import_worker(self, _id: str, resource_type: str):
         try:
-            self.config.resources[resource_type]._import_resource(_id=_id)
+            _id = self.config.resources[resource_type]._import_resource(_id=_id)
         except CustomClientHTTPError as e:
             self.config.logger.error(f"error importing {resource_type} with id {_id}: {str(e)}")
             return


### PR DESCRIPTION
Some resources such as synthetics require the ids to be combination of multiple things. When resolving dependencies, we do not have access to this information until the import is complete. Hence need to return the new _id to avoid errors