### PR TITLE
Update docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-buster
+FROM python:3.11-slim-bullseye
 
 # Install Dependencies
 RUN apt-get update -y \


### PR DESCRIPTION
### What does this PR do?

Building the docker image fails now because the `buster` base image is no longer supported. https://github.com/DataDog/datadog-sync-cli/actions/runs/16446765947/job/46481174072


### Description of the Change

Updated to `bullseye`

