### PR TITLE
Update warning message when defaulting to EXACT_MATCH_OPERATOR

### DIFF
--- a/datadog_sync/utils/filter.py
+++ b/datadog_sync/utils/filter.py
@@ -102,8 +102,8 @@ def process_filters(filter_list: List[str]) -> Dict[str, List[Filter]]:
         if not f_dict.get(FILTER_OPERATOR_KEY):
             f_dict[FILTER_OPERATOR_KEY] = EXACT_MATCH_OPERATOR
             log.warning(
-                "Defaulting to filter Operator `ExactMatch'. Please ensure the filter Value provided is"
-                + "updated as this behavior will be removed in the future. See the official README for more information"
+                "Defaulting to filter Operator `ExactMatch'. Please ensure the filter Value provided is "
+                + "updated as this behavior will be removed in the future. See the official README.md for more information."
             )
 
         # Build and assign regex matcher to VALUE key for the deprecated Operators

--- a/datadog_sync/utils/filter.py
+++ b/datadog_sync/utils/filter.py
@@ -97,13 +97,14 @@ def process_filters(filter_list: List[str]) -> Dict[str, List[Filter]]:
         if invalid_filter:
             continue
 
-        #  Default to EXACT_MATCH_OPERATOR for backward compatibility. This behavior will be removed in the
+        # Default to EXACT_MATCH_OPERATOR for backward compatibility. This behavior will be removed in the
         # future as it can already be achieved using regex in the Value.
         if not f_dict.get(FILTER_OPERATOR_KEY):
             f_dict[FILTER_OPERATOR_KEY] = EXACT_MATCH_OPERATOR
             log.warning(
                 "Defaulting to filter Operator `ExactMatch'. Please ensure the filter Value provided is "
-                + "updated as this behavior will be removed in the future. See the official README.md for more information."
+                + "updated as this behavior will be removed in the future. See the official README.md "
+                + "for more information."
             )
 
         # Build and assign regex matcher to VALUE key for the deprecated Operators


### PR DESCRIPTION
### What does this PR do?

Fixes a typo in the warning message shown to users.

### Description of the Change

Previous warning message:

```
Defaulting to filter Operator `ExactMatch'. Please ensure the filter Value provided isupdated as this behavior will be removed in the future. See the official README for more information
```

After changes:

```
Defaulting to filter Operator `ExactMatch'. Please ensure the filter Value provided is updated as this behavior will be removed in the future. See the official README.md for more information.
```

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additional notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
