### PR TITLE
Support migration of log indexes without Flex tier

### DIFF
--- a/datadog_sync/model/logs_indexes.py
+++ b/datadog_sync/model/logs_indexes.py
@@ -39,6 +39,9 @@ class LogsIndexes(BaseResource):
         resource = cast(dict, resource)
         if not resource.get("daily_limit"):
             resource["disable_daily_limit"] = True
+        # TODO: Remove this block once the Logs Indexes API is fixed to return null for indexes with no flex logs
+        if resource.get("num_flex_logs_retention_days") == 0:
+            resource.pop("num_flex_logs_retention_days")
 
         return resource["name"], resource
 


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).

### What does this PR do?

<!--

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->
The Log Indexes API currently returns `num_flex_logs_retention_days` as 0 instead of null for indexes without the Flex tier, leading to migration failures when attempting to create or update log indexes in an organization where Flex logs are not enabled.

This PR ensures that when `num_flex_logs_retention_days` is 0, the field is removed from the imported resource, preventing unnecessary Flex log-related parameters from being included in migration requests.

### Description of the Change

<!--

A brief description of the change being made with this pull request.

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
- Added a check in the import method to remove `num_flex_logs_retention_days` when its value is 0.

### Alternate Designs
An alternative approach considered was to add a check in both the `create_resource` and `update_resource` methods to remove `num_flex_logs_retention_days` when its value is 0.  

However, this was discarded because the issue originates from the Log Indexes API's get all indexes response, which returns `num_flex_logs_retention_days` as `0` instead of `null`. The create and update APIs do not have this issue, so modifying those methods would introduce unnecessary logic for a problem that only occurs in the retrieval step.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->
Since an existing test for log index migration behavior is currently skipped, no new tests were added or modified.
Instead, manual verification was performed using the import command:

1. Ran import targeting log indexes with and without the Flex tier.
2. Verified that the resulting JSON output does not include `num_flex_logs_retention_days` for indexes without the Flex tier.

```
...
  "with-flex-log": {
    "name": "with-flex-log",
    ...
    "num_flex_logs_retention_days": 180
  },
  "without-flex-log": {
    "name": "without-flex-log"
    ...
    // No num_flex_logs_retention_days entry
  }
}
```


### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
