### PR TITLE
Mitigate flakey tests

### DIFF
--- a/.github/workflows/test_integrations.yml
+++ b/.github/workflows/test_integrations.yml
@@ -60,5 +60,5 @@ jobs:
           DD_TAGS: "team:hamr"
           DD_TRACE_ANALYTICS_ENABLED: "true"
           RECORD: "none"
-          PYTEST_ADDOPTS: "--ddtrace --disable-recording --retries 2"
+          PYTEST_ADDOPTS: "--ddtrace --disable-recording --retries 3 --retry-delay 10"
           


### PR DESCRIPTION
### What does this PR do?

There are some tests that are still flakey. Going to try bumping up the retries and adding a delay between retries. It's odd that there aren't flags for jitter or back-off.