### PR TITLE
Fix endless process spawn when "frozen"

### DIFF
--- a/datadog_sync/cli.py
+++ b/datadog_sync/cli.py
@@ -18,6 +18,11 @@ def cli():
 for command in ALL_COMMANDS:
     cli.add_command(command)
 
+
 # Invoke cli manually if using executable
 if getattr(sys, "frozen", False):
+    import multiprocessing
+
+    multiprocessing.freeze_support()
+
     cli(sys.argv[1:])


### PR DESCRIPTION
Using pyinstaller will cause endless process spawns in certain platforms. To avoid this, we need to call `freeze_support`.

See: https://pyinstaller.org/en/latest/common-issues-and-pitfalls.html#multi-processing