### PR TITLE
Fix cherry picked from PR337

### DIFF
--- a/datadog_sync/utils/state.py
+++ b/datadog_sync/utils/state.py
@@ -6,8 +6,6 @@ from typing import Any, Dict, List, Tuple
 
 from datadog_sync.constants import (
     Origin,
-    AWS_BUCKET_KEY_PREFIX_DESTINATION,
-    AWS_BUCKET_KEY_PREFIX_SOURCE,
     DESTINATION_PATH_DEFAULT,
     DESTINATION_PATH_PARAM,
     RESOURCE_PER_FILE,
@@ -23,18 +21,15 @@ from datadog_sync.utils.storage.storage_types import StorageType
 class State:
     def __init__(self, type_: StorageType = StorageType.LOCAL_FILE, **kwargs: object) -> None:
         resource_per_file = kwargs.get(RESOURCE_PER_FILE, False)
-
+        source_resources_path = kwargs.get(SOURCE_PATH_PARAM, SOURCE_PATH_DEFAULT)
+        destination_resources_path = kwargs.get(DESTINATION_PATH_PARAM, DESTINATION_PATH_DEFAULT)
         if type_ == StorageType.LOCAL_FILE:
-            source_resources_path = kwargs.get(SOURCE_PATH_PARAM, SOURCE_PATH_DEFAULT)
-            destination_resources_path = kwargs.get(DESTINATION_PATH_PARAM, DESTINATION_PATH_DEFAULT)
             self._storage: BaseStorage = LocalFile(
                 source_resources_path=source_resources_path,
                 destination_resources_path=destination_resources_path,
                 resource_per_file=resource_per_file,
             )
         elif type_ == StorageType.AWS_S3_BUCKET:
-            source_resources_path = kwargs.get(AWS_BUCKET_KEY_PREFIX_SOURCE, SOURCE_PATH_DEFAULT)
-            destination_resources_path = kwargs.get(AWS_BUCKET_KEY_PREFIX_DESTINATION, DESTINATION_PATH_DEFAULT)
             config = kwargs.get("config", {})
             if not config:
                 raise ValueError("AWS configuration not found")


### PR DESCRIPTION

### What does this PR do?

Implements the fix in the following PR: https://github.com/DataDog/datadog-sync-cli/pull/337
The tests aren't running on that PR and trouble shooting the tests is burdensome if we can just pull that change into the main branch all the better.

### Description of the Change

The code was trying to pull the env var from `kwargs`, but it should be pulling this parameter instead. A little confusing because the parameter names are stored in a constant.

