### PR TITLE
feat: migrate Tier 2 resources to map_existing_resources

### DIFF
--- a/datadog_sync/model/roles.py
+++ b/datadog_sync/model/roles.py
@@ -29,12 +29,11 @@ class Roles(BaseResource):
             "attributes.user_count",
             "id",
         ],
-        skip_resource_mapping=True,
+        resource_mapping_key="attributes.name",
     )
     # Additional Roles specific attributes
     source_permissions: Dict = {}
     destination_permissions: Dict = {}
-    destination_roles_mapping: Optional[Dict] = None
     permissions_base_path: str = "/api/v2/permissions"
 
     async def get_resources(self, client: CustomClient) -> List[Dict]:
@@ -70,11 +69,13 @@ class Roles(BaseResource):
 
         return resource["id"], resource
 
+    async def map_existing_resources(self) -> None:
+        self._existing_resources_map = await self.get_destination_roles_mapping()
+
     async def pre_apply_hook(self) -> None:
-        self.destination_roles_mapping = await self.get_destination_roles_mapping()
+        pass
 
     async def pre_resource_action_hook(self, _id, resource: Dict) -> None:
-        self.destination_roles_mapping = await self.get_destination_roles_mapping()
         await self.remap_permissions(resource)
 
     async def create_resource(self, _id, resource) -> Tuple[str, Dict]:
@@ -85,7 +86,7 @@ class Roles(BaseResource):
         resource["attributes"].pop("managed", None)
 
         # role does not exist at the destination, so create it
-        if role_name not in self.destination_roles_mapping:
+        if role_name not in self._existing_resources_map:
             destination_client = self.config.destination_client
 
             # Retry loop to handle multiple invalid permissions
@@ -111,8 +112,8 @@ class Roles(BaseResource):
 
                                 # Check if the modified resource now matches an existing destination role
                                 # This can happen if we already synced the role without this permission before
-                                if role_name in self.destination_roles_mapping:
-                                    matching_destination_role = self.destination_roles_mapping[role_name]
+                                if role_name in self._existing_resources_map:
+                                    matching_destination_role = self._existing_resources_map[role_name]
                                     role_copy = copy.deepcopy(resource)
                                     role_copy.update(matching_destination_role)
 
@@ -135,7 +136,7 @@ class Roles(BaseResource):
             raise Exception(f"Exceeded maximum retries ({max_retries}) while creating role '{role_name}'")
 
         # role already exists at the destination
-        matching_destination_role = self.destination_roles_mapping[role_name]
+        matching_destination_role = self._existing_resources_map[role_name]
         role_copy = copy.deepcopy(resource)
         role_copy.update(matching_destination_role)
 

--- a/datadog_sync/model/security_monitoring_rules.py
+++ b/datadog_sync/model/security_monitoring_rules.py
@@ -52,7 +52,7 @@ class SecurityMonitoringRules(BaseResource):
             "creator": [{"handle": "", "name": ""}],
             "updater": [{"handle": "", "name": ""}],
         },
-        skip_resource_mapping=True,
+        resource_mapping_key="name",
     )
     # maximum page_size for this endpoint is 100 according to public api doc
     pagination_config = PaginationConfig(
@@ -61,7 +61,6 @@ class SecurityMonitoringRules(BaseResource):
         page_size_param="page[size]",
         remaining_func=lambda *args: 1,
     )
-    destination_rules = {}
     # can't even enable or disable immutable rules
     immutable_rule_names = [
         "Impossible travel event leads to permission enumeration",
@@ -71,7 +70,6 @@ class SecurityMonitoringRules(BaseResource):
     ]
 
     async def get_resources(self, client: CustomClient) -> List[Dict]:
-        self.destination_rules = await self.get_destination_rules()
         resp = await client.paginated_request(client.get)(
             self.resource_config.base_path, pagination_config=self.pagination_config
         )
@@ -88,7 +86,7 @@ class SecurityMonitoringRules(BaseResource):
         return resource["id"], resource
 
     async def pre_resource_action_hook(self, _id, resource: Dict) -> None:
-        matching_destination_rule = self.destination_rules.get(resource["name"], None)
+        matching_destination_rule = self._existing_resources_map.get(resource["name"], None)
         if resource.get("isDefault", False) and not matching_destination_rule:
             raise SkipResource(_id, self.resource_type, "Default rule does not exist at destination")
         if resource["name"] in self.immutable_rule_names:
@@ -96,15 +94,18 @@ class SecurityMonitoringRules(BaseResource):
         if matching_destination_rule and matching_destination_rule.get("isDeprecated", False):
             raise SkipResource(_id, self.resource_type, "Cannot update deprecated rules")
 
+    async def map_existing_resources(self) -> None:
+        self._existing_resources_map = await self.get_destination_rules()
+
     async def pre_apply_hook(self) -> None:
-        self.destination_rules = await self.get_destination_rules()
+        pass
 
     async def create_resource(self, _id: str, resource: Dict) -> Tuple[str, Dict]:
         # this method uses rule name for matching default rules
         rule_name = resource["name"]
 
         # rule does not exist at the destination, so create it
-        if rule_name not in self.destination_rules and not resource["isDefault"]:
+        if rule_name not in self._existing_resources_map and not resource["isDefault"]:
             destination_client = self.config.destination_client
             self.handle_special_case_attr(resource)
             try:
@@ -122,7 +123,7 @@ class SecurityMonitoringRules(BaseResource):
                 raise err
 
         # Skip any default rules that do no exist at the destination
-        matching_destination_rule = self.destination_rules.get(rule_name, None)
+        matching_destination_rule = self._existing_resources_map.get(rule_name, None)
         if not matching_destination_rule:
             raise SkipResource(_id, self.resource_type, "Default rule does not exist at destination")
 
@@ -138,7 +139,7 @@ class SecurityMonitoringRules(BaseResource):
 
     async def update_resource(self, _id: str, resource: Dict) -> Tuple[str, Dict]:
         # Skip any default rules that do no exist at the destination
-        matching_destination_rule = self.destination_rules.get(resource["name"], None)
+        matching_destination_rule = self._existing_resources_map.get(resource["name"], None)
         if not matching_destination_rule:
             raise SkipResource(_id, self.resource_type, "Default rule does not exist at destination")
 

--- a/datadog_sync/model/team_memberships.py
+++ b/datadog_sync/model/team_memberships.py
@@ -15,6 +15,10 @@ if TYPE_CHECKING:
     from datadog_sync.utils.custom_client import CustomClient
 
 
+def _team_membership_key(r):
+    return f"{r['relationships']['team']['data']['id']}:{r['relationships']['user']['data']['id']}"
+
+
 class TeamMemberships(BaseResource):
     resource_type = "team_memberships"
     resource_config = ResourceConfig(
@@ -28,10 +32,9 @@ class TeamMemberships(BaseResource):
             "attributes.provisioned_by",
             "attributes.provisioned_by_id",
         ],
-        skip_resource_mapping=True,
+        resource_mapping_key=_team_membership_key,
     )
     team_memberships_path = "/api/v2/team/{}/memberships"
-    destination_team_memberships: List[Dict] = []
     # Additional TeamMemberships specific attributes
 
     async def get_resources(self, client: CustomClient) -> List[Dict]:
@@ -105,16 +108,24 @@ class TeamMemberships(BaseResource):
     async def pre_resource_action_hook(self, _id, resource: Dict) -> None:
         pass
 
+    async def map_existing_resources(self) -> None:
+        dest_memberships = await self.get_resources(self.config.destination_client)
+        self._existing_resources_map = {}
+        for membership in dest_memberships:
+            key = self.get_resource_mapping_key(membership)
+            if key is not None:
+                self._existing_resources_map[key] = membership
+
     async def pre_apply_hook(self) -> None:
-        destination_client = self.config.destination_client
-        self.destination_team_memberships = await self.get_resources(destination_client)
+        pass
 
     async def create_resource(self, _id: str, resource: Dict) -> Tuple[str, Dict]:
         destination_client = self.config.destination_client
         resource_team_id = resource["relationships"]["team"]["data"]["id"]
         destination_resource = copy.deepcopy(resource)
 
-        existing = self._get_existing_team_membership(destination_resource)
+        key = self.get_resource_mapping_key(destination_resource)
+        existing = self._existing_resources_map.get(key, {}) if key else {}
         if existing:
             raise SkipResource(_id, self.resource_type, "User is already a member of the team")
 
@@ -128,7 +139,8 @@ class TeamMemberships(BaseResource):
     async def update_resource(self, _id: str, resource: Dict) -> Tuple[str, Dict]:
         destination_client = self.config.destination_client
         state = self.config.state.destination[self.resource_type].get(_id, None)
-        existing = self._get_existing_team_membership(state)
+        key = self.get_resource_mapping_key(state) if state else None
+        existing = self._existing_resources_map.get(key, {}) if key else {}
 
         # membership doesn't exist, create it instead of updating
         if not existing:
@@ -194,17 +206,3 @@ class TeamMemberships(BaseResource):
             else:
                 failed_connections.append(_id)
         return failed_connections
-
-    def _get_existing_team_membership(self, state):
-        existing = {}
-        if state:
-            state_team_id = state["relationships"]["team"]["data"]["id"]
-            state_user_id = state["relationships"]["user"]["data"]["id"]
-            for destination_team_membership in self.destination_team_memberships:
-                if (
-                    destination_team_membership["relationships"]["team"]["data"]["id"] == state_team_id
-                    and destination_team_membership["relationships"]["user"]["data"]["id"] == state_user_id
-                ):
-                    existing = destination_team_membership
-                    break
-        return existing

--- a/tests/unit/test_map_existing_resources.py
+++ b/tests/unit/test_map_existing_resources.py
@@ -45,9 +45,7 @@ OPT_OUT_RESOURCES = [
     "notebooks",
     "powerpacks",
     "restriction_policies",
-    "roles",
     "rum_applications",
-    "security_monitoring_rules",
     "sensitive_data_scanner_groups",
     "sensitive_data_scanner_groups_order",
     "sensitive_data_scanner_rules",
@@ -59,16 +57,18 @@ OPT_OUT_RESOURCES = [
     "synthetics_private_locations",
     "synthetics_test_suites",
     "synthetics_tests",
-    "team_memberships",
 ]
 
-# The 5 Tier 1 resources that use resource mapping
+# The 8 resources that use resource mapping
 MAPPING_RESOURCES = [
     "users",
     "teams",
     "synthetics_global_variables",
     "logs_indexes",
     "metric_tag_configurations",
+    "roles",
+    "security_monitoring_rules",
+    "team_memberships",
 ]
 
 


### PR DESCRIPTION
## Summary
- Migrate 3 complex Tier 2 resources that override `map_existing_resources()` with custom logic
- All resources now use `_existing_resources_map` as the standardized dict name

### Migrated resources
| Resource | Key | Override reason |
|---|---|---|
| `roles` | `attributes.name` | Custom fetch via `get_destination_roles_mapping()`; removed N+1 re-fetch from `pre_resource_action_hook` |
| `security_monitoring_rules` | `name` | Custom fetch via `get_destination_rules()`; removed side-effect dest fetch from `get_resources()` |
| `team_memberships` | `team_id:user_id` (callable) | Custom multi-step fetch; O(1) dict lookup replaces O(n) list scan |

### Notable improvements
- **roles**: Eliminated per-resource API re-fetch in `pre_resource_action_hook` (was O(n) calls where n = number of roles)
- **team_memberships**: Composite key dict lookup replaces `_get_existing_team_membership()` linear scan

## Stack
- PR 1: Infrastructure + opt-out flags
- PR 2: Tier 1 resources migration
- **PR 3 (this)**: Tier 2 resources migration

## Test plan
- [x] All 68 new tests pass (zero RED remaining)
- [x] 226 existing unit tests pass with zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)