### PR TITLE
Handle complex source queries for Logs integration pipeline syncing

### DIFF
--- a/tests/integration/resources/test_logs_indexes.py
+++ b/tests/integration/resources/test_logs_indexes.py
@@ -20,14 +20,14 @@ class TestLogsIndexesResources(BaseResourcesTestClass):
 
     def test_resource_cleanup(self, runner, caplog):
         caplog.set_level(logging.DEBUG)
-        
+
         api_key = os.environ.get("DD_DESTINATION_API_KEY")
         app_key = os.environ.get("DD_DESTINATION_APP_KEY")
         api_url = os.environ.get("DD_DESTINATION_API_URL")
         logs_index_order_req = urllib.request.Request(
             f"{api_url}/api/v1/logs/config/index-order", headers={"DD-API-KEY": api_key, "DD-APPLICATION-KEY": app_key}
         )
-        
+
         # Get the initial logs index order
         with urllib.request.urlopen(logs_index_order_req) as response:
             order = json.loads(response.read())

--- a/tests/integration/resources/test_logs_pipelines.py
+++ b/tests/integration/resources/test_logs_pipelines.py
@@ -23,3 +23,54 @@ class TestLogsPipelinesResourcesIntegrationFilter(BaseResourcesTestClass):
     @pytest.mark.skip(reason="resource is only updated by default")
     def test_resource_update_sync(self):
         pass
+
+
+@pytest.mark.parametrize(
+    "query, expected",
+    [
+        (
+            "",
+            None,
+        ),
+        (
+            "source:",
+            None,
+        ),
+        (
+            None,
+            None,
+        ),
+        (
+            "source:haproxy",
+            "haproxy",
+        ),
+        (
+            "source:citrix_hypervisor",
+            "citrix_hypervisor",
+        ),
+        (
+            "source:gcp.pubsub.subscription",
+            "gcp.pubsub.subscription",
+        ),
+        (
+            "source:(gcp.bigquery.dataset OR gcp.bigquery.project OR gcp.bigquery.resource)",
+            "gcp.bigquery.dataset",
+        ),
+        (
+            "source:nginx-ingress-controller",
+            "nginx-ingress-controller",
+        ),
+        (
+            (
+                "source:(agent OR datadog-agent OR datadog-agent-cluster-worker OR "
+                "datadog-cluster-agent OR process-agent OR security-agent OR "
+                "system-probe OR trace-agent OR cluster-agent)"
+            ),
+            "agent",
+        ),
+    ],
+)
+def test_tagging_config(query, expected):
+    source = LogsPipelines.extract_source_from_query(query)
+
+    assert source == expected


### PR DESCRIPTION
APITL-893

Source queries for integration pipelines can contain multiple sources. Lets make sure we always use the first one.