### PR TITLE
Fix subdomain for integration log pipelines

### DIFF
--- a/datadog_sync/model/logs_pipelines.py
+++ b/datadog_sync/model/logs_pipelines.py
@@ -80,7 +80,10 @@ class LogsPipelines(BaseResource):
             }
 
             # Submit a log to the logs intake API to trigger the creation of the integration pipeline
-            subdomain = f"{self.logs_intake_subdomain}.{destination_client.url_object.subdomain}"
+            subdomain = self.logs_intake_subdomain
+            if destination_client.url_object.subdomain != "api":
+                subdomain = f"{self.logs_intake_subdomain}.{destination_client.url_object.subdomain}"
+
             await destination_client.post(self.logs_intake_path, payload, subdomain=subdomain)
             created = False
             for _ in range(12):

--- a/datadog_sync/model/logs_pipelines.py
+++ b/datadog_sync/model/logs_pipelines.py
@@ -80,7 +80,8 @@ class LogsPipelines(BaseResource):
             }
 
             # Submit a log to the logs intake API to trigger the creation of the integration pipeline
-            await destination_client.post(self.logs_intake_path, payload, subdomain=self.logs_intake_subdomain)
+            subdomain = f"{self.logs_intake_subdomain}.{destination_client.url_object.subdomain}"
+            await destination_client.post(self.logs_intake_path, payload, subdomain=subdomain)
             created = False
             for _ in range(12):
                 updated_pipelines = await self.get_destination_integration_pipelines()

--- a/tests/integration/resources/cassettes/test_logs_pipelines/TestLogsPipelinesResourcesIntegrationFilter.test_resource_sync.yaml
+++ b/tests/integration/resources/cassettes/test_logs_pipelines/TestLogsPipelinesResourcesIntegrationFilter.test_resource_sync.yaml
@@ -355,7 +355,7 @@ interactions:
       Content-Type:
       - application/json
     method: POST
-    uri: https://http-intake.logs.api.datadoghq.eu/api/v2/logs
+    uri: https://http-intake.logs.datadoghq.eu/api/v2/logs
   response:
     body:
       string: '{}'

--- a/tests/integration/resources/cassettes/test_logs_pipelines/TestLogsPipelinesResourcesIntegrationFilter.test_resource_sync.yaml
+++ b/tests/integration/resources/cassettes/test_logs_pipelines/TestLogsPipelinesResourcesIntegrationFilter.test_resource_sync.yaml
@@ -355,7 +355,7 @@ interactions:
       Content-Type:
       - application/json
     method: POST
-    uri: https://http-intake.logs.datadoghq.eu/api/v2/logs
+    uri: https://http-intake.logs.api.datadoghq.eu/api/v2/logs
   response:
     body:
       string: '{}'


### PR DESCRIPTION


### What does this PR do?

Alters the subdomain when submitting logs

### Description of the Change

The subdomain for the logs intake needs to be `http-intake.logs.us5` not `http-intake.logs`

