### PR TITLE
Handle invalid integration pipelines

### DIFF
--- a/datadog_sync/utils/resource_utils.py
+++ b/datadog_sync/utils/resource_utils.py
@@ -52,13 +52,12 @@ class LogsPipelinesOrderIdsComparator(BaseOperator):
             level.t1 = deepcopy(level.t1)
             level.t2 = deepcopy(level.t2)
 
-            # If we are at the top level, modify the list to only include the intersections.
+            # If we are at the top level, modify the list to exclude extra pipelines in destination.
             t1 = set(level.t1["pipeline_ids"])
             t2 = set(level.t2["pipeline_ids"])
-            intersection = t1 & t2
+            d_ignore = t1 - t2
 
-            level.t1["pipeline_ids"] = [_id for _id in level.t1["pipeline_ids"] if _id in intersection]
-            level.t2["pipeline_ids"] = [_id for _id in level.t2["pipeline_ids"] if _id in intersection]
+            level.t1["pipeline_ids"] = [_id for _id in level.t1["pipeline_ids"] if _id not in d_ignore]
         return True
 
     def give_up_diffing(self, level, diff_instance) -> bool:


### PR DESCRIPTION
APITL-893

 We do not create invalid integration pipelines in destination org if they are not already enabled. 

This PR injects and additional field `"__datadog_sync_invalid"` in the state file which is then used by the logs pipeline order resource to drop them from the payload.