### PR TITLE
Add dependabot and run tests daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/test_integrations.yml
+++ b/.github/workflows/test_integrations.yml
@@ -18,8 +18,8 @@ on:
       - synchronize
       - reopened
   schedule:
-    # M-F at 06:17 GMT
-    - cron: '17 6 * * 1-5'
+    # Every day at 06:17 GMT
+    - cron: '17 6 * * *'
 
 env:
   DD_DESTINATION_API_KEY: ${{ secrets.DD_DESTINATION_API_KEY }}


### PR DESCRIPTION


### What does this PR do?

Dependabot should keep actions safely up to date, this was a suggestion from: https://github.com/DataDog/datadog-sync-cli/pull/366

Change the integration test schedule from M-F to daily (this will help stabilize the monitor)


