### PR TITLE
Avoid using GITHUB_TOKEN for PR creation/approval

### DIFF
--- a/.github/chainguard/self.prepare-release.create-pr.sts.yaml
+++ b/.github/chainguard/self.prepare-release.create-pr.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/datadog-sync-cli:ref:refs/heads/main
+
+claim_pattern:
+  event_name: workflow_dispatch
+  ref: refs/heads/main
+  ref_protected: "true"
+  job_workflow_ref: DataDog/datadog-sync-cli/.github/workflows/prepare_release.yml@refs/heads/main
+
+permissions:
+  contents: write
+  pull_requests: write 

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,9 +1,5 @@
 name: Prepare release
 
-permissions: 
-  contents: write
-  pull-requests: write
-
 env:
   GIT_AUTHOR_EMAIL: "packages@datadoghq.com"
   GIT_AUTHOR_NAME: "ci.datadog-sync-cli"
@@ -18,7 +14,16 @@ jobs:
   prepare_release:
     name: Create release PR
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
+      - name: Get access token
+        uses: DataDog/dd-octo-sts-action@08f2144903ced3254a3dafec2592563409ba2aa0 # v1.0.1
+        id: octo-sts
+        with:
+          scope: DataDog/datadog-sync-cli
+          policy: self.prepare-release.create-pr
+
       - name: Checkout code
         uses: actions/checkout@v3
         with:
@@ -47,7 +52,7 @@ jobs:
         env:
           RELEASE_VERSION: ${{ steps.get_version.outputs.version }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.octo-sts.outputs.token }}
           script: |
             const { data: notes } = await github.rest.repos.generateReleaseNotes({
               owner: context.repo.owner,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: Release
 
-permissions: 
+permissions:
   contents: write
-  pull-requests: write
 
 on:
   pull_request:


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see [CONTRIBUTING](/CONTRIBUTING.md).

### What does this PR do?

Replace usage of `GITHUB_TOKEN` for creation of PRs by dd-octo-sts to allow us to de-activate the insecure setting to allow the `GITHUB_TOKEN` to create/approve PRs.

### Description of the Change

* added a dd-octo-sts trust policy
* adjusted affected workflows
* removed an unneeded permission

### Alternate Designs

none

### Possible Drawbacks

none

### Verification Process

can only be tested via dispatch on default branch

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bug fix MUST have appropriate tests (unit, integration, etc...)
- [x] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
