### PR TITLE
HAMR-179 Build the docker image and push it to github's registry

### DIFF
--- a/.github/workflows/build_publish_docker.yml
+++ b/.github/workflows/build_publish_docker.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: datadog-sync
 
 jobs:
   build-and-push-image:
@@ -33,7 +33,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
         id: push
@@ -47,6 +47,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-name: ${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/build_publish_docker.yml
+++ b/.github/workflows/build_publish_docker.yml
@@ -2,7 +2,7 @@ name: Build and publish docker image
 
 on:
   push:
-    branches: ['release']
+    branches: ['release','michael.richey/**']
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build_publish_docker.yml
+++ b/.github/workflows/build_publish_docker.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -31,22 +31,22 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ env.IMAGE_NAME }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ${{ env.IMAGE_NAME }}
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/build_publish_docker.yml
+++ b/.github/workflows/build_publish_docker.yml
@@ -31,7 +31,7 @@ jobs:
           flavor: |
             latest=true
             prefix=
-            suffic=
+            suffix=
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Build and push Docker image
         id: push

--- a/.github/workflows/build_publish_docker.yml
+++ b/.github/workflows/build_publish_docker.yml
@@ -2,7 +2,7 @@ name: Build and publish docker image
 
 on:
   push:
-    branches: ['release','michael.richey/**']
+    branches: ['release']
 
 env:
   REGISTRY: ghcr.io
@@ -28,7 +28,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            datadog/datadog-sync
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4

--- a/.github/workflows/build_publish_docker.yml
+++ b/.github/workflows/build_publish_docker.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.IMAGE_NAME }}
+          tags: ${{ steps.meta.output.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Generate artifact attestation

--- a/.github/workflows/build_publish_docker.yml
+++ b/.github/workflows/build_publish_docker.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: datadog-sync
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/build_publish_docker.yml
+++ b/.github/workflows/build_publish_docker.yml
@@ -28,9 +28,11 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-            datadog/datadog-sync
+          flavor: |
+            latest=true
+            prefix=
+            suffic=
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4

--- a/.github/workflows/build_publish_docker.yml
+++ b/.github/workflows/build_publish_docker.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/build_publish_docker.yml
+++ b/.github/workflows/build_publish_docker.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: datadog-sync
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1

--- a/.github/workflows/build_publish_docker.yml
+++ b/.github/workflows/build_publish_docker.yml
@@ -1,8 +1,8 @@
 name: Build and publish docker image
 
 on:
-  push:
-    branches: ['release', 'michael.richey/**']
+  release:
+    types: [published]
 
 env:
   REGISTRY: ghcr.io
@@ -10,20 +10,24 @@ env:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
+
     permissions:
       contents: read
       packages: write
       attestations: write
       id-token: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
@@ -33,6 +37,7 @@ jobs:
             prefix=
             suffix=
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
@@ -41,6 +46,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:

--- a/.github/workflows/build_publish_docker.yml
+++ b/.github/workflows/build_publish_docker.yml
@@ -1,0 +1,52 @@
+name: Build and publish docker image
+
+on:
+  push:
+    branches: ['release']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/build_publish_docker.yml
+++ b/.github/workflows/build_publish_docker.yml
@@ -7,43 +7,36 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
-
     permissions:
       contents: read
       packages: write
       attestations: write
       id-token: write
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.output.tags }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:

--- a/.github/workflows/build_publish_docker.yml
+++ b/.github/workflows/build_publish_docker.yml
@@ -2,7 +2,7 @@ name: Build and publish docker image
 
 on:
   push:
-    branches: ['release']
+    branches: ['release', 'michael.richey/**']
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build_publish_docker.yml
+++ b/.github/workflows/build_publish_docker.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: datadog-sync
           labels: ${{ steps.meta.outputs.labels }}
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,3 +63,38 @@ jobs:
         run: python scripts/build.py -f -u
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ghcr.io/${{ github.repository }}
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,38 +63,3 @@ jobs:
         run: python scripts/build.py -f -u
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  build-and-push-image:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
-      id-token: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-        with:
-          images: ghcr.io/${{ github.repository }}
-      - name: Build and push Docker image
-        id: push
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-      - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-name: ghcr.io/${{ github.repository }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true


### PR DESCRIPTION
### What does this PR do?
Modify the release process to build a docker image that we can distribute.

<!--

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

### Description of the Change
This change comes straight from the github documentation on how to build a docker image and publish it to github packages. 

<!--

A brief description of the change being made with this pull request.

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
### What could go wrong?
This bit is untested but comes from the documentation:
```
on:
  release:
    types: [published]
```
I was building on any push to my feature branch to test the building and publishing. Since this will create a `latest` version of the image, we want to make sure we only run it when we _publish_ a release.

### Verification

Starting state:
```
~$ docker image ls
REPOSITORY   TAG       IMAGE ID   CREATED   SIZE
~$
```

Verify image was created from this repository:
```
~$ gh attestation verify oci://ghcr.io/datadog/datadog-sync-cli --repo DataDog/datadog-sync-cli
Loaded digest sha256:edf626695aeb3aef98818eebaae0dfa8236bfe8cc6d77007a798f9188a3289dc for oci://ghcr.io/datadog/datadog-sync-cli
Loaded 1 attestation from GitHub API
✓ Verification succeeded!

sha256:edf626695aeb3aef98818eebaae0dfa8236bfe8cc6d77007a798f9188a3289dc was attested by:
REPO                      PREDICATE_TYPE                  WORKFLOW                                                                                 
DataDog/datadog-sync-cli  https://slsa.dev/provenance/v1  .github/workflows/build_publish_docker.yml@refs/heads/michael.richey/publish-docker-image
~$
```

Download the docker image:
```
~$ docker run --rm ghcr.io/datadog/datadog-sync-cli
Unable to find image 'ghcr.io/datadog/datadog-sync-cli:latest' locally
latest: Pulling from datadog/datadog-sync-cli
8b91b88d5577: Pull complete 
824416e23423: Pull complete 
482d64d97d4e: Pull complete 
c87b3089b2ed: Pull complete 
91bdacd599c6: Pull complete 
96dd7bc6fadb: Pull complete 
13d2db1b4640: Pull complete 
2656443a97f4: Pull complete 
03b4039beaa9: Pull complete 
Digest: sha256:edf626695aeb3aef98818eebaae0dfa8236bfe8cc6d77007a798f9188a3289dc
Status: Downloaded newer image for ghcr.io/datadog/datadog-sync-cli:latest
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
Usage: datadog-sync [OPTIONS] COMMAND [ARGS]...

  Initialize cli

Options:
  --help  Show this message and exit.

Commands:
  diffs   Log resource diffs.
  import  Import Datadog resources.
  sync    Sync Datadog resources to destination.
~$
```

Running the local docker image (after setting env vars)
```
~$ docker run --rm -v ~/dd/datadog-sync-cli:/datadog-sync:rw -e DD_SOURCE_API_KEY=${DATADOG_API_KEY} -e DD_SOURCE_APP_KEY=${DATADOG_APP_KEY} -e DD_SOURCE_API_URL=${DATADOG_API_URL} -e DD_DESTINATION_API_KEY=${DATADOG_API_KEY} -e DD_DESTINATION_APP_KEY=${DATADOG_APP_KEY} -e DD_DESTINATION_API_URL=${DATADOG_API_URL} ghcr.io/datadog/datadog-sync-cli import --resources="dashboards" --filter='Type=dashboards;Name=id;Value=redacted;Operator=ExactMatch'
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
2024-09-06 18:08:52,532 - INFO - clients validated successfully
2024-09-06 18:08:52,535 - INFO - Starting import...
2024-09-06 18:08:52,616 - INFO - Getting resources for dashboards
100%|██████████| 1/1 [00:00<00:00,  4.42it/s]
2024-09-06 18:08:52,842 - INFO - Finished getting resources. Successes: 1, Failures: 0, Skipped: 0, Filtered: 0
2024-09-06 18:08:52,842 - INFO - Importing individual resource items
100%|██████████| 1/1 [00:00<00:00, 76.47it/s] 
2024-09-06 18:08:52,857 - INFO - Finished importng individual resource items. Successes: 0, Failures: 0, Skipped: 0, Filtered: 1.
2024-09-06 18:08:52,859 - INFO - Finished import
~$ 
```

