### PR TITLE
fix: skip metric SLOs missing .as_count() modifier at sync time [DRALLSTSBX-52]

### DIFF
--- a/datadog_sync/model/service_level_objectives.py
+++ b/datadog_sync/model/service_level_objectives.py
@@ -28,14 +28,10 @@ class ServiceLevelObjectives(BaseResource):
 
         return resp["data"]
 
-    async def import_resource(
-        self, _id: Optional[str] = None, resource: Optional[Dict] = None
-    ) -> Tuple[str, Dict]:
+    async def import_resource(self, _id: Optional[str] = None, resource: Optional[Dict] = None) -> Tuple[str, Dict]:
         if _id:
             source_client = self.config.source_client
-            resource = (
-                await source_client.get(self.resource_config.base_path + f"/{_id}")
-            )["data"]
+            resource = (await source_client.get(self.resource_config.base_path + f"/{_id}"))["data"]
         resource = cast(dict, resource)
         return resource["id"], resource
 
@@ -50,8 +46,8 @@ class ServiceLevelObjectives(BaseResource):
                     raise SkipResource(
                         _id,
                         self.resource_type,
-                        f"Deprecated resource configuration: Metric SLO query '{field}' is missing the .as_count() modifier. "
-                        "Update the source SLO query before syncing.",
+                        f"Deprecated resource configuration: Metric SLO query '{field}' "
+                        "is missing the .as_count() modifier. Update the source SLO query before syncing.",
                     )
 
     async def pre_apply_hook(self) -> None:
@@ -66,8 +62,7 @@ class ServiceLevelObjectives(BaseResource):
     async def update_resource(self, _id: str, resource: Dict) -> Tuple[str, Dict]:
         destination_client = self.config.destination_client
         resp = await destination_client.put(
-            self.resource_config.base_path
-            + f"/{self.config.state.destination[self.resource_type][_id]['id']}",
+            self.resource_config.base_path + f"/{self.config.state.destination[self.resource_type][_id]['id']}",
             resource,
         )
 
@@ -76,14 +71,11 @@ class ServiceLevelObjectives(BaseResource):
     async def delete_resource(self, _id: str) -> None:
         destination_client = self.config.destination_client
         await destination_client.delete(
-            self.resource_config.base_path
-            + f"/{self.config.state.destination[self.resource_type][_id]['id']}",
+            self.resource_config.base_path + f"/{self.config.state.destination[self.resource_type][_id]['id']}",
             params={"force": "true"},
         )
 
-    def connect_id(
-        self, key: str, r_obj: Dict, resource_to_connect: str
-    ) -> Optional[List[str]]:
+    def connect_id(self, key: str, r_obj: Dict, resource_to_connect: str) -> Optional[List[str]]:
         monitors = self.config.state.destination["monitors"]
         synthetics_tests = self.config.state.destination["synthetics_tests"]
 

--- a/datadog_sync/model/service_level_objectives.py
+++ b/datadog_sync/model/service_level_objectives.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, List, Dict, Tuple, cast
 
 from datadog_sync.utils.base_resource import BaseResource, ResourceConfig, TaggingConfig
+from datadog_sync.utils.resource_utils import SkipResource
 
 if TYPE_CHECKING:
     from datadog_sync.utils.custom_client import CustomClient
@@ -35,7 +36,17 @@ class ServiceLevelObjectives(BaseResource):
         return resource["id"], resource
 
     async def pre_resource_action_hook(self, _id, resource: Dict) -> None:
-        pass
+        if resource.get("type") == "metric":
+            for q in resource.get("queries", []):
+                for field in ("numerator", "denominator"):
+                    query_str = q.get(field, "")
+                    if query_str and ".as_count()" not in query_str:
+                        raise SkipResource(
+                            _id,
+                            self.resource_type,
+                            f"Metric SLO query '{field}' is missing the .as_count() modifier. "
+                            "Update the source SLO query before syncing.",
+                        )
 
     async def pre_apply_hook(self) -> None:
         pass

--- a/datadog_sync/model/service_level_objectives.py
+++ b/datadog_sync/model/service_level_objectives.py
@@ -46,7 +46,7 @@ class ServiceLevelObjectives(BaseResource):
                     raise SkipResource(
                         _id,
                         self.resource_type,
-                        f"Metric SLO query '{field}' is missing the .as_count() modifier. "
+                        f"Deprecated resource configuration: Metric SLO query '{field}' is missing the .as_count() modifier. "
                         "Update the source SLO query before syncing.",
                     )
 

--- a/datadog_sync/model/service_level_objectives.py
+++ b/datadog_sync/model/service_level_objectives.py
@@ -28,10 +28,14 @@ class ServiceLevelObjectives(BaseResource):
 
         return resp["data"]
 
-    async def import_resource(self, _id: Optional[str] = None, resource: Optional[Dict] = None) -> Tuple[str, Dict]:
+    async def import_resource(
+        self, _id: Optional[str] = None, resource: Optional[Dict] = None
+    ) -> Tuple[str, Dict]:
         if _id:
             source_client = self.config.source_client
-            resource = (await source_client.get(self.resource_config.base_path + f"/{_id}"))["data"]
+            resource = (
+                await source_client.get(self.resource_config.base_path + f"/{_id}")
+            )["data"]
         resource = cast(dict, resource)
         return resource["id"], resource
 
@@ -62,7 +66,8 @@ class ServiceLevelObjectives(BaseResource):
     async def update_resource(self, _id: str, resource: Dict) -> Tuple[str, Dict]:
         destination_client = self.config.destination_client
         resp = await destination_client.put(
-            self.resource_config.base_path + f"/{self.config.state.destination[self.resource_type][_id]['id']}",
+            self.resource_config.base_path
+            + f"/{self.config.state.destination[self.resource_type][_id]['id']}",
             resource,
         )
 
@@ -71,11 +76,14 @@ class ServiceLevelObjectives(BaseResource):
     async def delete_resource(self, _id: str) -> None:
         destination_client = self.config.destination_client
         await destination_client.delete(
-            self.resource_config.base_path + f"/{self.config.state.destination[self.resource_type][_id]['id']}",
+            self.resource_config.base_path
+            + f"/{self.config.state.destination[self.resource_type][_id]['id']}",
             params={"force": "true"},
         )
 
-    def connect_id(self, key: str, r_obj: Dict, resource_to_connect: str) -> Optional[List[str]]:
+    def connect_id(
+        self, key: str, r_obj: Dict, resource_to_connect: str
+    ) -> Optional[List[str]]:
         monitors = self.config.state.destination["monitors"]
         synthetics_tests = self.config.state.destination["synthetics_tests"]
 

--- a/datadog_sync/model/service_level_objectives.py
+++ b/datadog_sync/model/service_level_objectives.py
@@ -37,16 +37,18 @@ class ServiceLevelObjectives(BaseResource):
 
     async def pre_resource_action_hook(self, _id, resource: Dict) -> None:
         if resource.get("type") == "metric":
-            for q in resource.get("queries", []):
-                for field in ("numerator", "denominator"):
-                    query_str = q.get(field, "")
-                    if query_str and ".as_count()" not in query_str:
-                        raise SkipResource(
-                            _id,
-                            self.resource_type,
-                            f"Metric SLO query '{field}' is missing the .as_count() modifier. "
-                            "Update the source SLO query before syncing.",
-                        )
+            query = resource.get("query")
+            if not isinstance(query, dict):
+                return
+            for field in ("numerator", "denominator"):
+                query_str = query.get(field, "")
+                if query_str and ".as_count()" not in query_str:
+                    raise SkipResource(
+                        _id,
+                        self.resource_type,
+                        f"Metric SLO query '{field}' is missing the .as_count() modifier. "
+                        "Update the source SLO query before syncing.",
+                    )
 
     async def pre_apply_hook(self) -> None:
         pass

--- a/tests/unit/test_service_level_objectives.py
+++ b/tests/unit/test_service_level_objectives.py
@@ -1,0 +1,123 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+"""
+Unit tests for service_level_objectives resource handling.
+
+These tests verify that metric-based SLOs with queries missing the .as_count()
+modifier are skipped at sync time rather than failing with a 400.
+"""
+
+import asyncio
+import pytest
+from unittest.mock import MagicMock
+
+from datadog_sync.model.service_level_objectives import ServiceLevelObjectives
+from datadog_sync.utils.resource_utils import SkipResource
+
+
+class TestSLOPreResourceActionHook:
+    """Test suite for SLO pre_resource_action_hook validation."""
+
+    def _make_slos(self):
+        mock_config = MagicMock()
+        mock_config.state = MagicMock()
+        return ServiceLevelObjectives(mock_config)
+
+    def test_metric_slo_missing_as_count_in_numerator_raises_skip(self):
+        """Metric SLO with numerator missing .as_count() should be skipped."""
+        slos = self._make_slos()
+        resource = {
+            "id": "9d6ac152e1ce5fbf861798ebcac1ac47",
+            "type": "metric",
+            "queries": [{"numerator": "sum:custom.metric{*}", "denominator": "sum:custom.total{*}.as_count()"}],
+        }
+        with pytest.raises(SkipResource):
+            asyncio.run(slos.pre_resource_action_hook("9d6ac152e1ce5fbf861798ebcac1ac47", resource))
+
+    def test_metric_slo_missing_as_count_in_denominator_raises_skip(self):
+        """Metric SLO with denominator missing .as_count() should be skipped."""
+        slos = self._make_slos()
+        resource = {
+            "id": "abc123",
+            "type": "metric",
+            "queries": [{"numerator": "sum:custom.metric{*}.as_count()", "denominator": "sum:custom.total{*}"}],
+        }
+        with pytest.raises(SkipResource):
+            asyncio.run(slos.pre_resource_action_hook("abc123", resource))
+
+    def test_metric_slo_valid_queries_does_not_skip(self):
+        """Metric SLO with both numerator and denominator using .as_count() should NOT be skipped."""
+        slos = self._make_slos()
+        resource = {
+            "id": "valid123",
+            "type": "metric",
+            "queries": [
+                {
+                    "numerator": "sum:custom.metric{*}.as_count()",
+                    "denominator": "sum:custom.total{*}.as_count()",
+                }
+            ],
+        }
+        # Should not raise
+        asyncio.run(slos.pre_resource_action_hook("valid123", resource))
+
+    def test_monitor_slo_not_affected(self):
+        """Monitor-based SLO should not be checked for .as_count()."""
+        slos = self._make_slos()
+        resource = {
+            "id": "monitor456",
+            "type": "monitor",
+            "monitor_ids": [12345],
+        }
+        # Should not raise
+        asyncio.run(slos.pre_resource_action_hook("monitor456", resource))
+
+    def test_metric_slo_empty_query_string_does_not_skip(self):
+        """Empty query string should not trigger a skip (guard against false positives)."""
+        slos = self._make_slos()
+        resource = {
+            "id": "empty789",
+            "type": "metric",
+            "queries": [{"numerator": "", "denominator": ""}],
+        }
+        # Empty strings are falsy — no skip triggered
+        asyncio.run(slos.pre_resource_action_hook("empty789", resource))
+
+    def test_metric_slo_no_queries_does_not_skip(self):
+        """Metric SLO with no queries list should not crash."""
+        slos = self._make_slos()
+        resource = {
+            "id": "noqueries",
+            "type": "metric",
+        }
+        # Should not raise
+        asyncio.run(slos.pre_resource_action_hook("noqueries", resource))
+
+    def test_metric_slo_multiple_queries_any_missing_raises_skip(self):
+        """If any query in the list is missing .as_count(), the SLO should be skipped."""
+        slos = self._make_slos()
+        resource = {
+            "id": "multi123",
+            "type": "metric",
+            "queries": [
+                {"numerator": "sum:ok.metric{*}.as_count()", "denominator": "sum:ok.total{*}.as_count()"},
+                {"numerator": "sum:bad.metric{*}", "denominator": "sum:bad.total{*}.as_count()"},
+            ],
+        }
+        with pytest.raises(SkipResource):
+            asyncio.run(slos.pre_resource_action_hook("multi123", resource))
+
+    def test_skip_message_mentions_field(self):
+        """SkipResource message should identify which field is missing the modifier."""
+        slos = self._make_slos()
+        resource = {
+            "id": "msgtest",
+            "type": "metric",
+            "queries": [{"numerator": "sum:bad.metric{*}", "denominator": "sum:ok.total{*}.as_count()"}],
+        }
+        with pytest.raises(SkipResource) as exc_info:
+            asyncio.run(slos.pre_resource_action_hook("msgtest", resource))
+        assert "numerator" in str(exc_info.value)

--- a/tests/unit/test_service_level_objectives.py
+++ b/tests/unit/test_service_level_objectives.py
@@ -8,6 +8,10 @@ Unit tests for service_level_objectives resource handling.
 
 These tests verify that metric-based SLOs with queries missing the .as_count()
 modifier are skipped at sync time rather than failing with a 400.
+
+Note: The Datadog SLO API uses "query" (singular dict with "numerator"/"denominator")
+for metric-based SLOs, NOT "queries" (list). This matches the cassette data at
+tests/integration/resources/cassettes/test_service_level_objectives/.
 """
 
 import asyncio
@@ -32,7 +36,7 @@ class TestSLOPreResourceActionHook:
         resource = {
             "id": "9d6ac152e1ce5fbf861798ebcac1ac47",
             "type": "metric",
-            "queries": [{"numerator": "sum:custom.metric{*}", "denominator": "sum:custom.total{*}.as_count()"}],
+            "query": {"numerator": "sum:custom.metric{*}", "denominator": "sum:custom.total{*}.as_count()"},
         }
         with pytest.raises(SkipResource):
             asyncio.run(slos.pre_resource_action_hook("9d6ac152e1ce5fbf861798ebcac1ac47", resource))
@@ -43,7 +47,7 @@ class TestSLOPreResourceActionHook:
         resource = {
             "id": "abc123",
             "type": "metric",
-            "queries": [{"numerator": "sum:custom.metric{*}.as_count()", "denominator": "sum:custom.total{*}"}],
+            "query": {"numerator": "sum:custom.metric{*}.as_count()", "denominator": "sum:custom.total{*}"},
         }
         with pytest.raises(SkipResource):
             asyncio.run(slos.pre_resource_action_hook("abc123", resource))
@@ -54,12 +58,10 @@ class TestSLOPreResourceActionHook:
         resource = {
             "id": "valid123",
             "type": "metric",
-            "queries": [
-                {
-                    "numerator": "sum:custom.metric{*}.as_count()",
-                    "denominator": "sum:custom.total{*}.as_count()",
-                }
-            ],
+            "query": {
+                "numerator": "sum:custom.metric{*}.as_count()",
+                "denominator": "sum:custom.total{*}.as_count()",
+            },
         }
         # Should not raise
         asyncio.run(slos.pre_resource_action_hook("valid123", resource))
@@ -75,19 +77,30 @@ class TestSLOPreResourceActionHook:
         # Should not raise
         asyncio.run(slos.pre_resource_action_hook("monitor456", resource))
 
+    def test_time_slice_slo_not_affected(self):
+        """Time-slice SLO should not be checked for .as_count()."""
+        slos = self._make_slos()
+        resource = {
+            "id": "timeslice789",
+            "type": "time_slice",
+            "sli_specification": {},
+        }
+        # Should not raise
+        asyncio.run(slos.pre_resource_action_hook("timeslice789", resource))
+
     def test_metric_slo_empty_query_string_does_not_skip(self):
         """Empty query string should not trigger a skip (guard against false positives)."""
         slos = self._make_slos()
         resource = {
             "id": "empty789",
             "type": "metric",
-            "queries": [{"numerator": "", "denominator": ""}],
+            "query": {"numerator": "", "denominator": ""},
         }
         # Empty strings are falsy — no skip triggered
         asyncio.run(slos.pre_resource_action_hook("empty789", resource))
 
-    def test_metric_slo_no_queries_does_not_skip(self):
-        """Metric SLO with no queries list should not crash."""
+    def test_metric_slo_no_query_does_not_crash(self):
+        """Metric SLO with no 'query' key should not crash."""
         slos = self._make_slos()
         resource = {
             "id": "noqueries",
@@ -96,19 +109,23 @@ class TestSLOPreResourceActionHook:
         # Should not raise
         asyncio.run(slos.pre_resource_action_hook("noqueries", resource))
 
-    def test_metric_slo_multiple_queries_any_missing_raises_skip(self):
-        """If any query in the list is missing .as_count(), the SLO should be skipped."""
+    def test_metric_slo_null_query_does_not_crash(self):
+        """Metric SLO with query=None should not crash (guard against AttributeError)."""
         slos = self._make_slos()
         resource = {
-            "id": "multi123",
+            "id": "nullquery",
             "type": "metric",
-            "queries": [
-                {"numerator": "sum:ok.metric{*}.as_count()", "denominator": "sum:ok.total{*}.as_count()"},
-                {"numerator": "sum:bad.metric{*}", "denominator": "sum:bad.total{*}.as_count()"},
-            ],
+            "query": None,
         }
-        with pytest.raises(SkipResource):
-            asyncio.run(slos.pre_resource_action_hook("multi123", resource))
+        # Should not raise (isinstance guard handles None)
+        asyncio.run(slos.pre_resource_action_hook("nullquery", resource))
+
+    def test_missing_type_key_does_not_skip(self):
+        """Resource without a 'type' key should not trigger the check."""
+        slos = self._make_slos()
+        resource = {"id": "notype"}
+        # Should not raise
+        asyncio.run(slos.pre_resource_action_hook("notype", resource))
 
     def test_skip_message_mentions_field(self):
         """SkipResource message should identify which field is missing the modifier."""
@@ -116,7 +133,7 @@ class TestSLOPreResourceActionHook:
         resource = {
             "id": "msgtest",
             "type": "metric",
-            "queries": [{"numerator": "sum:bad.metric{*}", "denominator": "sum:ok.total{*}.as_count()"}],
+            "query": {"numerator": "sum:bad.metric{*}", "denominator": "sum:ok.total{*}.as_count()"},
         }
         with pytest.raises(SkipResource) as exc_info:
             asyncio.run(slos.pre_resource_action_hook("msgtest", resource))


### PR DESCRIPTION
## Summary

- **Jira:** [DRALLSTSBX-52](https://datadoghq.atlassian.net/browse/DRALLSTSBX-52)
- Metric-based SLOs were failing sync with `400: "Metric queries require the 'as count' modifier"`
- Root cause: source SLO has a metric query without `.as_count()`; sync-cli sends the payload verbatim
- Fix: detect the condition in `pre_resource_action_hook` using the correct `"query"` (singular dict) field confirmed via integration cassettes, skip at sync time with actionable message

## Changes

- `datadog_sync/model/service_level_objectives.py`: add `pre_resource_action_hook` that checks metric SLOs for `.as_count()` in `query.numerator` and `query.denominator`
- `tests/unit/test_service_level_objectives.py`: 10 unit tests covering all field/type/null edge cases

## Test plan

- [x] `pytest tests/unit/` — all unit tests pass
- [x] SLO API shape verified against cassette data (`"query"` singular dict, not `"queries"` list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DRALLSTSBX-52]: https://datadoghq.atlassian.net/browse/DRALLSTSBX-52