### PR TITLE
feat: migrate Tier 1 resources to map_existing_resources

### DIFF
--- a/datadog_sync/model/logs_indexes.py
+++ b/datadog_sync/model/logs_indexes.py
@@ -21,10 +21,9 @@ class LogsIndexes(BaseResource):
             "is_rate_limited",
         ],
         non_nullable_attr=["daily_limit"],
-        skip_resource_mapping=True,
+        resource_mapping_key="name",
     )
     # Additional LogsIndexes specific attributes
-    destination_logs_indexes: Dict[str, Dict] = dict()
     logs_indexes_order_url: str = "/api/v1/logs/config/index-order"
 
     async def get_resources(self, client: CustomClient) -> List[Dict]:
@@ -51,11 +50,11 @@ class LogsIndexes(BaseResource):
         pass
 
     async def pre_apply_hook(self) -> None:
-        self.destination_logs_indexes = await self.get_destination_logs_indexes()
+        pass
 
     async def create_resource(self, _id: str, resource: Dict) -> Tuple[str, Dict]:
-        if _id in self.destination_logs_indexes:
-            self.config.state.destination[self.resource_type][_id] = self.destination_logs_indexes[_id]
+        if _id in self._existing_resources_map:
+            self.config.state.destination[self.resource_type][_id] = self._existing_resources_map[_id]
             return await self.update_resource(_id, resource)
 
         destination_client = self.config.destination_client
@@ -92,13 +91,3 @@ class LogsIndexes(BaseResource):
             index_order["index_names"].remove(index_name)
             index_order["index_names"].append(index_name)
             await self.config.destination_client.put(self.logs_indexes_order_url, index_order)
-
-    async def get_destination_logs_indexes(self) -> Dict[str, Dict]:
-        destination_global_variable_obj = {}
-        destination_client = self.config.destination_client
-
-        resp = await self.get_resources(destination_client)
-        for variable in resp:
-            destination_global_variable_obj[variable["name"]] = variable
-
-        return destination_global_variable_obj

--- a/datadog_sync/model/metric_tag_configurations.py
+++ b/datadog_sync/model/metric_tag_configurations.py
@@ -17,10 +17,9 @@ class MetricTagConfigurations(BaseResource):
     resource_config = ResourceConfig(
         base_path="/api/v2/metrics",
         excluded_attributes=["attributes.created_at", "attributes.modified_at"],
-        skip_resource_mapping=True,
+        resource_mapping_key="id",
     )
     # Additional MetricTagConfigurations specific attributes
-    destination_metric_tag_configurations: Dict[str, Dict] = dict()
 
     async def get_resources(self, client: CustomClient) -> List[Dict]:
         resp = await client.get(self.resource_config.base_path, params={"filter[configured]": "true"})
@@ -39,11 +38,11 @@ class MetricTagConfigurations(BaseResource):
         pass
 
     async def pre_apply_hook(self) -> None:
-        self.destination_metric_tag_configurations = await self.get_destination_metric_tag_configuration()
+        pass
 
     async def create_resource(self, _id: str, resource: Dict) -> Tuple[str, Dict]:
-        if _id in self.destination_metric_tag_configurations:
-            self.config.state.destination[self.resource_type][_id] = self.destination_metric_tag_configurations[_id]
+        if _id in self._existing_resources_map:
+            self.config.state.destination[self.resource_type][_id] = self._existing_resources_map[_id]
             return await self.update_resource(_id, resource)
 
         destination_client = self.config.destination_client
@@ -72,13 +71,3 @@ class MetricTagConfigurations(BaseResource):
         await destination_client.delete(
             self.resource_config.base_path + f"/{self.config.state.destination[self.resource_type][_id]['id']}/tags"
         )
-
-    async def get_destination_metric_tag_configuration(self) -> Dict[str, Dict]:
-        destination_metric_tag_configurations = {}
-        destination_client = self.config.destination_client
-
-        resp = await self.get_resources(destination_client)
-        for metric_tag_config in resp:
-            destination_metric_tag_configurations[metric_tag_config["id"]] = metric_tag_config
-
-        return destination_metric_tag_configurations

--- a/datadog_sync/model/synthetics_global_variables.py
+++ b/datadog_sync/model/synthetics_global_variables.py
@@ -33,10 +33,9 @@ class SyntheticsGlobalVariables(BaseResource):
             "editor",
         ],
         tagging_config=TaggingConfig(path="tags"),
-        skip_resource_mapping=True,
+        resource_mapping_key="name",
     )
     # Additional SyntheticsGlobalVariables specific attributes
-    destination_global_variables: Dict[str, Dict] = dict()
 
     async def get_resources(self, client: CustomClient) -> List[Dict]:
         resp = await client.get(self.resource_config.base_path)
@@ -54,7 +53,7 @@ class SyntheticsGlobalVariables(BaseResource):
         pass
 
     async def pre_apply_hook(self) -> None:
-        self.destination_global_variables = await self.get_destination_global_variables()
+        pass
 
     async def _inject_secret_value(self, _id: str, resource: Dict) -> None:
         """Fetch the clear (unobfuscated) secret value from the source and inject it
@@ -62,9 +61,7 @@ class SyntheticsGlobalVariables(BaseResource):
         to state files."""
         if "value" not in resource.get("value", {}):
             try:
-                clear = await self.config.source_client.get(
-                    self.resource_config.base_path + f"/{_id}/clear"
-                )
+                clear = await self.config.source_client.get(self.resource_config.base_path + f"/{_id}/clear")
                 resource.setdefault("value", {})["value"] = clear["value"]["value"]
             except (CustomClientHTTPError, KeyError):
                 self.config.logger.warning(f"Failed to inject secret value for global variable {_id}")
@@ -77,8 +74,9 @@ class SyntheticsGlobalVariables(BaseResource):
             resp["value"].pop("value", None)
 
     async def create_resource(self, _id: str, resource: Dict) -> Tuple[str, Dict]:
-        if resource["name"] in self.destination_global_variables:
-            self.config.state.destination[self.resource_type][_id] = self.destination_global_variables[resource["name"]]
+        key = self.get_resource_mapping_key(resource)
+        if key and key in self._existing_resources_map:
+            self.config.state.destination[self.resource_type][_id] = self._existing_resources_map[key]
             return await self.update_resource(_id, resource)
 
         destination_client = self.config.destination_client
@@ -127,13 +125,3 @@ class SyntheticsGlobalVariables(BaseResource):
         if not found:
             failed_connections.append(r_obj[key])
         return failed_connections
-
-    async def get_destination_global_variables(self) -> Dict[str, Dict]:
-        destination_global_variable_obj = {}
-        destination_client = self.config.destination_client
-
-        resp = await self.get_resources(destination_client)
-        for variable in resp:
-            destination_global_variable_obj[variable["name"]] = variable
-
-        return destination_global_variable_obj

--- a/datadog_sync/model/teams.py
+++ b/datadog_sync/model/teams.py
@@ -31,11 +31,10 @@ class Teams(BaseResource):
             "attributes.hidden_modules",
             "attributes.summary",
         ],
-        skip_resource_mapping=True,
+        resource_mapping_key=lambda r: f"{r['attributes']['name']}:{r['attributes']['handle']}",
     )
     # Additional Teams specific attributes
     pagination_config = PaginationConfig(remaining_func=lambda *args: 1)
-    destination_teams: Dict[str, Dict] = {}
 
     async def get_resources(self, client: CustomClient) -> List[Dict]:
         resp = await client.paginated_request(client.get)(
@@ -56,18 +55,14 @@ class Teams(BaseResource):
         pass
 
     async def pre_apply_hook(self) -> None:
-        client = self.config.destination_client
-        resp = await self.get_resources(client)
-        self.destination_teams = {}
-        for r in resp:
-            self.destination_teams[f"{r['attributes']['name']}:{r['attributes']['handle']}"] = r
+        pass
 
     async def create_resource(self, _id: str, resource: Dict) -> Tuple[str, Dict]:
         destination_client = self.config.destination_client
 
-        k = f"{resource['attributes']['name']}:{resource['attributes']['handle']}"
-        if k in self.destination_teams:
-            self.config.state.destination[self.resource_type][_id] = self.destination_teams[k]
+        key = self.get_resource_mapping_key(resource)
+        if key and key in self._existing_resources_map:
+            self.config.state.destination[self.resource_type][_id] = self._existing_resources_map[key]
             return await self.update_resource(_id, resource)
 
         payload = {"data": resource}

--- a/datadog_sync/model/users.py
+++ b/datadog_sync/model/users.py
@@ -40,14 +40,13 @@ class Users(BaseResource):
             "relationships.org",
             "relationships.team_roles",
         ],
-        skip_resource_mapping=True,
+        resource_mapping_key="attributes.email",
     )
     # Additional Users specific attributes
     pagination_config = PaginationConfig(
         page_size=500,
     )
     roles_path: str = "/api/v2/roles/{}/users"
-    remote_destination_users: Dict[str, Dict] = dict()
 
     async def get_resources(self, client: CustomClient) -> List[Dict]:
         resp = await client.paginated_request(client.get)(
@@ -73,14 +72,12 @@ class Users(BaseResource):
         pass
 
     async def pre_apply_hook(self) -> None:
-        self.remote_destination_users = await self.get_remote_destination_users()
+        pass
 
     async def create_resource(self, _id: str, resource: Dict) -> Tuple[str, Dict]:
-        if resource["attributes"]["email"] in self.remote_destination_users:
-            self.config.state.destination[self.resource_type][_id] = self.remote_destination_users[
-                resource["attributes"]["email"]
-            ]
-
+        key = self.get_resource_mapping_key(resource)
+        if key and key in self._existing_resources_map:
+            self.config.state.destination[self.resource_type][_id] = self._existing_resources_map[key]
             return await self.update_resource(_id, resource)
 
         destination_client = self.config.destination_client
@@ -113,16 +110,6 @@ class Users(BaseResource):
 
     def connect_id(self, key: str, r_obj: Dict, resource_to_connect: str) -> Optional[List[str]]:
         return super(Users, self).connect_id(key, r_obj, resource_to_connect)
-
-    async def get_remote_destination_users(self):
-        remote_user_obj = {}
-        destination_client = self.config.destination_client
-        remote_users = await self.get_resources(destination_client)
-
-        for user in remote_users:
-            remote_user_obj[user["attributes"]["email"]] = user
-
-        return remote_user_obj
 
     async def update_user_roles(self, _id, diff):
         for k, v in diff.items():

--- a/tests/unit/test_map_existing_resources.py
+++ b/tests/unit/test_map_existing_resources.py
@@ -23,7 +23,7 @@ from datadog_sync.utils.base_resource import BaseResource, ResourceConfig
 # Helpers
 # ---------------------------------------------------------------------------
 
-# The 32 resources that must opt out of resource mapping
+# Resources that opt out of resource mapping (still have skip_resource_mapping=True)
 OPT_OUT_RESOURCES = [
     "authn_mappings",
     "dashboard_lists",
@@ -45,7 +45,9 @@ OPT_OUT_RESOURCES = [
     "notebooks",
     "powerpacks",
     "restriction_policies",
+    "roles",
     "rum_applications",
+    "security_monitoring_rules",
     "sensitive_data_scanner_groups",
     "sensitive_data_scanner_groups_order",
     "sensitive_data_scanner_rules",
@@ -57,6 +59,16 @@ OPT_OUT_RESOURCES = [
     "synthetics_private_locations",
     "synthetics_test_suites",
     "synthetics_tests",
+    "team_memberships",
+]
+
+# The 5 Tier 1 resources that use resource mapping
+MAPPING_RESOURCES = [
+    "users",
+    "teams",
+    "synthetics_global_variables",
+    "logs_indexes",
+    "metric_tag_configurations",
 ]
 
 
@@ -362,7 +374,7 @@ class TestMapExistingResourcesCb:
 
 
 class TestOptOutResources:
-    """Verify all 32 non-mapping resources have skip_resource_mapping=True."""
+    """Verify non-mapping resources have skip_resource_mapping=True."""
 
     @pytest.mark.parametrize("resource_type", OPT_OUT_RESOURCES)
     def test_opt_out_resource_has_skip_flag(self, config, resource_type):
@@ -371,3 +383,23 @@ class TestOptOutResources:
         assert (
             resource.resource_config.skip_resource_mapping is True
         ), f"{resource_type} should have skip_resource_mapping=True"
+
+
+class TestMappingResources:
+    """Verify mapping resources have resource_mapping_key set."""
+
+    @pytest.mark.parametrize("resource_type", MAPPING_RESOURCES)
+    def test_mapping_resource_has_key(self, config, resource_type):
+        """Each mapping resource must have resource_mapping_key configured."""
+        resource = config.resources[resource_type]
+        assert (
+            resource.resource_config.resource_mapping_key is not None
+        ), f"{resource_type} should have resource_mapping_key set"
+
+    @pytest.mark.parametrize("resource_type", MAPPING_RESOURCES)
+    def test_mapping_resource_has_skip_false(self, config, resource_type):
+        """Each mapping resource must have skip_resource_mapping=False."""
+        resource = config.resources[resource_type]
+        assert (
+            resource.resource_config.skip_resource_mapping is False
+        ), f"{resource_type} should have skip_resource_mapping=False"


### PR DESCRIPTION
## Summary
- Migrate 5 Tier 1 resources to use the standardized `map_existing_resources` pattern
- Each resource defines `resource_mapping_key` in `ResourceConfig` and uses `_existing_resources_map` in `create_resource()`
- Removed old destination dicts, fetch helper methods, and `pre_apply_hook` bodies

### Migrated resources
| Resource | Key | Notes |
|---|---|---|
| `users` | `attributes.email` | Removed `remote_destination_users`, `get_remote_destination_users()` |
| `teams` | `name:handle` (callable) | Removed `destination_teams` |
| `synthetics_global_variables` | `name` | Removed `destination_global_variables`, `get_destination_global_variables()` |
| `logs_indexes` | `name` | Removed `destination_logs_indexes`, `get_destination_logs_indexes()` |
| `metric_tag_configurations` | `id` | Removed `destination_metric_tag_configurations`, `get_destination_metric_tag_configuration()` |

## Stack
- PR 1: Infrastructure + opt-out flags
- **PR 2 (this)**: Tier 1 resources migration
- PR 3: Tier 2 resources migration

## Test plan
- [x] 62 tests pass (previously RED mapping tests for these 5 now GREEN)
- [x] 226 existing unit tests pass with zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)