### PR TITLE
Small logging cleanup

### DIFF
--- a/datadog_sync/utils/resources_handler.py
+++ b/datadog_sync/utils/resources_handler.py
@@ -265,11 +265,13 @@ class ResourcesHandler:
         except SkipResource as e:
             self.worker.counter.increment_skipped()
             await r_class._send_action_metrics(Command.IMPORT.value, _id, Status.SKIPPED.value)
+            self.config.logger.warning(f"skip importing resource: resource_type:{resource_type} id:{_id}")
             self.config.logger.debug(str(e))
         except Exception as e:
             self.worker.counter.increment_failure()
             await r_class._send_action_metrics(Command.IMPORT.value, _id, Status.FAILURE.value)
-            self.config.logger.error(f"error while importing resource: {str(e)}", resource_type=resource_type)
+            self.config.logger.error(f"error while importing resource: resource_type:{resource_type} id:{_id}")
+            self.config.logger.debug(f"error detail: {str(e)}", resource_type=resource_type)
 
     async def _force_missing_dep_import_cb(self, q_item: List):
         resource_type, _id = q_item


### PR DESCRIPTION
### What does this PR do?

Cleanup the logging of errors.

### Description of the Change

Stop logging the entire error by default and give a summary of it instead. Give a warning for resources that are skipped. Devs can still get the whole error by changing logging level to debug if needed.
ditionnal notes about feature deprecation or backward incompatible changes.
