### PR TITLE
Fix a bug with sending metrics

### DIFF
--- a/datadog_sync/utils/configuration.py
+++ b/datadog_sync/utils/configuration.py
@@ -96,8 +96,21 @@ class Configuration(object):
         else:
             self.logger.warning("DDR verification skipped.")
 
-        await self.source_client.send_metric(f"{cmd.value}.start")
-        await self.destination_client.send_metric(f"{cmd.value}.start")
+        if cmd in [Command.IMPORT] and self.send_metrics:
+            await self.source_client.send_metric(f"{cmd.value}.start")
+            try:
+                await self.destination_client.send_metric(f"{cmd.value}.start")
+            except Exception:
+                self.logger.info("Optional destination not defined")
+        if cmd in [Command.SYNC, Command.RESET] and self.send_metrics:
+            await self.destination_client.send_metric(f"{cmd.value}.start")
+            try:
+                await self.source_client.send_metric(f"{cmd.value}.start")
+            except Exception:
+                self.logger.info("Optional source not defined")
+        if cmd in [Command.MIGRATE] and self.send_metrics:
+            await self.source_client.send_metric(f"{cmd.value}.start")
+            await self.destination_client.send_metric(f"{cmd.value}.start")
 
     async def exit_async(self):
         await self.source_client._end_session()


### PR DESCRIPTION
### What does this PR do?

Add try/except block around sending optional metrics.

### Description of the Change

During an `import` there's no *need* to define a destination; however, a destination can be defined. The old code would error out when sending metrics to the optional destination. It should not error out, it should give a best effort and log. Same for `sync` and `delete` and having an optional source.

### Motivation
https://github.com/DataDog/datadog-sync-cli/issues/301