### PR TITLE
Change the default value of --create-global-downtime

### DIFF
--- a/datadog_sync/commands/shared/options.py
+++ b/datadog_sync/commands/shared/options.py
@@ -227,8 +227,8 @@ _sync_common_options = [
     option(
         "--create-global-downtime",
         required=False,
-        is_flag=True,
-        default=False,
+        type=bool,
+        default=True,
         show_default=True,
         help="Scheduled downtime is meant to be removed during failover when "
         "user determines monitors have enough telemetry to trigger appropriately.",

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -74,6 +74,7 @@ class BaseResourcesTestClass:
             "--validate=false",
             f"--resources={self.resource_type}",
             f"--filter={self.filter}",
+            "--create-global-downtime=False",
         ]
         if self.force_missing_deps:
             cmd_list.append("--force-missing-dependencies")
@@ -128,6 +129,7 @@ class BaseResourcesTestClass:
                 "--validate=false",
                 f"--resources={self.resource_type}",
                 f"--filter={self.filter}",
+                "--create-global-downtime=False",
             ],
         )
         assert 0 == ret.exit_code
@@ -201,6 +203,7 @@ class BaseResourcesTestClass:
                 f"--resources={self.resource_type}",
                 f"--filter={self.filter}",
                 "--cleanup=force",
+                "--create-global-downtime=False",
             ],
         )
 

--- a/tests/integration/resources/test_logs_indexes.py
+++ b/tests/integration/resources/test_logs_indexes.py
@@ -48,6 +48,7 @@ class TestLogsIndexesResources(BaseResourcesTestClass):
                 f"--filter={self.filter}",
                 "--cleanup=force",
                 "--verify-ddr-status=False",
+                "--create-global-downtime=False",
             ],
         )
         assert 0 == ret.exit_code

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -65,6 +65,7 @@ class TestCli:
                 "--validate=false",
                 f"--resources={self.resources}",
                 "--skip-failed-resource-connections=False",
+                "--create-global-downtime=False",
             ],
         )
         assert 0 == ret.exit_code
@@ -141,6 +142,7 @@ class TestCli:
                 "--skip-failed-resource-connections=False",
                 "--verify-ddr-status=False",
                 "--send-metrics=False",
+                "--create-global-downtime=False",
             ],
         )
         assert "No match for the request" not in caplog.text
@@ -173,6 +175,7 @@ class TestCli:
                 f"--resources={self.resources}",
                 "--verify-ddr-status=False",
                 "--send-metrics=False",
+                "--create-global-downtime=False",
             ],
         )
         assert "No match for the request" not in caplog.text
@@ -227,6 +230,7 @@ class TestCli:
                 "--cleanup=force",
                 "--skip-failed-resource-connections=False",
                 "--send-metrics=False",
+                "--create-global-downtime=False",
             ],
         )
         if ret.exit_code != 0:
@@ -244,6 +248,7 @@ class TestCli:
                     "--cleanup=force",
                     "--skip-failed-resource-connections=False",
                     "--send-metrics=False",
+                    "--create-global-downtime=False",
                 ],
             )
 
@@ -280,6 +285,7 @@ class TestCli:
                 "--validate=false",
                 f"--resources={self.resources}",
                 "--send-metrics=False",
+                "--create-global-downtime=False",
             ],
         )
         assert "No match for the request" not in caplog.text


### PR DESCRIPTION
### What does this PR do?
Create a global downtime at the destination for `sync` and `migrate` commands by default. Allow the user to override it by setting the `--create-global-downtime` command line option to `False`

### Description of the Change

This changes the default value of `--create-global-downtime` to `True`, changed the type to `bool` rather than a flag.

### Possible Drawbacks

This changes the default behavior on `sync-cli`. Users could accidentally create downtimes at destinations when they don't mean to do so. This will mute *all their monitors* at the destination org.

### Release Notes

Need to bump the major release number for this change.

