### PR TITLE
Remove `public_id` from synthetics sub step

### DIFF
--- a/datadog_sync/model/synthetics_tests.py
+++ b/datadog_sync/model/synthetics_tests.py
@@ -38,6 +38,7 @@ class SyntheticsTests(BaseResource):
             "overall_state",
             "overall_state_modified",
             "stepCount",
+            "steps.public_id",
         ],
         non_nullable_attr=[
             "options.monitor_options.on_missing_data",

--- a/datadog_sync/utils/resource_utils.py
+++ b/datadog_sync/utils/resource_utils.py
@@ -179,6 +179,11 @@ def remove_non_nullable_attributes(resource_config, resource):
 
 
 def del_attr(k_list, resource):
+    if isinstance(resource, list):
+        for r in resource:
+            del_attr(k_list, r)
+        return
+
     if len(k_list) == 1:
         resource.pop(k_list[0], None)
     else:

--- a/datadog_sync/utils/resources_handler.py
+++ b/datadog_sync/utils/resources_handler.py
@@ -144,7 +144,7 @@ class ResourcesHandler:
             )
         except Exception as e:
             self.worker.counter.increment_failure()
-            self.config.logger.error(str(e))
+            self.config.logger.error(str(e), resource_type=resource_type, _id=_id)
             await r_class._send_action_metrics(Command.SYNC.value, _id, Status.FAILURE.value)
         finally:
             # always place in done queue regardless of exception thrown


### PR DESCRIPTION
`public_id` should not be sent in the synthetics sub step.