### PR TITLE
Inject resource context into logs

### DIFF
--- a/datadog_sync/utils/base_resource.py
+++ b/datadog_sync/utils/base_resource.py
@@ -196,10 +196,10 @@ class BaseResource(abc.ABC):
             e = ResourceConnectionError(failed_connections_dict=failed_connections_dict)
             if self.config.skip_failed_resource_connections:
                 e = ResourceConnectionError(failed_connections_dict=failed_connections_dict)
-                self.config.logger.info(f"Skipping resource: {self.resource_type} with ID: {_id}. {str(e)}")
+                self.config.logger.info(f"skipping resource: {str(e)}", _id=_id, resource_type=self.resource_type)
                 raise e
             else:
-                self.config.logger.debug(f"{self.resource_type} with ID: {_id}. {str(e)}")
+                self.config.logger.debug(f"{str(e)}", _id=_id, resource_type=self.resource_type)
 
     def filter(self, resource: Dict) -> bool:
         if not self.config.filters or self.resource_type not in self.config.filters:

--- a/datadog_sync/utils/log.py
+++ b/datadog_sync/utils/log.py
@@ -26,21 +26,34 @@ class Log:
         self.logger = logging.getLogger(LOGGER_NAME)
         self.logger.propagate = True
 
-    def debug(self, msg, *arg):
+    def debug(self, msg, *arg, _id: str = "", resource_type: str = ""):
+        if resource_type or _id:
+            msg = f"[{resource_type} - {_id}] - {msg}"
+
         self.logger.debug(msg, *arg)
 
-    def exception(self, msg, *arg):
-        self._exception_logged()
+    def exception(self, msg, *arg, _id: str = "", resource_type: str = ""):
+        if resource_type or _id:
+            msg = f"[{resource_type} - {_id}] - {msg}"
+
         self.logger.exception(msg, *arg)
-
-    def error(self, msg, *arg):
         self._exception_logged()
-        self.logger.error(msg, *arg)
 
-    def info(self, msg: str, *arg) -> None:
+    def error(self, msg, *arg, _id: str = "", resource_type: str = ""):
+        if resource_type or _id:
+            msg = f"[{resource_type} - {_id}] - {msg}"
+
+        self.logger.error(msg, *arg)
+        self._exception_logged()
+
+    def info(self, msg: str, *arg, _id: str = "", resource_type: str = "") -> None:
+        if resource_type or _id:
+            msg = f"[{resource_type} - {_id}] - {msg}"
         self.logger.info(msg, *arg)
 
-    def warning(self, msg, *arg):
+    def warning(self, msg, *arg, _id: str = "", resource_type: str = ""):
+        if resource_type or _id:
+            msg = f"[{resource_type} - {_id}] - {msg}"
         self.logger.warning(msg, *arg)
 
     def _exception_logged(self):

--- a/datadog_sync/utils/resources_handler.py
+++ b/datadog_sync/utils/resources_handler.py
@@ -47,7 +47,7 @@ class ResourcesHandler:
 
         # Import resources that are missing but needed for resource connections
         if self.config.force_missing_dependencies and missing:
-            self.config.logger.info("Importing missing dependencies...")
+            self.config.logger.info("importing missing dependencies...")
             await self.worker.init_workers(self._force_missing_dep_import_cb, None, len(missing))
             for item in missing:
                 self.worker.work_queue.put_nowait(item)
@@ -60,7 +60,7 @@ class ResourcesHandler:
             if cleanup_resources:
                 cleanup = _cleanup_prompt(self.config, cleanup_resources)
                 if cleanup:
-                    self.config.logger.info("Cleaning up resources...")
+                    self.config.logger.info("cleaning up resources...")
                     await self.worker.init_workers(self._cleanup_worker, None, None)
                     for i in cleanup_resources:
                         self.worker.work_queue.put_nowait(i)
@@ -84,7 +84,7 @@ class ResourcesHandler:
         await self.worker.schedule_workers_with_pbar(
             total=len(self._dependency_graph), additional_coros=[self.run_sorter()]
         )
-        self.config.logger.info(f"Finished syncing resource items. {self.worker.counter}.")
+        self.config.logger.info(f"finished syncing resource items: {self.worker.counter}.")
 
         self.config.state.dump_state()
 
@@ -109,28 +109,28 @@ class ResourcesHandler:
             if _id in self.config.state.destination[resource_type]:
                 diff = check_diff(r_class.resource_config, resource, self.config.state.destination[resource_type][_id])
                 if diff:
-                    self.config.logger.debug(f"Running update for {resource_type} with {_id}")
+                    self.config.logger.debug("running update", resource_type=resource_type, _id=_id)
 
                     prep_resource(r_class.resource_config, resource)
                     await r_class._update_resource(_id, resource)
 
-                    self.config.logger.debug(f"Finished update for {resource_type} with {_id}")
+                    self.config.logger.debug("finished update", resource_type=resource_type, _id=_id)
             else:
-                self.config.logger.debug(f"Running create for {resource_type} with id: {_id}")
+                self.config.logger.debug("running create", resource_type=resource_type, _id=_id)
 
                 prep_resource(r_class.resource_config, resource)
                 await r_class._create_resource(_id, resource)
 
-                self.config.logger.debug(f"finished create for {resource_type} with id: {_id}")
+                self.config.logger.debug("finished create", resource_type=resource_type, _id=_id)
             self.worker.counter.increment_success()
         except SkipResource as e:
-            self.config.logger.info(str(e))
+            self.config.logger.info(str(e), resource_type=resource_type, _id=_id)
             self.worker.counter.increment_skipped()
         except ResourceConnectionError:
             self.worker.counter.increment_skipped()
         except Exception as e:
             self.worker.counter.increment_failure()
-            self.config.logger.error(str(e))
+            self.config.logger.error(str(e), resource_type=resource_type, _id=_id)
         finally:
             # always place in done queue regardless of exception thrown
             self.sorter.done(q_item)
@@ -162,11 +162,11 @@ class ResourcesHandler:
 
         if delete:
             self.config.logger.info(
-                "{} resource with source ID {} to be deleted: \n {}".format(
-                    resource_type,
-                    _id,
+                "to be deleted: \n {}".format(
                     pformat(self.config.state.destination[resource_type][_id]),
-                )
+                ),
+                resource_type=resource_type,
+                _id=_id,
             )
         else:
             resource = self.config.state.source[resource_type][_id]
@@ -183,12 +183,10 @@ class ResourcesHandler:
             if _id in self.config.state.destination[resource_type]:
                 diff = check_diff(r_class.resource_config, self.config.state.destination[resource_type][_id], resource)
                 if diff:
-                    self.config.logger.info(
-                        "{} resource source ID {} diff: \n {}".format(resource_type, _id, pformat(diff))
-                    )
+                    self.config.logger.info("diff: \n {}".format(pformat(diff)), resource_type=resource_type, _id=_id)
             else:
                 self.config.logger.info(
-                    "Resource to be added {} source ID {}: \n {}".format(resource_type, _id, pformat(resource))
+                    "to be created: \n {}".format(pformat(resource)), resource_type=resource_type, _id=_id
                 )
 
     async def import_resources(self) -> None:
@@ -201,7 +199,7 @@ class ResourcesHandler:
         self.config.logger.info(f"Finished getting resources. {self.worker.counter}")
 
         # Begin importing individual resource items
-        self.config.logger.info("Importing individual resource items")
+        self.config.logger.info("importing individual resource items")
         await self.worker.init_workers(self._import_resource, None, None)
         total = 0
         for k, v in tmp_storage.items():
@@ -209,13 +207,13 @@ class ResourcesHandler:
             for resource in v:
                 self.worker.work_queue.put_nowait((k, resource))
         await self.worker.schedule_workers_with_pbar(total=total)
-        self.config.logger.info(f"Finished importng individual resource items. {self.worker.counter}.")
+        self.config.logger.info(f"finished importng individual resource items: {self.worker.counter}.")
 
         # Dump resources
         self.config.state.dump_state(Origin.SOURCE)
 
     async def _import_get_resources_cb(self, resource_type: str, tmp_storage) -> None:
-        self.config.logger.info("Getting resources for %s", resource_type)
+        self.config.logger.info("getting resources", resource_type=resource_type)
 
         r_class = self.config.resources[resource_type]
         self.config.state.source[resource_type].clear()
@@ -225,7 +223,7 @@ class ResourcesHandler:
             self.worker.counter.increment_success()
             tmp_storage[resource_type] = get_resp
         except Exception as e:
-            self.config.logger.error(f"Error while getting resources {resource_type}: {str(e)}")
+            self.config.logger.error(f"error while getting resources: {str(e)}", resource_type=resource_type)
             self.worker.counter.increment_failure()
 
     async def _import_resource(self, q_item: List) -> None:
@@ -244,14 +242,14 @@ class ResourcesHandler:
             self.config.logger.debug(str(e))
         except Exception as e:
             self.worker.counter.increment_failure()
-            self.config.logger.error(f"Error while importing resource {resource_type}: {str(e)}")
+            self.config.logger.error(f"error while importing resource: {str(e)}", resource_type=resource_type)
 
     async def _force_missing_dep_import_cb(self, q_item: List):
         resource_type, _id = q_item
         try:
             _id = await self.config.resources[resource_type]._import_resource(_id=_id)
         except CustomClientHTTPError as e:
-            self.config.logger.error(f"error importing dependency {resource_type} with id {_id}: {str(e)}")
+            self.config.logger.error(f"error importing dependency: {str(e)}", resource_type=resource_type, _id=_id)
             return
 
         failed_connections, missing_deps = self._resource_connections(resource_type, _id)
@@ -261,7 +259,7 @@ class ResourcesHandler:
 
     async def _cleanup_worker(self, q_item: List) -> None:
         resource_type, _id = q_item
-        self.config.logger.info(f"deleting resource type {resource_type} with id: {_id}")
+        self.config.logger.info("deleting resource", resource_type=resource_type, _id=_id)
 
         r_class = self.config.resources[resource_type]
         try:
@@ -271,7 +269,7 @@ class ResourcesHandler:
             await r_class._delete_resource(_id)
             self.worker.counter.increment_success()
         except Exception as e:
-            self.config.logger.error(f"error deleting resource {resource_type} with id {_id}: {str(e)}")
+            self.config.logger.error(f"error deleting resource: {str(e)}", resource_type=resource_type, _id=_id)
             self.worker.counter.increment_failure()
         finally:
             if not r_class.resource_config.concurrent:
@@ -281,7 +279,7 @@ class ResourcesHandler:
         try:
             await self.config.resources[resource_type]._pre_apply_hook()
         except Exception as e:
-            self.config.logger.warning(f"Error while running pre-apply hook: {str(e)}")
+            self.config.logger.warning(f"error while running pre-apply hook: {str(e)}", resource_type=resource_type)
 
     async def run_sorter(self):
         loop = asyncio.get_event_loop()
@@ -362,7 +360,9 @@ def _cleanup_prompt(
     elif config.cleanup == TRUE:
         for resource_type, _id in resources_to_cleanup:
             config.logger.warning(
-                f"Following resource will be deleted: \n" f"{pformat(config.state.destination[resource_type][_id])}"
+                f"Resource will be deleted: \n" f"{pformat(config.state.destination[resource_type][_id])}",
+                resource_type=resource_type,
+                _id=_id,
             )
 
         return confirm("Delete above resources from destination org?")

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -13,8 +13,8 @@ import pytest
 from datadog_sync.cli import cli
 
 
-RESOURCE_TO_ADD_RE = re.compile("Resource to be added")
-RESOURCE_SKIPPED_RE = re.compile("Skipping resource")
+RESOURCE_TO_ADD_RE = re.compile("to be created")
+RESOURCE_SKIPPED_RE = re.compile("skipping resource")
 RESOURCE_FILE_PATH = "resources/{}/{}.json"
 
 


### PR DESCRIPTION
It is currently difficult to understand from which resource the logs are being outputted for. This makes it so that the resource type and id is injected into the log output.
```
2024-09-12 11:37:18,223 - ERROR - 400 Bad Request - {"errors":[.....]}
```

```
2024-09-12 11:37:37,375 - ERROR - [users - 123-123-123] - 400 Bad Request - {"errors":[.....]}
```