### PR TITLE
fix: skip SDS rules with missing standard patterns; strip null included_keywords [DRALLSTSBX-53]

### DIFF
--- a/datadog_sync/model/sensitive_data_scanner_rules.py
+++ b/datadog_sync/model/sensitive_data_scanner_rules.py
@@ -19,9 +19,7 @@ class SensitiveDataScannerRules(BaseResource):
         excluded_attributes=[
             "id",
         ],
-        resource_connections={
-            "sensitive_data_scanner_groups": ["relationships.group.data.id"]
-        },
+        resource_connections={"sensitive_data_scanner_groups": ["relationships.group.data.id"]},
         non_nullable_attr=["attributes.included_keywords"],
         concurrent=False,
         skip_resource_mapping=True,
@@ -34,58 +32,38 @@ class SensitiveDataScannerRules(BaseResource):
     async def get_resources(self, client: CustomClient) -> List[Dict]:
         resp = await client.get(self.resource_config.base_path)
 
-        return [
-            r
-            for r in resp.get("included", [])
-            if r["type"] == "sensitive_data_scanner_rule"
-        ]
+        return [r for r in resp.get("included", []) if r["type"] == "sensitive_data_scanner_rule"]
 
-    async def import_resource(
-        self, _id: Optional[str] = None, resource: Optional[Dict] = None
-    ) -> Tuple[str, Dict]:
+    async def import_resource(self, _id: Optional[str] = None, resource: Optional[Dict] = None) -> Tuple[str, Dict]:
         source_client = self.config.source_client
         if not self.source_standard_pattern_mapping:
             # Populate the standard pattern mapping
             try:
-                std_patterns = (
-                    await source_client.get(
-                        self.resource_config.base_path + "/standard-patterns"
-                    )
-                )["data"]
+                std_patterns = (await source_client.get(self.resource_config.base_path + "/standard-patterns"))["data"]
                 for pattern in std_patterns:
-                    self.source_standard_pattern_mapping[pattern["id"]] = pattern[
-                        "attributes"
-                    ]["name"]
+                    self.source_standard_pattern_mapping[pattern["id"]] = pattern["attributes"]["name"]
             except Exception as e:
                 self.config.logger.warning("error retrieving standard patterns: %s", e)
 
         if _id:
-            resource = await source_client.get(
-                self.resource_config.base_path + f"/rules/{_id}"
-            )
+            resource = await source_client.get(self.resource_config.base_path + f"/rules/{_id}")
 
-        if _std_id := (
-            resource.get("relationships", {}).get("standard_pattern", {}).get("data")
-            or {}
-        ).get("id"):
-            resource["relationships"]["standard_pattern"]["data"]["id"] = (
-                self.source_standard_pattern_mapping.get(_std_id, _std_id)
+        if _std_id := (resource.get("relationships", {}).get("standard_pattern", {}).get("data") or {}).get("id"):
+            resource["relationships"]["standard_pattern"]["data"]["id"] = self.source_standard_pattern_mapping.get(
+                _std_id, _std_id
             )
 
         return resource["id"], resource
 
     async def pre_resource_action_hook(self, _id, resource: Dict) -> None:
-        if name := (
-            resource.get("relationships", {}).get("standard_pattern", {}).get("data")
-            or {}
-        ).get("id"):
+        if name := (resource.get("relationships", {}).get("standard_pattern", {}).get("data") or {}).get("id"):
             dest_id = self.destination_standard_pattern_mapping.get(name)
             if dest_id is None:
                 raise SkipResource(
                     _id,
                     self.resource_type,
-                    f"Deprecated resource configuration: Standard pattern '{name}' does not exist in the destination org. "
-                    "Provision the standard scanner pattern before syncing.",
+                    f"Deprecated resource configuration: Standard pattern '{name}' "
+                    "does not exist in the destination org. Provision the standard scanner pattern before syncing.",
                 )
             resource["relationships"]["standard_pattern"]["data"]["id"] = dest_id
 
@@ -95,11 +73,9 @@ class SensitiveDataScannerRules(BaseResource):
             mapping = {}
             # Populate the standard pattern mapping
             try:
-                std_patterns = (
-                    await destination_client.get(
-                        self.resource_config.base_path + "/standard-patterns"
-                    )
-                )["data"]
+                std_patterns = (await destination_client.get(self.resource_config.base_path + "/standard-patterns"))[
+                    "data"
+                ]
                 for pattern in std_patterns:
                     mapping[pattern["attributes"]["name"]] = pattern["id"]
                 self.destination_standard_pattern_mapping = mapping
@@ -110,9 +86,7 @@ class SensitiveDataScannerRules(BaseResource):
         destination_client = self.config.destination_client
 
         payload = {"data": resource, "meta": {}}
-        resp = await destination_client.post(
-            self.resource_config.base_path + "/rules", payload
-        )
+        resp = await destination_client.post(self.resource_config.base_path + "/rules", payload)
 
         return _id, resp["data"]
 
@@ -121,8 +95,7 @@ class SensitiveDataScannerRules(BaseResource):
         resource["id"] = self.config.state.destination[self.resource_type][_id]["id"]
         payload = {"data": resource, "meta": {}}
         await destination_client.patch(
-            self.resource_config.base_path
-            + f"/rules/{self.config.state.destination[self.resource_type][_id]['id']}",
+            self.resource_config.base_path + f"/rules/{self.config.state.destination[self.resource_type][_id]['id']}",
             payload,
         )
 
@@ -132,14 +105,9 @@ class SensitiveDataScannerRules(BaseResource):
         destination_client = self.config.destination_client
         payload = {"meta": {}}
         await destination_client.delete(
-            self.resource_config.base_path
-            + f"/rules/{self.config.state.destination[self.resource_type][_id]['id']}",
+            self.resource_config.base_path + f"/rules/{self.config.state.destination[self.resource_type][_id]['id']}",
             body=payload,
         )
 
-    def connect_id(
-        self, key: str, r_obj: Dict, resource_to_connect: str
-    ) -> Optional[List[str]]:
-        return super(SensitiveDataScannerRules, self).connect_id(
-            key, r_obj, resource_to_connect
-        )
+    def connect_id(self, key: str, r_obj: Dict, resource_to_connect: str) -> Optional[List[str]]:
+        return super(SensitiveDataScannerRules, self).connect_id(key, r_obj, resource_to_connect)

--- a/datadog_sync/model/sensitive_data_scanner_rules.py
+++ b/datadog_sync/model/sensitive_data_scanner_rules.py
@@ -62,7 +62,7 @@ class SensitiveDataScannerRules(BaseResource):
                 raise SkipResource(
                     _id,
                     self.resource_type,
-                    f"Standard pattern '{name}' does not exist in the destination org. "
+                    f"Deprecated resource configuration: Standard pattern '{name}' does not exist in the destination org. "
                     "Provision the standard scanner pattern before syncing.",
                 )
             resource["relationships"]["standard_pattern"]["data"]["id"] = dest_id

--- a/datadog_sync/model/sensitive_data_scanner_rules.py
+++ b/datadog_sync/model/sensitive_data_scanner_rules.py
@@ -48,7 +48,7 @@ class SensitiveDataScannerRules(BaseResource):
         if _id:
             resource = await source_client.get(self.resource_config.base_path + f"/rules/{_id}")
 
-        if _std_id := resource.get("relationships", {}).get("standard_pattern", {}).get("data", {}).get("id"):
+        if _std_id := (resource.get("relationships", {}).get("standard_pattern", {}).get("data") or {}).get("id"):
             resource["relationships"]["standard_pattern"]["data"]["id"] = self.source_standard_pattern_mapping.get(
                 _std_id, _std_id
             )

--- a/datadog_sync/model/sensitive_data_scanner_rules.py
+++ b/datadog_sync/model/sensitive_data_scanner_rules.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, List, Dict, Tuple
 
 from datadog_sync.utils.base_resource import BaseResource, ResourceConfig
+from datadog_sync.utils.resource_utils import SkipResource
 
 if TYPE_CHECKING:
     from datadog_sync.utils.custom_client import CustomClient
@@ -19,6 +20,7 @@ class SensitiveDataScannerRules(BaseResource):
             "id",
         ],
         resource_connections={"sensitive_data_scanner_groups": ["relationships.group.data.id"]},
+        non_nullable_attr=["attributes.included_keywords"],
         concurrent=False,
         skip_resource_mapping=True,
     )
@@ -54,10 +56,16 @@ class SensitiveDataScannerRules(BaseResource):
         return resource["id"], resource
 
     async def pre_resource_action_hook(self, _id, resource: Dict) -> None:
-        if name := resource.get("relationships", {}).get("standard_pattern", {}).get("data", {}).get("id"):
-            resource["relationships"]["standard_pattern"]["data"]["id"] = self.destination_standard_pattern_mapping.get(
-                name, name
-            )
+        if name := (resource.get("relationships", {}).get("standard_pattern", {}).get("data") or {}).get("id"):
+            dest_id = self.destination_standard_pattern_mapping.get(name)
+            if dest_id is None:
+                raise SkipResource(
+                    _id,
+                    self.resource_type,
+                    f"Standard pattern '{name}' does not exist in the destination org. "
+                    "Provision the standard scanner pattern before syncing.",
+                )
+            resource["relationships"]["standard_pattern"]["data"]["id"] = dest_id
 
     async def pre_apply_hook(self) -> None:
         destination_client = self.config.destination_client

--- a/datadog_sync/model/sensitive_data_scanner_rules.py
+++ b/datadog_sync/model/sensitive_data_scanner_rules.py
@@ -19,7 +19,9 @@ class SensitiveDataScannerRules(BaseResource):
         excluded_attributes=[
             "id",
         ],
-        resource_connections={"sensitive_data_scanner_groups": ["relationships.group.data.id"]},
+        resource_connections={
+            "sensitive_data_scanner_groups": ["relationships.group.data.id"]
+        },
         non_nullable_attr=["attributes.included_keywords"],
         concurrent=False,
         skip_resource_mapping=True,
@@ -32,31 +34,51 @@ class SensitiveDataScannerRules(BaseResource):
     async def get_resources(self, client: CustomClient) -> List[Dict]:
         resp = await client.get(self.resource_config.base_path)
 
-        return [r for r in resp.get("included", []) if r["type"] == "sensitive_data_scanner_rule"]
+        return [
+            r
+            for r in resp.get("included", [])
+            if r["type"] == "sensitive_data_scanner_rule"
+        ]
 
-    async def import_resource(self, _id: Optional[str] = None, resource: Optional[Dict] = None) -> Tuple[str, Dict]:
+    async def import_resource(
+        self, _id: Optional[str] = None, resource: Optional[Dict] = None
+    ) -> Tuple[str, Dict]:
         source_client = self.config.source_client
         if not self.source_standard_pattern_mapping:
             # Populate the standard pattern mapping
             try:
-                std_patterns = (await source_client.get(self.resource_config.base_path + "/standard-patterns"))["data"]
+                std_patterns = (
+                    await source_client.get(
+                        self.resource_config.base_path + "/standard-patterns"
+                    )
+                )["data"]
                 for pattern in std_patterns:
-                    self.source_standard_pattern_mapping[pattern["id"]] = pattern["attributes"]["name"]
+                    self.source_standard_pattern_mapping[pattern["id"]] = pattern[
+                        "attributes"
+                    ]["name"]
             except Exception as e:
                 self.config.logger.warning("error retrieving standard patterns: %s", e)
 
         if _id:
-            resource = await source_client.get(self.resource_config.base_path + f"/rules/{_id}")
+            resource = await source_client.get(
+                self.resource_config.base_path + f"/rules/{_id}"
+            )
 
-        if _std_id := (resource.get("relationships", {}).get("standard_pattern", {}).get("data") or {}).get("id"):
-            resource["relationships"]["standard_pattern"]["data"]["id"] = self.source_standard_pattern_mapping.get(
-                _std_id, _std_id
+        if _std_id := (
+            resource.get("relationships", {}).get("standard_pattern", {}).get("data")
+            or {}
+        ).get("id"):
+            resource["relationships"]["standard_pattern"]["data"]["id"] = (
+                self.source_standard_pattern_mapping.get(_std_id, _std_id)
             )
 
         return resource["id"], resource
 
     async def pre_resource_action_hook(self, _id, resource: Dict) -> None:
-        if name := (resource.get("relationships", {}).get("standard_pattern", {}).get("data") or {}).get("id"):
+        if name := (
+            resource.get("relationships", {}).get("standard_pattern", {}).get("data")
+            or {}
+        ).get("id"):
             dest_id = self.destination_standard_pattern_mapping.get(name)
             if dest_id is None:
                 raise SkipResource(
@@ -73,9 +95,11 @@ class SensitiveDataScannerRules(BaseResource):
             mapping = {}
             # Populate the standard pattern mapping
             try:
-                std_patterns = (await destination_client.get(self.resource_config.base_path + "/standard-patterns"))[
-                    "data"
-                ]
+                std_patterns = (
+                    await destination_client.get(
+                        self.resource_config.base_path + "/standard-patterns"
+                    )
+                )["data"]
                 for pattern in std_patterns:
                     mapping[pattern["attributes"]["name"]] = pattern["id"]
                 self.destination_standard_pattern_mapping = mapping
@@ -86,7 +110,9 @@ class SensitiveDataScannerRules(BaseResource):
         destination_client = self.config.destination_client
 
         payload = {"data": resource, "meta": {}}
-        resp = await destination_client.post(self.resource_config.base_path + "/rules", payload)
+        resp = await destination_client.post(
+            self.resource_config.base_path + "/rules", payload
+        )
 
         return _id, resp["data"]
 
@@ -95,7 +121,8 @@ class SensitiveDataScannerRules(BaseResource):
         resource["id"] = self.config.state.destination[self.resource_type][_id]["id"]
         payload = {"data": resource, "meta": {}}
         await destination_client.patch(
-            self.resource_config.base_path + f"/rules/{self.config.state.destination[self.resource_type][_id]['id']}",
+            self.resource_config.base_path
+            + f"/rules/{self.config.state.destination[self.resource_type][_id]['id']}",
             payload,
         )
 
@@ -105,9 +132,14 @@ class SensitiveDataScannerRules(BaseResource):
         destination_client = self.config.destination_client
         payload = {"meta": {}}
         await destination_client.delete(
-            self.resource_config.base_path + f"/rules/{self.config.state.destination[self.resource_type][_id]['id']}",
+            self.resource_config.base_path
+            + f"/rules/{self.config.state.destination[self.resource_type][_id]['id']}",
             body=payload,
         )
 
-    def connect_id(self, key: str, r_obj: Dict, resource_to_connect: str) -> Optional[List[str]]:
-        return super(SensitiveDataScannerRules, self).connect_id(key, r_obj, resource_to_connect)
+    def connect_id(
+        self, key: str, r_obj: Dict, resource_to_connect: str
+    ) -> Optional[List[str]]:
+        return super(SensitiveDataScannerRules, self).connect_id(
+            key, r_obj, resource_to_connect
+        )

--- a/tests/unit/test_sensitive_data_scanner_rules.py
+++ b/tests/unit/test_sensitive_data_scanner_rules.py
@@ -1,0 +1,147 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+"""
+Unit tests for sensitive_data_scanner_rules resource handling.
+
+These tests cover two bugs fixed in DRALLSTSBX-53:
+1. Standard pattern not found in destination → SkipResource instead of sending bad ID
+2. Null included_keywords → stripped via non_nullable_attr before API call
+"""
+
+import asyncio
+import pytest
+from unittest.mock import MagicMock
+
+from datadog_sync.model.sensitive_data_scanner_rules import SensitiveDataScannerRules
+from datadog_sync.utils.resource_utils import SkipResource, prep_resource
+
+
+class TestSensitiveDataScannerRulesPreResourceActionHook:
+    """Tests for Bug 1: standard pattern resolution in pre_resource_action_hook."""
+
+    def _make_rules(self, destination_mapping=None):
+        mock_config = MagicMock()
+        mock_config.state = MagicMock()
+        rules = SensitiveDataScannerRules(mock_config)
+        rules.destination_standard_pattern_mapping = destination_mapping or {}
+        return rules
+
+    def test_standard_pattern_not_in_destination_raises_skip(self):
+        """Rule referencing a standard pattern missing from destination should be skipped."""
+        rules = self._make_rules(destination_mapping={})
+        resource = {
+            "id": "OfoIOTrPSw6Dix6xmeKUaA",
+            "type": "sensitive_data_scanner_rule",
+            "relationships": {
+                "standard_pattern": {"data": {"id": "Visa Card Scanner (4x4 digits)", "type": "sensitive_data_scanner_standard_pattern"}}
+            },
+        }
+        with pytest.raises(SkipResource) as exc_info:
+            asyncio.run(rules.pre_resource_action_hook("OfoIOTrPSw6Dix6xmeKUaA", resource))
+        assert "Visa Card Scanner (4x4 digits)" in str(exc_info.value)
+
+    def test_standard_pattern_found_in_destination_updates_id(self):
+        """Rule with a standard pattern found in destination mapping should have ID replaced."""
+        rules = self._make_rules(
+            destination_mapping={"Visa Card Scanner (4x4 digits)": "dest-uuid-1234"}
+        )
+        resource = {
+            "id": "OfoIOTrPSw6Dix6xmeKUaA",
+            "type": "sensitive_data_scanner_rule",
+            "relationships": {
+                "standard_pattern": {"data": {"id": "Visa Card Scanner (4x4 digits)", "type": "sensitive_data_scanner_standard_pattern"}}
+            },
+        }
+        asyncio.run(rules.pre_resource_action_hook("OfoIOTrPSw6Dix6xmeKUaA", resource))
+        assert resource["relationships"]["standard_pattern"]["data"]["id"] == "dest-uuid-1234"
+
+    def test_no_standard_pattern_relationship_does_not_skip(self):
+        """Rule without a standard_pattern relationship should pass through unmodified."""
+        rules = self._make_rules()
+        resource = {
+            "id": "3gZ518MZSUi5Xqb6dANefQ",
+            "type": "sensitive_data_scanner_rule",
+            "relationships": {
+                "group": {"data": {"id": "some-group-id", "type": "sensitive_data_scanner_group"}}
+            },
+        }
+        # Should not raise
+        asyncio.run(rules.pre_resource_action_hook("3gZ518MZSUi5Xqb6dANefQ", resource))
+
+    def test_standard_pattern_data_none_does_not_crash(self):
+        """Rule with standard_pattern.data=None should not crash."""
+        rules = self._make_rules()
+        resource = {
+            "id": "nulldata",
+            "type": "sensitive_data_scanner_rule",
+            "relationships": {
+                "standard_pattern": {"data": None}
+            },
+        }
+        # Should not raise (walrus operator on None.get() is guarded by dict chain)
+        asyncio.run(rules.pre_resource_action_hook("nulldata", resource))
+
+    def test_multiple_standard_patterns_missing_raises_skip(self):
+        """Ensures each rule independently raises SkipResource when its pattern is missing."""
+        rules = self._make_rules(destination_mapping={"Present Pattern": "dest-id"})
+        for rule_id, pattern_name in [
+            ("rule1", "MasterCard Scanner (4x4 digits)"),
+            ("rule2", "Standard Email Address Scanner"),
+            ("rule3", "American Express Card Scanner (4+6+5 digits)"),
+        ]:
+            resource = {
+                "id": rule_id,
+                "type": "sensitive_data_scanner_rule",
+                "relationships": {
+                    "standard_pattern": {"data": {"id": pattern_name, "type": "sensitive_data_scanner_standard_pattern"}}
+                },
+            }
+            with pytest.raises(SkipResource):
+                asyncio.run(rules.pre_resource_action_hook(rule_id, resource))
+
+
+class TestSensitiveDataScannerRulesNonNullableAttr:
+    """Tests for Bug 2: null included_keywords is stripped via non_nullable_attr."""
+
+    def test_non_nullable_attr_includes_included_keywords(self):
+        """resource_config.non_nullable_attr should include 'attributes.included_keywords'."""
+        assert "attributes.included_keywords" in (SensitiveDataScannerRules.resource_config.non_nullable_attr or [])
+
+    def test_prep_resource_strips_null_included_keywords(self):
+        """prep_resource() should remove included_keywords when null."""
+        resource = {
+            "id": "Av3sSWVPSY2gLNh_8tN9TA",
+            "type": "sensitive_data_scanner_rule",
+            "attributes": {
+                "name": "My Rule",
+                "included_keywords": None,
+            },
+        }
+        prep_resource(SensitiveDataScannerRules.resource_config, resource)
+        assert "included_keywords" not in resource["attributes"]
+
+    def test_prep_resource_preserves_non_null_included_keywords(self):
+        """prep_resource() should leave included_keywords intact when not null."""
+        resource = {
+            "id": "validrule",
+            "type": "sensitive_data_scanner_rule",
+            "attributes": {
+                "name": "My Rule",
+                "included_keywords": {"keywords": ["password", "secret"], "character_count": 10},
+            },
+        }
+        prep_resource(SensitiveDataScannerRules.resource_config, resource)
+        assert "included_keywords" in resource["attributes"]
+        assert resource["attributes"]["included_keywords"]["keywords"] == ["password", "secret"]
+
+    def test_prep_resource_handles_missing_attributes_key(self):
+        """prep_resource() should not crash if 'attributes' key is missing."""
+        resource = {
+            "id": "noattrs",
+            "type": "sensitive_data_scanner_rule",
+        }
+        # Should not raise
+        prep_resource(SensitiveDataScannerRules.resource_config, resource)

--- a/tests/unit/test_sensitive_data_scanner_rules.py
+++ b/tests/unit/test_sensitive_data_scanner_rules.py
@@ -84,6 +84,19 @@ class TestSensitiveDataScannerRulesPreResourceActionHook:
         # Should not raise (walrus operator on None.get() is guarded by dict chain)
         asyncio.run(rules.pre_resource_action_hook("nulldata", resource))
 
+    def test_import_resource_standard_pattern_data_none_does_not_crash(self):
+        """import_resource with standard_pattern.data=None should not crash with AttributeError."""
+        rules = self._make_rules()
+        rules.source_standard_pattern_mapping = {"some-id": "Some Pattern"}
+        resource = {
+            "id": "importnulldata",
+            "type": "sensitive_data_scanner_rule",
+            "attributes": {"name": "My Rule"},
+            "relationships": {"standard_pattern": {"data": None}},
+        }
+        _id, result = asyncio.run(rules.import_resource(resource=resource))
+        assert _id == "importnulldata"
+
     def test_multiple_standard_patterns_missing_raises_skip(self):
         """Ensures each rule independently raises SkipResource when its pattern is missing."""
         rules = self._make_rules(destination_mapping={"Present Pattern": "dest-id"})

--- a/tests/unit/test_sensitive_data_scanner_rules.py
+++ b/tests/unit/test_sensitive_data_scanner_rules.py
@@ -36,7 +36,9 @@ class TestSensitiveDataScannerRulesPreResourceActionHook:
             "id": "OfoIOTrPSw6Dix6xmeKUaA",
             "type": "sensitive_data_scanner_rule",
             "relationships": {
-                "standard_pattern": {"data": {"id": "Visa Card Scanner (4x4 digits)", "type": "sensitive_data_scanner_standard_pattern"}}
+                "standard_pattern": {
+                    "data": {"id": "Visa Card Scanner (4x4 digits)", "type": "sensitive_data_scanner_standard_pattern"}
+                }
             },
         }
         with pytest.raises(SkipResource) as exc_info:
@@ -45,14 +47,14 @@ class TestSensitiveDataScannerRulesPreResourceActionHook:
 
     def test_standard_pattern_found_in_destination_updates_id(self):
         """Rule with a standard pattern found in destination mapping should have ID replaced."""
-        rules = self._make_rules(
-            destination_mapping={"Visa Card Scanner (4x4 digits)": "dest-uuid-1234"}
-        )
+        rules = self._make_rules(destination_mapping={"Visa Card Scanner (4x4 digits)": "dest-uuid-1234"})
         resource = {
             "id": "OfoIOTrPSw6Dix6xmeKUaA",
             "type": "sensitive_data_scanner_rule",
             "relationships": {
-                "standard_pattern": {"data": {"id": "Visa Card Scanner (4x4 digits)", "type": "sensitive_data_scanner_standard_pattern"}}
+                "standard_pattern": {
+                    "data": {"id": "Visa Card Scanner (4x4 digits)", "type": "sensitive_data_scanner_standard_pattern"}
+                }
             },
         }
         asyncio.run(rules.pre_resource_action_hook("OfoIOTrPSw6Dix6xmeKUaA", resource))
@@ -64,9 +66,7 @@ class TestSensitiveDataScannerRulesPreResourceActionHook:
         resource = {
             "id": "3gZ518MZSUi5Xqb6dANefQ",
             "type": "sensitive_data_scanner_rule",
-            "relationships": {
-                "group": {"data": {"id": "some-group-id", "type": "sensitive_data_scanner_group"}}
-            },
+            "relationships": {"group": {"data": {"id": "some-group-id", "type": "sensitive_data_scanner_group"}}},
         }
         # Should not raise
         asyncio.run(rules.pre_resource_action_hook("3gZ518MZSUi5Xqb6dANefQ", resource))
@@ -77,9 +77,7 @@ class TestSensitiveDataScannerRulesPreResourceActionHook:
         resource = {
             "id": "nulldata",
             "type": "sensitive_data_scanner_rule",
-            "relationships": {
-                "standard_pattern": {"data": None}
-            },
+            "relationships": {"standard_pattern": {"data": None}},
         }
         # Should not raise (walrus operator on None.get() is guarded by dict chain)
         asyncio.run(rules.pre_resource_action_hook("nulldata", resource))
@@ -109,7 +107,9 @@ class TestSensitiveDataScannerRulesPreResourceActionHook:
                 "id": rule_id,
                 "type": "sensitive_data_scanner_rule",
                 "relationships": {
-                    "standard_pattern": {"data": {"id": pattern_name, "type": "sensitive_data_scanner_standard_pattern"}}
+                    "standard_pattern": {
+                        "data": {"id": pattern_name, "type": "sensitive_data_scanner_standard_pattern"}
+                    }
                 },
             }
             with pytest.raises(SkipResource):


### PR DESCRIPTION
## Summary

- **Jira:** [DRALLSTSBX-53](https://datadoghq.atlassian.net/browse/DRALLSTSBX-53)
- Two distinct bugs in `sensitive_data_scanner_rules.py` caused 6 rules to fail sync

### Bug 1 — Standard rules don't exist in destination (4 rules)
`pre_resource_action_hook` was silently using the pattern name as a destination ID when the standard pattern wasn't found, causing `400: "standard rule with ID '...' does not exist"`. Now raises `SkipResource` with an actionable message.

Also applied `(... .get("data") or {})` guard to both `import_resource` and `pre_resource_action_hook` to prevent `AttributeError` when `standard_pattern.data` is `None`.

### Bug 2 — Null `included_keywords` (5 rules)
Source rules have `attributes.included_keywords: null` which the destination API rejects. Added `non_nullable_attr=["attributes.included_keywords"]` to resource config so `prep_resource()` strips null values before the API call.

## Changes

- `datadog_sync/model/sensitive_data_scanner_rules.py`: `SkipResource` on missing standard pattern, `or {}` null guards in both hooks, `non_nullable_attr` for `included_keywords`
- `tests/unit/test_sensitive_data_scanner_rules.py`: 10 unit tests covering both bugs and all null edge cases

## Test plan

- [x] `pytest tests/unit/` — 322 tests pass
- [x] Integration: verify 6 affected rules either skip cleanly (standard pattern missing) or sync successfully (null keywords stripped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DRALLSTSBX-53]: https://datadoghq.atlassian.net/browse/DRALLSTSBX-53?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ