### PR TITLE
Use `freezegun` for asyncio.sleep mock support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ tests =
     pytest-console-scripts
     pytest-recording
     vcrpy@git+https://github.com/skarimo/vcrpy.git
-    pytest-freezer==0.4.8
+    freezegun==1.5.0
 
 [mypy]
 ignore_missing_imports = true


### PR DESCRIPTION
freezegun supports asyncio. This is nice to have so we can test coroutines which require sleeping such as during retry