### PR TITLE
Adding more python versions to testing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ console_scripts =
 
 [options.extras_require]
 tests =
-    ddtrace==2.8.0
+    ddtrace==2.21.1
     black==24.3.0
     pytest==8.1.1
     pytest-black

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 3.9.0
 skip_missing_interpreters = true
 envlist =
-    py{39,311}
+    py{39,310,311,312,313}
     ruff
     black
 


### PR DESCRIPTION

### What does this PR do?
Run tests on all versions of python that are active, 3.9, 3.10, 3.11, 3.12, 3.13

### Description of the Change

Had to update `ddtrace` to run in 3.13

