### PR TITLE
Allow the resources directories to be passed in

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ By default all commands check the Datadog Disaster Recovery (DDR) status of both
 
 #### State files
 
-By default a `resources` directory is generated in the current working directory of the user. This directory contains `json` mapping of resources between the source and destination organization. To avoid duplication and loss of mapping, this directory should be retained between tool usage. To override these directories use the `--source-resources-path` and `--destination-resource-path`.
+By default, a `resources` directory is generated in the current working directory of the user. This directory contains `json` mapping of resources between the source and destination organization. To avoid duplication and loss of mapping, this directory should be retained between tool usage. To override these directories use the `--source-resources-path` and `--destination-resource-path`.
 
 When running againts multiple destination organizations, a seperate working directory should be used to ensure seperation of data. 
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ By default all commands check the Datadog Disaster Recovery (DDR) status of both
 
 #### State files
 
-A `resources` directory is generated in the current working directory of the user. This directory contains `json` mapping of resources between the source and destination organization. To avoid duplication and loss of mapping, this directory should be retained between tool usage.
+By default a `resources` directory is generated in the current working directory of the user. This directory contains `json` mapping of resources between the source and destination organization. To avoid duplication and loss of mapping, this directory should be retained between tool usage. To override these directories use the `--source-resources-path` and `--destination-resource-path`.
 
 When running againts multiple destination organizations, a seperate working directory should be used to ensure seperation of data. 
 

--- a/datadog_sync/commands/shared/options.py
+++ b/datadog_sync/commands/shared/options.py
@@ -187,6 +187,20 @@ _common_options = [
         help="Enables sync-cli metrics being sent to both source and destination",
         cls=CustomOptionClass,
     ),
+    option(
+        "--source-resources-dir",
+        required=False,
+        help="Specify the local path to the source resources",
+        default=constants.SOURCE_DIR_DEFAULT,
+        cls=CustomOptionClass,
+    ),
+    option(
+        "--destination-resources-dir",
+        required=False,
+        help="Specify the local path to the destination resources",
+        default=constants.DESTINATION_DIR_DEFAULT,
+        cls=CustomOptionClass,
+    ),
 ]
 
 

--- a/datadog_sync/commands/shared/options.py
+++ b/datadog_sync/commands/shared/options.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import configobj
 from sys import exit
 
-from click import Choice, Option, option, File
+from click import Choice, Option, option, File, Path
 
 from datadog_sync import constants
 from typing import TYPE_CHECKING, Any, Callable, Dict, List
@@ -188,17 +188,29 @@ _common_options = [
         cls=CustomOptionClass,
     ),
     option(
-        "--source-resources-dir",
+        "--source-resources-path",
+        envvar=constants.DD_SOURCE_RESOURCES_PATH,
+        type=Path(
+            file_okay=False,
+            dir_okay=True,
+            resolve_path=True,
+        ),
         required=False,
         help="Specify the local path to the source resources",
-        default=constants.SOURCE_DIR_DEFAULT,
+        default=constants.SOURCE_PATH_DEFAULT,
         cls=CustomOptionClass,
     ),
     option(
-        "--destination-resources-dir",
+        "--destination-resources-path",
+        envvar=constants.DD_DESTINATION_RESOURCES_PATH,
+        type=Path(
+            file_okay=False,
+            dir_okay=True,
+            resolve_path=True,
+        ),
         required=False,
         help="Specify the local path to the destination resources",
-        default=constants.DESTINATION_DIR_DEFAULT,
+        default=constants.DESTINATION_PATH_DEFAULT,
         cls=CustomOptionClass,
     ),
 ]

--- a/datadog_sync/constants.py
+++ b/datadog_sync/constants.py
@@ -21,6 +21,8 @@ DD_FILTER_OPERATOR = "DD_FILTER_OPERATOR"
 DD_CLEANUP = "DD_CLEANUP"
 DD_VALIDATE = "DD_VALIDATE"
 DD_VERIFY_DDR_STATUS = "DD_VERIFY_DDR_STATUS"
+DD_DESTINATION_RESOURCES_PATH = "DD_DESTINATION_RESOURCES_PATH"
+DD_SOURCE_RESOURCES_PATH = "DD_SOURCE_RESOURCES_PATH"
 
 # Default variables
 DEFAULT_API_URL = "https://api.datadoghq.com"
@@ -34,10 +36,10 @@ TRUE = 1
 FORCE = 2
 
 # State parameters
-SOURCE_DIR_PARAM = "source_resources_dir"
-SOURCE_DIR_DEFAULT = "resources/source"
-DESTINATION_DIR_PARAM = "destination_resources_dir"
-DESTINATION_DIR_DEFAULT = "resources/destination"
+SOURCE_PATH_PARAM = "source_resources_path"
+SOURCE_PATH_DEFAULT = "resources/source"
+DESTINATION_PATH_PARAM = "destination_resources_path"
+DESTINATION_PATH_DEFAULT = "resources/destination"
 
 
 # Commands

--- a/datadog_sync/constants.py
+++ b/datadog_sync/constants.py
@@ -33,6 +33,12 @@ FALSE = 0
 TRUE = 1
 FORCE = 2
 
+# State parameters
+SOURCE_DIR_PARAM = "source_resources_dir"
+SOURCE_DIR_DEFAULT = "resources/source"
+DESTINATION_DIR_PARAM = "destination_resources_dir"
+DESTINATION_DIR_DEFAULT = "resources/destination"
+
 
 # Commands
 class Command(Enum):

--- a/datadog_sync/utils/configuration.py
+++ b/datadog_sync/utils/configuration.py
@@ -20,13 +20,13 @@ from datadog_sync.utils.log import Log
 from datadog_sync.utils.filter import Filter, process_filters
 from datadog_sync.constants import (
     Command,
-    DESTINATION_DIR_DEFAULT,
-    DESTINATION_DIR_PARAM,
+    DESTINATION_PATH_DEFAULT,
+    DESTINATION_PATH_PARAM,
     FALSE,
     FORCE,
     LOGGER_NAME,
-    SOURCE_DIR_DEFAULT,
-    SOURCE_DIR_PARAM,
+    SOURCE_PATH_DEFAULT,
+    SOURCE_PATH_PARAM,
     TRUE,
     VALIDATE_ENDPOINT,
     VALID_DDR_STATES,
@@ -147,9 +147,9 @@ def build_config(cmd: Command, **kwargs: Optional[Any]) -> Configuration:
         }[cleanup.lower()]
 
     # Initialize state
-    source_resources_dir = kwargs.get(SOURCE_DIR_PARAM, SOURCE_DIR_DEFAULT)
-    destination_resources_dir = kwargs.get(DESTINATION_DIR_PARAM, DESTINATION_DIR_DEFAULT)
-    state = State(source_resources_dir=source_resources_dir, destination_resources_dir=destination_resources_dir)
+    source_resources_path = kwargs.get(SOURCE_PATH_PARAM, SOURCE_PATH_DEFAULT)
+    destination_resources_path = kwargs.get(DESTINATION_PATH_PARAM, DESTINATION_PATH_DEFAULT)
+    state = State(source_resources_path=source_resources_path, destination_resources_path=destination_resources_path)
 
     # Initialize Configuration
     config = Configuration(

--- a/datadog_sync/utils/configuration.py
+++ b/datadog_sync/utils/configuration.py
@@ -20,9 +20,13 @@ from datadog_sync.utils.log import Log
 from datadog_sync.utils.filter import Filter, process_filters
 from datadog_sync.constants import (
     Command,
+    DESTINATION_DIR_DEFAULT,
+    DESTINATION_DIR_PARAM,
     FALSE,
     FORCE,
     LOGGER_NAME,
+    SOURCE_DIR_DEFAULT,
+    SOURCE_DIR_PARAM,
     TRUE,
     VALIDATE_ENDPOINT,
     VALID_DDR_STATES,
@@ -143,7 +147,9 @@ def build_config(cmd: Command, **kwargs: Optional[Any]) -> Configuration:
         }[cleanup.lower()]
 
     # Initialize state
-    state = State()
+    source_resources_dir = kwargs.get(SOURCE_DIR_PARAM, SOURCE_DIR_DEFAULT)
+    destination_resources_dir = kwargs.get(DESTINATION_DIR_PARAM, DESTINATION_DIR_DEFAULT)
+    state = State(source_resources_dir=source_resources_dir, destination_resources_dir=destination_resources_dir)
 
     # Initialize Configuration
     config = Configuration(

--- a/datadog_sync/utils/state.py
+++ b/datadog_sync/utils/state.py
@@ -17,7 +17,7 @@ from datadog_sync.utils.storage.storage_types import StorageType
 
 
 class State:
-    def __init__(self, type_: StorageType = StorageType.LOCAL_FILE, **kwargs: Any) -> None:
+    def __init__(self, type_: StorageType = StorageType.LOCAL_FILE, **kwargs: object) -> None:
         if type_ == StorageType.LOCAL_FILE:
             source_resources_dir = kwargs.get(SOURCE_DIR_PARAM, SOURCE_DIR_DEFAULT)
             destination_resources_dir = kwargs.get(DESTINATION_DIR_PARAM, DESTINATION_DIR_DEFAULT)

--- a/datadog_sync/utils/state.py
+++ b/datadog_sync/utils/state.py
@@ -6,10 +6,10 @@ from typing import Any, Dict, List, Tuple
 
 from datadog_sync.constants import (
     Origin,
-    DESTINATION_DIR_PARAM,
-    DESTINATION_DIR_DEFAULT,
-    SOURCE_DIR_PARAM,
-    SOURCE_DIR_DEFAULT,
+    DESTINATION_PATH_PARAM,
+    DESTINATION_PATH_DEFAULT,
+    SOURCE_PATH_PARAM,
+    SOURCE_PATH_DEFAULT,
 )
 from datadog_sync.utils.storage._base_storage import BaseStorage, StorageData
 from datadog_sync.utils.storage.local_file import LocalFile
@@ -19,11 +19,11 @@ from datadog_sync.utils.storage.storage_types import StorageType
 class State:
     def __init__(self, type_: StorageType = StorageType.LOCAL_FILE, **kwargs: object) -> None:
         if type_ == StorageType.LOCAL_FILE:
-            source_resources_dir = kwargs.get(SOURCE_DIR_PARAM, SOURCE_DIR_DEFAULT)
-            destination_resources_dir = kwargs.get(DESTINATION_DIR_PARAM, DESTINATION_DIR_DEFAULT)
+            source_resources_path = kwargs.get(SOURCE_PATH_PARAM, SOURCE_PATH_DEFAULT)
+            destination_resources_path = kwargs.get(DESTINATION_PATH_PARAM, DESTINATION_PATH_DEFAULT)
             self._storage: BaseStorage = LocalFile(
-                source_resources_dir=source_resources_dir,
-                destination_resources_dir=destination_resources_dir,
+                source_resources_path=source_resources_path,
+                destination_resources_path=destination_resources_path,
             )
         else:
             raise NotImplementedError(f"Storage type {type_} not implemented")

--- a/datadog_sync/utils/state.py
+++ b/datadog_sync/utils/state.py
@@ -4,16 +4,27 @@
 # Copyright 2019 Datadog, Inc.
 from typing import Any, Dict, List, Tuple
 
-from datadog_sync.constants import Origin
+from datadog_sync.constants import (
+    Origin,
+    DESTINATION_DIR_PARAM,
+    DESTINATION_DIR_DEFAULT,
+    SOURCE_DIR_PARAM,
+    SOURCE_DIR_DEFAULT,
+)
 from datadog_sync.utils.storage._base_storage import BaseStorage, StorageData
 from datadog_sync.utils.storage.local_file import LocalFile
 from datadog_sync.utils.storage.storage_types import StorageType
 
 
 class State:
-    def __init__(self, type_: StorageType = StorageType.LOCAL_FILE) -> None:
+    def __init__(self, type_: StorageType = StorageType.LOCAL_FILE, **kwargs: Any) -> None:
         if type_ == StorageType.LOCAL_FILE:
-            self._storage: BaseStorage = LocalFile()
+            source_resources_dir = kwargs.get(SOURCE_DIR_PARAM, SOURCE_DIR_DEFAULT)
+            destination_resources_dir = kwargs.get(DESTINATION_DIR_PARAM, DESTINATION_DIR_DEFAULT)
+            self._storage: BaseStorage = LocalFile(
+                source_resources_dir=source_resources_dir,
+                destination_resources_dir=destination_resources_dir,
+            )
         else:
             raise NotImplementedError(f"Storage type {type_} not implemented")
 

--- a/datadog_sync/utils/storage/local_file.py
+++ b/datadog_sync/utils/storage/local_file.py
@@ -35,7 +35,7 @@ class LocalFile(BaseStorage):
             for file in os.listdir(self.source_resources_dir):
                 if file.endswith(".json"):
                     resource_type = file.split(".")[0]
-                    with open(self.source_resources_dir + f"/{file}", "r") as f:
+                    with open(self.source_resources_dir + f"/{file}") as f:
                         try:
                             data.source[resource_type] = json.load(f)
                         except json.decoder.JSONDecodeError:
@@ -45,7 +45,7 @@ class LocalFile(BaseStorage):
             for file in os.listdir(self.destination_resources_dir):
                 if file.endswith(".json"):
                     resource_type = file.split(".")[0]
-                    with open(self.destination_resources_dir + f"/{file}", "r") as f:
+                    with open(self.destination_resources_dir + f"/{file}") as f:
                         try:
                             data.destination[resource_type] = json.load(f)
                         except json.decoder.JSONDecodeError:

--- a/datadog_sync/utils/storage/local_file.py
+++ b/datadog_sync/utils/storage/local_file.py
@@ -7,7 +7,12 @@ import json
 import logging
 import os
 
-from datadog_sync.constants import LOGGER_NAME, Origin
+from datadog_sync.constants import (
+    Origin,
+    DESTINATION_DIR_DEFAULT,
+    LOGGER_NAME,
+    SOURCE_DIR_DEFAULT,
+)
 from datadog_sync.utils.storage._base_storage import BaseStorage, StorageData
 
 
@@ -15,27 +20,32 @@ log = logging.getLogger(LOGGER_NAME)
 
 
 class LocalFile(BaseStorage):
-    SOURCE_RESOURCES_DIR = "resources/source"
-    DESTINATION_RESOURCES_DIR = "resources/destination"
+
+    def __init__(
+        self, source_resources_dir=SOURCE_DIR_DEFAULT, destination_resources_dir=DESTINATION_DIR_DEFAULT
+    ) -> None:
+        super().__init__()
+        self.source_resources_dir = source_resources_dir
+        self.destination_resources_dir = destination_resources_dir
 
     def get(self, origin: Origin) -> StorageData:
         data = StorageData()
 
-        if origin in [Origin.SOURCE, Origin.ALL] and os.path.exists(self.SOURCE_RESOURCES_DIR):
-            for file in os.listdir(self.SOURCE_RESOURCES_DIR):
+        if origin in [Origin.SOURCE, Origin.ALL] and os.path.exists(self.source_resources_dir):
+            for file in os.listdir(self.source_resources_dir):
                 if file.endswith(".json"):
                     resource_type = file.split(".")[0]
-                    with open(self.SOURCE_RESOURCES_DIR + f"/{file}", "r") as f:
+                    with open(self.source_resources_dir + f"/{file}", "r") as f:
                         try:
                             data.source[resource_type] = json.load(f)
                         except json.decoder.JSONDecodeError:
                             log.warning(f"invalid json in source resource file: {resource_type}")
 
-        if origin in [Origin.DESTINATION, Origin.ALL] and os.path.exists(self.DESTINATION_RESOURCES_DIR):
-            for file in os.listdir(self.DESTINATION_RESOURCES_DIR):
+        if origin in [Origin.DESTINATION, Origin.ALL] and os.path.exists(self.destination_resources_dir):
+            for file in os.listdir(self.destination_resources_dir):
                 if file.endswith(".json"):
                     resource_type = file.split(".")[0]
-                    with open(self.DESTINATION_RESOURCES_DIR + f"/{file}", "r") as f:
+                    with open(self.destination_resources_dir + f"/{file}", "r") as f:
                         try:
                             data.destination[resource_type] = json.load(f)
                         except json.decoder.JSONDecodeError:
@@ -45,20 +55,20 @@ class LocalFile(BaseStorage):
 
     def put(self, origin: Origin, data: StorageData) -> None:
         if origin in [Origin.SOURCE, Origin.ALL]:
-            os.makedirs(self.SOURCE_RESOURCES_DIR, exist_ok=True)
+            os.makedirs(self.source_resources_dir, exist_ok=True)
             self.write_resources_file(Origin.SOURCE, data)
 
         if origin in [Origin.DESTINATION, Origin.ALL]:
-            os.makedirs(self.DESTINATION_RESOURCES_DIR, exist_ok=True)
+            os.makedirs(self.destination_resources_dir, exist_ok=True)
             self.write_resources_file(origin, data)
 
     def write_resources_file(self, origin: Origin, data: StorageData) -> None:
         if origin in [Origin.SOURCE, Origin.ALL]:
             for resource_type, v in data.source.items():
-                with open(self.SOURCE_RESOURCES_DIR + f"/{resource_type}.json", "w+") as f:
+                with open(self.source_resources_dir + f"/{resource_type}.json", "w+") as f:
                     json.dump(v, f)
 
         if origin in [Origin.DESTINATION, Origin.ALL]:
             for resource_type, v in data.destination.items():
-                with open(self.DESTINATION_RESOURCES_DIR + f"/{resource_type}.json", "w+") as f:
+                with open(self.destination_resources_dir + f"/{resource_type}.json", "w+") as f:
                     json.dump(v, f)

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -8,6 +8,7 @@ import shutil
 import os
 
 import pytest
+from tempfile import TemporaryDirectory
 
 from datadog_sync.cli import cli
 
@@ -278,18 +279,22 @@ class TestCli:
     def test_migrate(self, runner, caplog):
         caplog.set_level(logging.DEBUG)
         # Migrate
-        ret = runner.invoke(
-            cli,
-            [
-                "migrate",
-                "--validate=false",
-                f"--resources={self.resources}",
-                "--send-metrics=False",
-                "--create-global-downtime=False",
-            ],
-        )
-        assert "No match for the request" not in caplog.text
-        assert 0 == ret.exit_code
+
+        with TemporaryDirectory() as source_path, TemporaryDirectory() as destination_path:
+            ret = runner.invoke(
+                cli,
+                [
+                    "migrate",
+                    "--validate=false",
+                    f"--resources={self.resources}",
+                    "--send-metrics=False",
+                    "--create-global-downtime=False",
+                    f"--source-resources-path={source_path}",
+                    f"--destination-resources-path={destination_path}",
+                ],
+            )
+            assert "No match for the request" not in caplog.text
+            assert 0 == ret.exit_code
 
         caplog.clear()
         # Check diff


### PR DESCRIPTION
### What does this PR do?
Allows users to specify the directories for storing resources locally.


### Description of the Change
Added `--source-resources-path` and `--destination-resources-path` flags to the command line rather than hard coding the local file storage. The defaults remain the same.


### Verification Process
Added tests and ran tests locally.
