### PR TITLE
Add a reset command to remove destination resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Then, you can run the `sync` command which will use the stored files from previo
 
 The `migrate` command will run an `import` followed immediately by a `sync`.
 
-The `reset` command will delete resources at the destination; however, by default it backup those resources first and fail if it cannot. You can (but probably shouldn't) skip the backup by using the `--do-not-backup` flag.
+The `reset` command will delete resources at the destination; however, by default it backs up those resources first and fails if it cannot. You can (but probably shouldn't) skip the backup by using the `--do-not-backup` flag.
 
 *Note*: The tool uses the `resources` directory as the source of truth for determining what resources need to be created and modified. Hence, this directory should not be removed or corrupted.
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Then, you can run the `sync` command which will use the stored files from previo
 
 The `migrate` command will run an `import` followed immediately by a `sync`.
 
+The `reset` command will delete resources at the destination; however, by default it backup those resources first and fail if it cannot. You can (but probably shouldn't) skip the backup by using the `--do-not-backup` flag.
+
 *Note*: The tool uses the `resources` directory as the source of truth for determining what resources need to be created and modified. Hence, this directory should not be removed or corrupted.
 
 **Example Usage**

--- a/datadog_sync/commands/__init__.py
+++ b/datadog_sync/commands/__init__.py
@@ -7,6 +7,7 @@ from datadog_sync.commands.sync import sync
 from datadog_sync.commands._import import _import
 from datadog_sync.commands.diffs import diffs
 from datadog_sync.commands.migrate import migrate
+from datadog_sync.commands.reset import reset
 
 
 ALL_COMMANDS = [
@@ -14,4 +15,5 @@ ALL_COMMANDS = [
     _import,
     diffs,
     migrate,
+    reset,
 ]

--- a/datadog_sync/commands/reset.py
+++ b/datadog_sync/commands/reset.py
@@ -3,25 +3,28 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019 Datadog, Inc.
 
-from click import command
+from click import command, option
 
 from datadog_sync.commands.shared.options import (
+    CustomOptionClass,
     common_options,
     destination_auth_options,
-    diffs_common_options,
-    source_auth_options,
-    sync_common_options,
 )
 from datadog_sync.commands.shared.utils import run_cmd
 from datadog_sync.constants import Command
 
 
-@command(Command.MIGRATE.value, short_help="Migrate Datadog resources from one datacenter to another.")
-@source_auth_options
+@command(Command.RESET.value, short_help="WARNING: Reset Datadog resources by deleting them.")
 @destination_auth_options
 @common_options
-@diffs_common_options
-@sync_common_options
-def migrate(**kwargs):
-    """Migrate Datadog resources from one datacenter to another."""
-    run_cmd(Command.MIGRATE, **kwargs)
+@option(
+    "--do-not-backup",
+    required=False,
+    is_flag=True,
+    default=False,
+    help="Skip backing up the destination you are about to reset. Not recommended.",
+    cls=CustomOptionClass,
+)
+def reset(**kwargs):
+    """WARNING: Reset Datadog resources by deleting them."""
+    run_cmd(Command.RESET, **kwargs)

--- a/datadog_sync/commands/shared/utils.py
+++ b/datadog_sync/commands/shared/utils.py
@@ -17,7 +17,7 @@ def run_cmd(cmd: Command, **kwargs):
         asyncio.run(run_cmd_async(cfg, handler, cmd))
     except KeyboardInterrupt:
         cfg.logger.error("Process interrupted by user")
-        if cmd in [Command.SYNC, Command.MIGRATE]:
+        if cmd in [Command.SYNC, Command.MIGRATE, Command.RESET]:
             cfg.logger.info("Writing synced resources to disk before exit...")
             cfg.state.dump_state()
             exit(0)
@@ -44,6 +44,8 @@ async def run_cmd_async(cfg: Configuration, handler: ResourcesHandler, cmd: Comm
         elif cmd == Command.MIGRATE:
             await handler.import_resources()
             await handler.apply_resources()
+        elif cmd == Command.RESET:
+            await handler.reset()
         else:
             cfg.logger.error(f"Command {cmd.value} not found")
             return

--- a/datadog_sync/constants.py
+++ b/datadog_sync/constants.py
@@ -40,6 +40,7 @@ class Command(Enum):
     SYNC = "sync"
     DIFFS = "diffs"
     MIGRATE = "migrate"
+    RESET = "reset"
 
 
 # Origin

--- a/datadog_sync/utils/configuration.py
+++ b/datadog_sync/utils/configuration.py
@@ -157,7 +157,7 @@ def build_config(cmd: Command, **kwargs: Optional[Any]) -> Configuration:
     #     the path for that backup is different
     if cmd == Command.RESET:
         cleanup = TRUE
-        source_client = destination_client
+        source_client = CustomClient(destination_api_url, destination_auth, retry_timeout, timeout, send_metrics)
         source_resources_path = f"{destination_resources_path}/.backup/{str(time.time())}"
 
     # Initialize state

--- a/datadog_sync/utils/configuration.py
+++ b/datadog_sync/utils/configuration.py
@@ -149,8 +149,8 @@ def build_config(cmd: Command, **kwargs: Optional[Any]) -> Configuration:
         }[cleanup.lower()]
 
     # Set resource paths
-    destination_resources_path = kwargs.get(DESTINATION_PATH_PARAM, DESTINATION_PATH_DEFAULT)
     source_resources_path = kwargs.get(SOURCE_PATH_PARAM, SOURCE_PATH_DEFAULT)
+    destination_resources_path = kwargs.get(DESTINATION_PATH_PARAM, DESTINATION_PATH_DEFAULT)
 
     # If backing up a destination for before reset then:
     #     the source of the backup is the destination

--- a/datadog_sync/utils/configuration.py
+++ b/datadog_sync/utils/configuration.py
@@ -152,9 +152,9 @@ def build_config(cmd: Command, **kwargs: Optional[Any]) -> Configuration:
     source_resources_path = kwargs.get(SOURCE_PATH_PARAM, SOURCE_PATH_DEFAULT)
     destination_resources_path = kwargs.get(DESTINATION_PATH_PARAM, DESTINATION_PATH_DEFAULT)
 
-    # If backing up a destination for before reset then:
-    #     the source of the backup is the destination
-    #     the path for that backup is different
+    # Confusing, but the source for the import needs to be the destination of the reset
+    # If a destination is going to be reset then a backup needs to be preformed. A back up
+    # is just an import, the source of that import is the destination of the reset.
     if cmd == Command.RESET:
         cleanup = TRUE
         source_client = CustomClient(destination_api_url, destination_auth, retry_timeout, timeout, send_metrics)

--- a/datadog_sync/utils/configuration.py
+++ b/datadog_sync/utils/configuration.py
@@ -47,6 +47,7 @@ class Configuration(object):
     send_metrics: bool
     state: State
     verify_ddr_status: bool
+    backup_before_reset: bool
     resources: Dict[str, BaseResource] = field(default_factory=dict)
     resources_arg: List[str] = field(default_factory=list)
 
@@ -56,10 +57,9 @@ class Configuration(object):
         for resource in self.resources.values():
             await resource.init_async()
 
-        # Validate the clients. For import we only validate the source client
-        # For sync/diffs we validate the destination client.
+        # Validate the clients.
         if self.validate:
-            if cmd in [Command.SYNC, Command.DIFFS, Command.MIGRATE]:
+            if cmd in [Command.SYNC, Command.DIFFS, Command.MIGRATE, Command.RESET]:
                 try:
                     await _validate_client(self.destination_client)
                 except Exception:
@@ -133,6 +133,7 @@ def build_config(cmd: Command, **kwargs: Optional[Any]) -> Configuration:
     create_global_downtime = kwargs.get("create_global_downtime")
     validate = kwargs.get("validate")
     verify_ddr_status = kwargs.get("verify_ddr_status")
+    backup_before_reset = not kwargs.get("do_not_backup")
 
     cleanup = kwargs.get("cleanup")
     if cleanup:
@@ -161,6 +162,7 @@ def build_config(cmd: Command, **kwargs: Optional[Any]) -> Configuration:
         send_metrics=send_metrics,
         state=state,
         verify_ddr_status=verify_ddr_status,
+        backup_before_reset=backup_before_reset,
     )
 
     # Initialize resource classes

--- a/datadog_sync/utils/state.py
+++ b/datadog_sync/utils/state.py
@@ -56,7 +56,6 @@ class State:
             Key is a tuple of resource_type and resource id.
         """
         all_resources = {}
-
         for resource_type in resources_types:
             for _id, r in self._data.source[resource_type].items():
                 all_resources[(resource_type, _id)] = r

--- a/datadog_sync/utils/state.py
+++ b/datadog_sync/utils/state.py
@@ -56,6 +56,7 @@ class State:
             Key is a tuple of resource_type and resource id.
         """
         all_resources = {}
+
         for resource_type in resources_types:
             for _id, r in self._data.source[resource_type].items():
                 all_resources[(resource_type, _id)] = r

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,6 +140,7 @@ def config():
         state=State(),
         verify_ddr_status=True,
         send_metrics=True,
+        backup_before_reset=True,
     )
 
     resources = init_resources(cfg)


### PR DESCRIPTION
### What does this PR do?

Add a `reset` command that deletes resources at a destination

### Description of the Change

The `reset` command will attempt to backup the destination before deleting the resources. Both the backup and the delete respect any filtering and the resources flag.

### Possible Drawbacks

The drawback is inherent with the functionality. The user will have to ability to delete all resources in an org. This is mitigated in the following ways. First, the DDR check stops the script from running if the org is in a disaster state or if the org isn't a DDR org at all. The use has to manually override that check to stop it. Second, by default the reset command performs a backup. 

### Verification Process

Ran multiple resets of an org and was able to restore it from back up.

### Additional Notes

Long term we may want to rethink the internal variable names with "source" and "destination" in them. In this specific case it gets confusing because we want to import and delete from the same datacenter, but sync-cli is very much built around the concept of moving data between a source and a destination. Renaming these might help with a future sync-cli where one or more sources are synced to one or more destinations. Imagine a large multi-org account wanting to sync dashboards from various child orgs to a single DDR R2 org.

