### PR TITLE
Fix help message for migrate command

### DIFF
--- a/datadog_sync/commands/migrate.py
+++ b/datadog_sync/commands/migrate.py
@@ -17,7 +17,7 @@ from datadog_sync.commands.shared.utils import run_cmd
 from datadog_sync.constants import Command
 
 
-@command(Command.MIGRATE.value, short_help="Migrate Datadog resources from one datacenter to another.")
+@command(Command.MIGRATE.value, short_help="Migrate Datadog resources from one Datadog organization to another.")
 @source_auth_options
 @destination_auth_options
 @common_options
@@ -25,5 +25,5 @@ from datadog_sync.constants import Command
 @sync_common_options
 @storage_options
 def migrate(**kwargs):
-    """Migrate Datadog resources from one datacenter to another."""
+    """Migrate Datadog resources from one Datadog organization to another."""
     run_cmd(Command.MIGRATE, **kwargs)


### PR DESCRIPTION
Replaces #329 to resolve CI issues related to forked PRs.

### What does this PR do?
This PR updates the help message for the migrate command to clarify that it applies to migrations between Datadog organizations, not just across datacenters. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
