### PR TITLE
Pinning the library to fix docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+resources/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     certifi>=2022.12.7
     python-dateutil
 setup_requires =
-    setuptools>=67.6.0
+    setuptools==67.6.0
     setuptools_scm
 
 [options.entry_points]


### PR DESCRIPTION

### What does this PR do?
The `docker build` command is currently failing because the code does not work with the latest version of setuptools. This pins the version of setuptools so the build will work.

### Description of the Change
The `setuptools` module is pinned to version `67.6.0`
