### PR TITLE
fix(storage): standardize filename sanitization across all backends

### DIFF
--- a/datadog_sync/utils/storage/_base_storage.py
+++ b/datadog_sync/utils/storage/_base_storage.py
@@ -3,10 +3,16 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019 Datadog, Inc.
 
+import logging
 from abc import ABC, abstractmethod
+from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
-from collections import defaultdict
+
+from datadog_sync.constants import LOGGER_NAME
+
+
+log = logging.getLogger(LOGGER_NAME)
 
 
 @dataclass
@@ -32,6 +38,29 @@ class BaseStorage(ABC):
         sanitization only affects the filename/object key used in storage.
         """
         return resource_id.replace(":", ".")
+
+    @staticmethod
+    def _check_id_collisions(resource_data: dict, resource_type: str) -> None:
+        """Log an error for any two IDs that sanitize to the same filename segment.
+
+        When resource_per_file=True, each resource ID becomes part of the filename.
+        Two distinct IDs that differ only by ':' vs '.' (e.g. 'foo:bar' and 'foo.bar')
+        would map to the same file, causing the second write to silently overwrite the first.
+        """
+        seen: dict = {}
+        for _id in resource_data:
+            safe = BaseStorage._sanitize_id_for_filename(_id)
+            if safe in seen:
+                log.error(
+                    "Filename collision for resource type '%s': IDs '%s' and '%s' both "
+                    "sanitize to '%s'. Only one will be written to storage.",
+                    resource_type,
+                    seen[safe],
+                    _id,
+                    safe,
+                )
+            else:
+                seen[safe] = _id
 
     @abstractmethod
     def get(self, origin, resource_types=None) -> StorageData:

--- a/datadog_sync/utils/storage/_base_storage.py
+++ b/datadog_sync/utils/storage/_base_storage.py
@@ -40,29 +40,34 @@ class BaseStorage(ABC):
         return resource_id.replace(":", ".")
 
     @staticmethod
-    def _check_id_collisions(resource_data: dict, resource_type: str) -> None:
-        """Log an error for any two IDs that sanitize to the same filename segment.
+    def _check_id_collisions(resource_data: dict, resource_type: str) -> set:
+        """Return the set of IDs that would collide with an earlier ID's sanitized filename.
 
         When resource_per_file=True, each resource ID becomes part of the filename.
         Two distinct IDs that differ only by ':' vs '.' (e.g. 'foo:bar' and 'foo.bar')
-        would map to the same file, causing the second write to silently overwrite the first.
+        would map to the same file. The first ID encountered wins; subsequent colliders
+        are returned in the skip set so callers can omit them from the write loop.
         """
         # Dict iteration is insertion-ordered (Python 3.7+). The first ID
         # encountered wins; subsequent colliders are skipped (only logged).
         seen: dict = {}
+        skip: set = set()
         for _id in resource_data:
             safe = BaseStorage._sanitize_id_for_filename(_id)
             if safe in seen:
                 log.error(
                     "Filename collision for resource type '%s': IDs '%s' and '%s' both "
-                    "sanitize to '%s'. Only one will be written to storage.",
+                    "sanitize to '%s'. Skipping '%s' to prevent overwrite.",
                     resource_type,
                     seen[safe],
                     _id,
                     safe,
+                    _id,
                 )
+                skip.add(_id)
             else:
                 seen[safe] = _id
+        return skip
 
     @abstractmethod
     def get(self, origin, resource_types=None) -> StorageData:

--- a/datadog_sync/utils/storage/_base_storage.py
+++ b/datadog_sync/utils/storage/_base_storage.py
@@ -31,7 +31,7 @@ class BaseStorage(ABC):
         The original resource ID is always preserved in JSON file content;
         sanitization only affects the filename/object key used in storage.
         """
-        return resource_id.replace(':', '.')
+        return resource_id.replace(":", ".")
 
     @abstractmethod
     def get(self, origin, resource_types=None) -> StorageData:

--- a/datadog_sync/utils/storage/_base_storage.py
+++ b/datadog_sync/utils/storage/_base_storage.py
@@ -5,7 +5,7 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional, Tuple
 from collections import defaultdict
 
 
@@ -18,9 +18,58 @@ class StorageData:
 class BaseStorage(ABC):
     """Base class for storage"""
 
+    @staticmethod
+    def _sanitize_id_for_filename(resource_id: str) -> str:
+        """Replace ':' with '.' for cross-platform filename safety.
+
+        Colons are problematic across storage backends:
+        - GCS: explicitly recommends avoiding ':' in object names
+        - S3: colons require special handling in some URL contexts
+        - Azure: reserved URL characters must be percent-encoded
+        - Windows: colons are invalid in filenames
+
+        The original resource ID is always preserved in JSON file content;
+        sanitization only affects the filename/object key used in storage.
+        """
+        return resource_id.replace(':', '.')
+
     @abstractmethod
-    def get(self, origin) -> StorageData:
-        """Get resouces state from storage"""
+    def get(self, origin, resource_types=None) -> StorageData:
+        """Get resources state from storage.
+
+        Args:
+            origin: Which data to load (SOURCE, DESTINATION, or ALL).
+            resource_types: If provided, only load files for these resource types.
+                            None (default) loads all types — existing behavior.
+        """
+        pass
+
+    @abstractmethod
+    def get_by_ids(self, origin, exact_ids: Dict[str, List[str]]) -> StorageData:
+        """Load specific resources by ID, constructing keys directly. No listing needed.
+
+        Args:
+            origin: Which data to load (SOURCE, DESTINATION, or ALL).
+            exact_ids: Mapping of resource_type -> [id1, id2, ...] to fetch.
+
+        Returns StorageData with only the requested resources. Missing resources
+        are silently skipped (no exception raised for NotFound).
+        """
+        pass
+
+    @abstractmethod
+    def get_single(self, resource_type: str, resource_id: str) -> Tuple[Optional[Dict], Optional[Dict]]:
+        """Load one resource's source and destination state.
+
+        Args:
+            resource_type: The resource type (e.g., 'dashboards').
+            resource_id: The original (unsanitized) resource ID.
+
+        Returns:
+            Tuple of (source_dict_entry, dest_dict_entry).
+            Either element is None if the corresponding file does not exist.
+            Never raises NotFound exceptions — returns None instead.
+        """
         pass
 
     @abstractmethod

--- a/datadog_sync/utils/storage/_base_storage.py
+++ b/datadog_sync/utils/storage/_base_storage.py
@@ -47,6 +47,8 @@ class BaseStorage(ABC):
         Two distinct IDs that differ only by ':' vs '.' (e.g. 'foo:bar' and 'foo.bar')
         would map to the same file, causing the second write to silently overwrite the first.
         """
+        # Dict iteration is insertion-ordered (Python 3.7+). The first ID
+        # encountered wins; subsequent colliders are skipped (only logged).
         seen: dict = {}
         for _id in resource_data:
             safe = BaseStorage._sanitize_id_for_filename(_id)

--- a/datadog_sync/utils/storage/aws_s3_bucket.py
+++ b/datadog_sync/utils/storage/aws_s3_bucket.py
@@ -116,6 +116,7 @@ class AWSS3Bucket(BaseStorage):
             for resource_type, resource_data in data.source.items():
                 base_key = f"{self.source_resources_path}/{resource_type}"
                 if self.resource_per_file:
+                    self._check_id_collisions(resource_data, resource_type)
                     for _id, resource in resource_data.items():
                         safe_id = self._sanitize_id_for_filename(_id)
                         key = f"{base_key}.{safe_id}.json"
@@ -138,6 +139,7 @@ class AWSS3Bucket(BaseStorage):
             for resource_type, resource_data in data.destination.items():
                 base_key = f"{self.destination_resources_path}/{resource_type}"
                 if self.resource_per_file:
+                    self._check_id_collisions(resource_data, resource_type)
                     for _id, resource in resource_data.items():
                         safe_id = self._sanitize_id_for_filename(_id)
                         key = f"{base_key}.{safe_id}.json"
@@ -171,6 +173,11 @@ class AWSS3Bucket(BaseStorage):
 
     def get_by_ids(self, origin: Origin, exact_ids: Dict[str, List[str]]) -> StorageData:
         """Load specific resources by ID without listing. Constructs keys directly."""
+        if not self.resource_per_file:
+            raise ValueError(
+                "get_by_ids() requires --resource-per-file. "
+                "Re-run with --resource-per-file enabled."
+            )
         data = StorageData()
         for resource_type, ids in exact_ids.items():
             for resource_id in ids:

--- a/datadog_sync/utils/storage/aws_s3_bucket.py
+++ b/datadog_sync/utils/storage/aws_s3_bucket.py
@@ -5,8 +5,11 @@
 
 import json
 import logging
+from collections import defaultdict
+from typing import Dict, List, Optional, Tuple
 
 import boto3
+from botocore.exceptions import ClientError
 
 from datadog_sync.constants import (
     Origin,
@@ -57,83 +60,59 @@ class AWSS3Bucket(BaseStorage):
         if not self.bucket_name:
             raise ValueError("AWS S3 bucket name is required")
 
-    def get(self, origin: Origin) -> StorageData:
+    def get(self, origin: Origin, resource_types=None) -> StorageData:
         log.info("AWS S3 get called")
         data = StorageData()
 
-        # Load source resources with pagination
         if origin in [Origin.SOURCE, Origin.ALL]:
-            continuation_token = None
-            while True:
-                # Build list_objects_v2 kwargs
-                list_kwargs = {
-                    "Bucket": self.bucket_name,
-                    "Prefix": self.source_resources_path,
-                }
-                if continuation_token:
-                    list_kwargs["ContinuationToken"] = continuation_token
+            data.source = self._list_and_load(self.source_resources_path, resource_types, "source")
 
-                prefix_contents = self.client.list_objects_v2(**list_kwargs)
-
-                # Process contents if they exist
-                if "Contents" in prefix_contents:
-                    for item in prefix_contents["Contents"]:
-                        key = item["Key"]
-                        if key.endswith(".json"):
-                            resource_type = key.split(".")[0].split("/")[-1]
-                            response = self.client.get_object(
-                                Bucket=self.bucket_name,
-                                Key=key,
-                            )
-                            content_body = response.get("Body")
-                            try:
-                                data.source[resource_type].update(json.load(content_body))
-                            except json.decoder.JSONDecodeError:
-                                log.warning(f"invalid json in aws source resource file: {resource_type}")
-
-                # Check if there are more pages to fetch
-                if prefix_contents.get("IsTruncated"):
-                    continuation_token = prefix_contents.get("NextContinuationToken")
-                else:
-                    break
-
-        # Load destination resources with pagination
         if origin in [Origin.DESTINATION, Origin.ALL]:
-            continuation_token = None
-            while True:
-                # Build list_objects_v2 kwargs
-                list_kwargs = {
-                    "Bucket": self.bucket_name,
-                    "Prefix": self.destination_resources_path,
-                }
-                if continuation_token:
-                    list_kwargs["ContinuationToken"] = continuation_token
-
-                prefix_contents = self.client.list_objects_v2(**list_kwargs)
-
-                # Process contents if they exist
-                if "Contents" in prefix_contents:
-                    for item in prefix_contents["Contents"]:
-                        key = item["Key"]
-                        if key.endswith(".json"):
-                            resource_type = key.split(".")[0].split("/")[-1]
-                            response = self.client.get_object(
-                                Bucket=self.bucket_name,
-                                Key=key,
-                            )
-                            content_body = response.get("Body")
-                            try:
-                                data.destination[resource_type].update(json.load(content_body))
-                            except json.decoder.JSONDecodeError:
-                                log.warning(f"invalid json in aws destination resource file: {resource_type}")
-
-                # Check if there are more pages to fetch
-                if prefix_contents.get("IsTruncated"):
-                    continuation_token = prefix_contents.get("NextContinuationToken")
-                else:
-                    break
+            data.destination = self._list_and_load(self.destination_resources_path, resource_types, "destination")
 
         return data
+
+    def _list_and_load(self, base_prefix: str, resource_types, label: str) -> defaultdict:
+        """List and load all matching objects under base_prefix, optionally scoped to resource_types.
+
+        When resource_types is None: single broad listing (existing behavior).
+        When resource_types is set: one listing per type using type-specific prefix,
+        reducing both list and get_object calls from O(all_resources) to O(requested_resources).
+        """
+        result = defaultdict(dict)
+        # Scoped: iterate one type at a time using tight prefix "{base}/{type}."
+        # Unscoped: single broad listing — existing behavior
+        prefixes = (
+            [f"{base_prefix}/{rt}." for rt in resource_types]
+            if resource_types is not None
+            else [base_prefix]
+        )
+        for prefix in prefixes:
+            continuation_token = None
+            while True:
+                list_kwargs = {"Bucket": self.bucket_name, "Prefix": prefix}
+                if continuation_token:
+                    list_kwargs["ContinuationToken"] = continuation_token
+
+                response = self.client.list_objects_v2(**list_kwargs)
+
+                if "Contents" in response:
+                    for item in response["Contents"]:
+                        key = item["Key"]
+                        if not key.endswith(".json"):
+                            continue
+                        resource_type = key.split(".")[0].split("/")[-1]
+                        obj = self.client.get_object(Bucket=self.bucket_name, Key=key)
+                        try:
+                            result[resource_type].update(json.load(obj["Body"]))
+                        except json.decoder.JSONDecodeError:
+                            log.warning(f"invalid json in aws {label} resource file: {resource_type}")
+
+                if response.get("IsTruncated"):
+                    continuation_token = response.get("NextContinuationToken")
+                else:
+                    break
+        return result
 
     def put(self, origin: Origin, data: StorageData) -> None:
         log.info("AWS S3 put called")
@@ -142,7 +121,8 @@ class AWSS3Bucket(BaseStorage):
                 base_key = f"{self.source_resources_path}/{resource_type}"
                 if self.resource_per_file:
                     for _id, resource in resource_data.items():
-                        key = f"{base_key}.{_id}.json"
+                        safe_id = self._sanitize_id_for_filename(_id)
+                        key = f"{base_key}.{safe_id}.json"
                         binary_data = bytes(json.dumps({_id: resource}), "UTF-8")
                         self.client.put_object(
                             Body=binary_data,
@@ -163,7 +143,8 @@ class AWSS3Bucket(BaseStorage):
                 base_key = f"{self.destination_resources_path}/{resource_type}"
                 if self.resource_per_file:
                     for _id, resource in resource_data.items():
-                        key = f"{base_key}.{_id}.json"
+                        safe_id = self._sanitize_id_for_filename(_id)
+                        key = f"{base_key}.{safe_id}.json"
                         binary_data = bytes(json.dumps({_id: resource}), "UTF-8")
                         self.client.put_object(
                             Body=binary_data,
@@ -178,3 +159,46 @@ class AWSS3Bucket(BaseStorage):
                         Bucket=self.bucket_name,
                         Key=key,
                     )
+
+    def _try_get_object(self, key: str) -> Optional[Dict]:
+        """Fetch and parse one S3 object. Returns None on NotFound."""
+        try:
+            response = self.client.get_object(Bucket=self.bucket_name, Key=key)
+            return json.load(response["Body"])
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "NoSuchKey":
+                return None
+            raise
+        except json.decoder.JSONDecodeError:
+            log.warning(f"invalid json in aws resource file: {key}")
+            return None
+
+    def get_by_ids(self, origin: Origin, exact_ids: Dict[str, List[str]]) -> StorageData:
+        """Load specific resources by ID without listing. Constructs keys directly."""
+        data = StorageData()
+        for resource_type, ids in exact_ids.items():
+            for resource_id in ids:
+                src, dst = self.get_single(resource_type, resource_id)
+                if origin in [Origin.SOURCE, Origin.ALL] and src is not None:
+                    data.source[resource_type][resource_id] = src
+                if origin in [Origin.DESTINATION, Origin.ALL] and dst is not None:
+                    data.destination[resource_type][resource_id] = dst
+        return data
+
+    def get_single(self, resource_type: str, resource_id: str) -> Tuple[Optional[Dict], Optional[Dict]]:
+        """Load one resource's source and destination state by ID.
+
+        Uses sanitized ID for key construction; content key is the original resource_id.
+        Returns (None, None) if files don't exist (NoSuchKey is handled gracefully).
+        """
+        safe_id = self._sanitize_id_for_filename(resource_id)
+
+        src_key = f"{self.source_resources_path}/{resource_type}.{safe_id}.json"
+        src_obj = self._try_get_object(src_key)
+        src_data = src_obj.get(resource_id) if src_obj else None
+
+        dst_key = f"{self.destination_resources_path}/{resource_type}.{safe_id}.json"
+        dst_obj = self._try_get_object(dst_key)
+        dst_data = dst_obj.get(resource_id) if dst_obj else None
+
+        return src_data, dst_data

--- a/datadog_sync/utils/storage/aws_s3_bucket.py
+++ b/datadog_sync/utils/storage/aws_s3_bucket.py
@@ -174,10 +174,7 @@ class AWSS3Bucket(BaseStorage):
     def get_by_ids(self, origin: Origin, exact_ids: Dict[str, List[str]]) -> StorageData:
         """Load specific resources by ID without listing. Constructs keys directly."""
         if not self.resource_per_file:
-            raise ValueError(
-                "get_by_ids() requires --resource-per-file. "
-                "Re-run with --resource-per-file enabled."
-            )
+            raise ValueError("get_by_ids() requires --resource-per-file. " "Re-run with --resource-per-file enabled.")
         data = StorageData()
         for resource_type, ids in exact_ids.items():
             for resource_id in ids:

--- a/datadog_sync/utils/storage/aws_s3_bucket.py
+++ b/datadog_sync/utils/storage/aws_s3_bucket.py
@@ -116,8 +116,10 @@ class AWSS3Bucket(BaseStorage):
             for resource_type, resource_data in data.source.items():
                 base_key = f"{self.source_resources_path}/{resource_type}"
                 if self.resource_per_file:
-                    self._check_id_collisions(resource_data, resource_type)
+                    skip_ids = self._check_id_collisions(resource_data, resource_type)
                     for _id, resource in resource_data.items():
+                        if _id in skip_ids:
+                            continue
                         safe_id = self._sanitize_id_for_filename(_id)
                         key = f"{base_key}.{safe_id}.json"
                         binary_data = bytes(json.dumps({_id: resource}), "UTF-8")
@@ -139,8 +141,10 @@ class AWSS3Bucket(BaseStorage):
             for resource_type, resource_data in data.destination.items():
                 base_key = f"{self.destination_resources_path}/{resource_type}"
                 if self.resource_per_file:
-                    self._check_id_collisions(resource_data, resource_type)
+                    skip_ids = self._check_id_collisions(resource_data, resource_type)
                     for _id, resource in resource_data.items():
+                        if _id in skip_ids:
+                            continue
                         safe_id = self._sanitize_id_for_filename(_id)
                         key = f"{base_key}.{safe_id}.json"
                         binary_data = bytes(json.dumps({_id: resource}), "UTF-8")

--- a/datadog_sync/utils/storage/aws_s3_bucket.py
+++ b/datadog_sync/utils/storage/aws_s3_bucket.py
@@ -82,11 +82,7 @@ class AWSS3Bucket(BaseStorage):
         result = defaultdict(dict)
         # Scoped: iterate one type at a time using tight prefix "{base}/{type}."
         # Unscoped: single broad listing — existing behavior
-        prefixes = (
-            [f"{base_prefix}/{rt}." for rt in resource_types]
-            if resource_types is not None
-            else [base_prefix]
-        )
+        prefixes = [f"{base_prefix}/{rt}." for rt in resource_types] if resource_types is not None else [base_prefix]
         for prefix in prefixes:
             continuation_token = None
             while True:

--- a/datadog_sync/utils/storage/azure_blob_container.py
+++ b/datadog_sync/utils/storage/azure_blob_container.py
@@ -5,6 +5,7 @@
 
 import json
 import logging
+from collections import defaultdict
 from typing import Dict, List, Optional, Tuple
 
 from azure.core.exceptions import ResourceNotFoundError
@@ -80,8 +81,6 @@ class AzureBlobContainer(BaseStorage):
 
     def _list_and_load(self, base_prefix: str, resource_types, label: str):
         """List and load Azure blobs, optionally scoped to resource_types."""
-        from collections import defaultdict
-
         result = defaultdict(dict)
         prefixes = [f"{base_prefix}/{rt}." for rt in resource_types] if resource_types is not None else [base_prefix]
         for prefix in prefixes:
@@ -102,6 +101,7 @@ class AzureBlobContainer(BaseStorage):
             for resource_type, resource_data in data.source.items():
                 base_key = f"{self.source_resources_path}/{resource_type}"
                 if self.resource_per_file:
+                    self._check_id_collisions(resource_data, resource_type)
                     for _id, resource in resource_data.items():
                         safe_id = self._sanitize_id_for_filename(_id)
                         key = f"{base_key}.{safe_id}.json"
@@ -114,6 +114,7 @@ class AzureBlobContainer(BaseStorage):
             for resource_type, resource_data in data.destination.items():
                 base_key = f"{self.destination_resources_path}/{resource_type}"
                 if self.resource_per_file:
+                    self._check_id_collisions(resource_data, resource_type)
                     for _id, resource in resource_data.items():
                         safe_id = self._sanitize_id_for_filename(_id)
                         key = f"{base_key}.{safe_id}.json"
@@ -135,6 +136,11 @@ class AzureBlobContainer(BaseStorage):
 
     def get_by_ids(self, origin: Origin, exact_ids: Dict[str, List[str]]) -> StorageData:
         """Load specific resources by ID without listing. Constructs keys directly."""
+        if not self.resource_per_file:
+            raise ValueError(
+                "get_by_ids() requires --resource-per-file. "
+                "Re-run with --resource-per-file enabled."
+            )
         data = StorageData()
         for resource_type, ids in exact_ids.items():
             for resource_id in ids:

--- a/datadog_sync/utils/storage/azure_blob_container.py
+++ b/datadog_sync/utils/storage/azure_blob_container.py
@@ -5,7 +5,9 @@
 
 import json
 import logging
+from typing import Dict, List, Optional, Tuple
 
+from azure.core.exceptions import ResourceNotFoundError
 from azure.storage.blob import BlobServiceClient, ContainerClient
 from azure.identity import DefaultAzureCredential
 
@@ -64,31 +66,38 @@ class AzureBlobContainer(BaseStorage):
         else:
             raise ValueError("Azure storage requires at least a connection string or storage account name")
 
-    def get(self, origin: Origin) -> StorageData:
+    def get(self, origin: Origin, resource_types=None) -> StorageData:
         log.info("Azure Blob Storage get called")
         data = StorageData()
 
         if origin in [Origin.SOURCE, Origin.ALL]:
-            for blob in self.container_client.list_blobs(name_starts_with=self.source_resources_path):
-                if blob.name.endswith(".json"):
-                    resource_type = blob.name.split(".")[0].split("/")[-1]
-                    try:
-                        content = self.container_client.download_blob(blob.name).readall().decode("utf-8")
-                        data.source[resource_type].update(json.loads(content))
-                    except json.decoder.JSONDecodeError:
-                        log.warning(f"invalid json in azure source resource file: {resource_type}")
+            data.source = self._list_and_load(self.source_resources_path, resource_types, "source")
 
         if origin in [Origin.DESTINATION, Origin.ALL]:
-            for blob in self.container_client.list_blobs(name_starts_with=self.destination_resources_path):
-                if blob.name.endswith(".json"):
-                    resource_type = blob.name.split(".")[0].split("/")[-1]
-                    try:
-                        content = self.container_client.download_blob(blob.name).readall().decode("utf-8")
-                        data.destination[resource_type].update(json.loads(content))
-                    except json.decoder.JSONDecodeError:
-                        log.warning(f"invalid json in azure destination resource file: {resource_type}")
+            data.destination = self._list_and_load(self.destination_resources_path, resource_types, "destination")
 
         return data
+
+    def _list_and_load(self, base_prefix: str, resource_types, label: str):
+        """List and load Azure blobs, optionally scoped to resource_types."""
+        from collections import defaultdict
+        result = defaultdict(dict)
+        prefixes = (
+            [f"{base_prefix}/{rt}." for rt in resource_types]
+            if resource_types is not None
+            else [base_prefix]
+        )
+        for prefix in prefixes:
+            for blob in self.container_client.list_blobs(name_starts_with=prefix):
+                if not blob.name.endswith(".json"):
+                    continue
+                resource_type = blob.name.split(".")[0].split("/")[-1]
+                try:
+                    content = self.container_client.download_blob(blob.name).readall().decode("utf-8")
+                    result[resource_type].update(json.loads(content))
+                except json.decoder.JSONDecodeError:
+                    log.warning(f"invalid json in azure {label} resource file: {resource_type}")
+        return result
 
     def put(self, origin: Origin, data: StorageData) -> None:
         log.info("Azure Blob Storage put called")
@@ -97,7 +106,8 @@ class AzureBlobContainer(BaseStorage):
                 base_key = f"{self.source_resources_path}/{resource_type}"
                 if self.resource_per_file:
                     for _id, resource in resource_data.items():
-                        key = f"{base_key}.{_id}.json"
+                        safe_id = self._sanitize_id_for_filename(_id)
+                        key = f"{base_key}.{safe_id}.json"
                         self.container_client.upload_blob(name=key, data=json.dumps({_id: resource}), overwrite=True)
                 else:
                     key = f"{base_key}.json"
@@ -108,8 +118,46 @@ class AzureBlobContainer(BaseStorage):
                 base_key = f"{self.destination_resources_path}/{resource_type}"
                 if self.resource_per_file:
                     for _id, resource in resource_data.items():
-                        key = f"{base_key}.{_id}.json"
+                        safe_id = self._sanitize_id_for_filename(_id)
+                        key = f"{base_key}.{safe_id}.json"
                         self.container_client.upload_blob(name=key, data=json.dumps({_id: resource}), overwrite=True)
                 else:
                     key = f"{base_key}.json"
                     self.container_client.upload_blob(name=key, data=json.dumps(resource_data), overwrite=True)
+
+    def _try_get_blob(self, key: str) -> Optional[Dict]:
+        """Fetch and parse one Azure blob. Returns None on ResourceNotFoundError."""
+        try:
+            content = self.container_client.download_blob(key).readall().decode("utf-8")
+            return json.loads(content)
+        except ResourceNotFoundError:
+            return None
+        except json.decoder.JSONDecodeError:
+            log.warning(f"invalid json in azure resource file: {key}")
+            return None
+
+    def get_by_ids(self, origin: Origin, exact_ids: Dict[str, List[str]]) -> StorageData:
+        """Load specific resources by ID without listing. Constructs keys directly."""
+        data = StorageData()
+        for resource_type, ids in exact_ids.items():
+            for resource_id in ids:
+                src, dst = self.get_single(resource_type, resource_id)
+                if origin in [Origin.SOURCE, Origin.ALL] and src is not None:
+                    data.source[resource_type][resource_id] = src
+                if origin in [Origin.DESTINATION, Origin.ALL] and dst is not None:
+                    data.destination[resource_type][resource_id] = dst
+        return data
+
+    def get_single(self, resource_type: str, resource_id: str) -> Tuple[Optional[Dict], Optional[Dict]]:
+        """Load one resource's source and destination state by ID."""
+        safe_id = self._sanitize_id_for_filename(resource_id)
+
+        src_key = f"{self.source_resources_path}/{resource_type}.{safe_id}.json"
+        src_obj = self._try_get_blob(src_key)
+        src_data = src_obj.get(resource_id) if src_obj else None
+
+        dst_key = f"{self.destination_resources_path}/{resource_type}.{safe_id}.json"
+        dst_obj = self._try_get_blob(dst_key)
+        dst_data = dst_obj.get(resource_id) if dst_obj else None
+
+        return src_data, dst_data

--- a/datadog_sync/utils/storage/azure_blob_container.py
+++ b/datadog_sync/utils/storage/azure_blob_container.py
@@ -137,10 +137,7 @@ class AzureBlobContainer(BaseStorage):
     def get_by_ids(self, origin: Origin, exact_ids: Dict[str, List[str]]) -> StorageData:
         """Load specific resources by ID without listing. Constructs keys directly."""
         if not self.resource_per_file:
-            raise ValueError(
-                "get_by_ids() requires --resource-per-file. "
-                "Re-run with --resource-per-file enabled."
-            )
+            raise ValueError("get_by_ids() requires --resource-per-file. " "Re-run with --resource-per-file enabled.")
         data = StorageData()
         for resource_type, ids in exact_ids.items():
             for resource_id in ids:

--- a/datadog_sync/utils/storage/azure_blob_container.py
+++ b/datadog_sync/utils/storage/azure_blob_container.py
@@ -101,8 +101,10 @@ class AzureBlobContainer(BaseStorage):
             for resource_type, resource_data in data.source.items():
                 base_key = f"{self.source_resources_path}/{resource_type}"
                 if self.resource_per_file:
-                    self._check_id_collisions(resource_data, resource_type)
+                    skip_ids = self._check_id_collisions(resource_data, resource_type)
                     for _id, resource in resource_data.items():
+                        if _id in skip_ids:
+                            continue
                         safe_id = self._sanitize_id_for_filename(_id)
                         key = f"{base_key}.{safe_id}.json"
                         self.container_client.upload_blob(name=key, data=json.dumps({_id: resource}), overwrite=True)
@@ -114,8 +116,10 @@ class AzureBlobContainer(BaseStorage):
             for resource_type, resource_data in data.destination.items():
                 base_key = f"{self.destination_resources_path}/{resource_type}"
                 if self.resource_per_file:
-                    self._check_id_collisions(resource_data, resource_type)
+                    skip_ids = self._check_id_collisions(resource_data, resource_type)
                     for _id, resource in resource_data.items():
+                        if _id in skip_ids:
+                            continue
                         safe_id = self._sanitize_id_for_filename(_id)
                         key = f"{base_key}.{safe_id}.json"
                         self.container_client.upload_blob(name=key, data=json.dumps({_id: resource}), overwrite=True)

--- a/datadog_sync/utils/storage/azure_blob_container.py
+++ b/datadog_sync/utils/storage/azure_blob_container.py
@@ -81,12 +81,9 @@ class AzureBlobContainer(BaseStorage):
     def _list_and_load(self, base_prefix: str, resource_types, label: str):
         """List and load Azure blobs, optionally scoped to resource_types."""
         from collections import defaultdict
+
         result = defaultdict(dict)
-        prefixes = (
-            [f"{base_prefix}/{rt}." for rt in resource_types]
-            if resource_types is not None
-            else [base_prefix]
-        )
+        prefixes = [f"{base_prefix}/{rt}." for rt in resource_types] if resource_types is not None else [base_prefix]
         for prefix in prefixes:
             for blob in self.container_client.list_blobs(name_starts_with=prefix):
                 if not blob.name.endswith(".json"):

--- a/datadog_sync/utils/storage/gcs_bucket.py
+++ b/datadog_sync/utils/storage/gcs_bucket.py
@@ -67,12 +67,9 @@ class GCSBucket(BaseStorage):
     def _list_and_load(self, base_prefix: str, resource_types, label: str):
         """List and load GCS blobs, optionally scoped to resource_types."""
         from collections import defaultdict
+
         result = defaultdict(dict)
-        prefixes = (
-            [f"{base_prefix}/{rt}." for rt in resource_types]
-            if resource_types is not None
-            else [base_prefix]
-        )
+        prefixes = [f"{base_prefix}/{rt}." for rt in resource_types] if resource_types is not None else [base_prefix]
         for prefix in prefixes:
             for blob in self.bucket.list_blobs(prefix=prefix):
                 if not blob.name.endswith(".json"):

--- a/datadog_sync/utils/storage/gcs_bucket.py
+++ b/datadog_sync/utils/storage/gcs_bucket.py
@@ -5,6 +5,7 @@
 
 import json
 import logging
+from collections import defaultdict
 from typing import Dict, List, Optional, Tuple
 
 from google.api_core.exceptions import NotFound
@@ -66,8 +67,6 @@ class GCSBucket(BaseStorage):
 
     def _list_and_load(self, base_prefix: str, resource_types, label: str):
         """List and load GCS blobs, optionally scoped to resource_types."""
-        from collections import defaultdict
-
         result = defaultdict(dict)
         prefixes = [f"{base_prefix}/{rt}." for rt in resource_types] if resource_types is not None else [base_prefix]
         for prefix in prefixes:
@@ -90,6 +89,7 @@ class GCSBucket(BaseStorage):
             for resource_type, resource_data in data.source.items():
                 base_key = f"{self.source_resources_path}/{resource_type}"
                 if self.resource_per_file:
+                    self._check_id_collisions(resource_data, resource_type)
                     for _id, resource in resource_data.items():
                         safe_id = self._sanitize_id_for_filename(_id)
                         key = f"{base_key}.{safe_id}.json"
@@ -104,6 +104,7 @@ class GCSBucket(BaseStorage):
             for resource_type, resource_data in data.destination.items():
                 base_key = f"{self.destination_resources_path}/{resource_type}"
                 if self.resource_per_file:
+                    self._check_id_collisions(resource_data, resource_type)
                     for _id, resource in resource_data.items():
                         safe_id = self._sanitize_id_for_filename(_id)
                         key = f"{base_key}.{safe_id}.json"
@@ -127,6 +128,11 @@ class GCSBucket(BaseStorage):
 
     def get_by_ids(self, origin: Origin, exact_ids: Dict[str, List[str]]) -> StorageData:
         """Load specific resources by ID without listing. Constructs keys directly."""
+        if not self.resource_per_file:
+            raise ValueError(
+                "get_by_ids() requires --resource-per-file. "
+                "Re-run with --resource-per-file enabled."
+            )
         data = StorageData()
         for resource_type, ids in exact_ids.items():
             for resource_id in ids:

--- a/datadog_sync/utils/storage/gcs_bucket.py
+++ b/datadog_sync/utils/storage/gcs_bucket.py
@@ -129,10 +129,7 @@ class GCSBucket(BaseStorage):
     def get_by_ids(self, origin: Origin, exact_ids: Dict[str, List[str]]) -> StorageData:
         """Load specific resources by ID without listing. Constructs keys directly."""
         if not self.resource_per_file:
-            raise ValueError(
-                "get_by_ids() requires --resource-per-file. "
-                "Re-run with --resource-per-file enabled."
-            )
+            raise ValueError("get_by_ids() requires --resource-per-file. " "Re-run with --resource-per-file enabled.")
         data = StorageData()
         for resource_type, ids in exact_ids.items():
             for resource_id in ids:

--- a/datadog_sync/utils/storage/gcs_bucket.py
+++ b/datadog_sync/utils/storage/gcs_bucket.py
@@ -89,8 +89,10 @@ class GCSBucket(BaseStorage):
             for resource_type, resource_data in data.source.items():
                 base_key = f"{self.source_resources_path}/{resource_type}"
                 if self.resource_per_file:
-                    self._check_id_collisions(resource_data, resource_type)
+                    skip_ids = self._check_id_collisions(resource_data, resource_type)
                     for _id, resource in resource_data.items():
+                        if _id in skip_ids:
+                            continue
                         safe_id = self._sanitize_id_for_filename(_id)
                         key = f"{base_key}.{safe_id}.json"
                         self.bucket.blob(key).upload_from_string(
@@ -104,8 +106,10 @@ class GCSBucket(BaseStorage):
             for resource_type, resource_data in data.destination.items():
                 base_key = f"{self.destination_resources_path}/{resource_type}"
                 if self.resource_per_file:
-                    self._check_id_collisions(resource_data, resource_type)
+                    skip_ids = self._check_id_collisions(resource_data, resource_type)
                     for _id, resource in resource_data.items():
+                        if _id in skip_ids:
+                            continue
                         safe_id = self._sanitize_id_for_filename(_id)
                         key = f"{base_key}.{safe_id}.json"
                         self.bucket.blob(key).upload_from_string(

--- a/datadog_sync/utils/storage/gcs_bucket.py
+++ b/datadog_sync/utils/storage/gcs_bucket.py
@@ -5,6 +5,7 @@
 
 import json
 import logging
+from typing import Dict, List, Optional, Tuple
 
 from google.api_core.exceptions import NotFound
 from google.cloud import storage as gcs_storage
@@ -51,35 +52,40 @@ class GCSBucket(BaseStorage):
             raise ValueError("GCS bucket name is required")
         self.bucket = self.client.bucket(bucket_name)
 
-    def get(self, origin: Origin) -> StorageData:
+    def get(self, origin: Origin, resource_types=None) -> StorageData:
         log.info("GCS get called")
         data = StorageData()
 
         if origin in [Origin.SOURCE, Origin.ALL]:
-            for blob in self.bucket.list_blobs(prefix=self.source_resources_path):
-                if blob.name.endswith(".json"):
-                    resource_type = blob.name.split(".")[0].split("/")[-1]
-                    try:
-                        content = self.bucket.blob(blob.name).download_as_text()
-                        data.source[resource_type].update(json.loads(content))
-                    except json.decoder.JSONDecodeError:
-                        log.warning(f"invalid json in gcs source resource file: {resource_type}")
-                    except NotFound:
-                        log.warning(f"gcs source resource file not found (may have been deleted): {blob.name}")
+            data.source = self._list_and_load(self.source_resources_path, resource_types, "source")
 
         if origin in [Origin.DESTINATION, Origin.ALL]:
-            for blob in self.bucket.list_blobs(prefix=self.destination_resources_path):
-                if blob.name.endswith(".json"):
-                    resource_type = blob.name.split(".")[0].split("/")[-1]
-                    try:
-                        content = self.bucket.blob(blob.name).download_as_text()
-                        data.destination[resource_type].update(json.loads(content))
-                    except json.decoder.JSONDecodeError:
-                        log.warning(f"invalid json in gcs destination resource file: {resource_type}")
-                    except NotFound:
-                        log.warning(f"gcs destination resource file not found (may have been deleted): {blob.name}")
+            data.destination = self._list_and_load(self.destination_resources_path, resource_types, "destination")
 
         return data
+
+    def _list_and_load(self, base_prefix: str, resource_types, label: str):
+        """List and load GCS blobs, optionally scoped to resource_types."""
+        from collections import defaultdict
+        result = defaultdict(dict)
+        prefixes = (
+            [f"{base_prefix}/{rt}." for rt in resource_types]
+            if resource_types is not None
+            else [base_prefix]
+        )
+        for prefix in prefixes:
+            for blob in self.bucket.list_blobs(prefix=prefix):
+                if not blob.name.endswith(".json"):
+                    continue
+                resource_type = blob.name.split(".")[0].split("/")[-1]
+                try:
+                    content = self.bucket.blob(blob.name).download_as_text()
+                    result[resource_type].update(json.loads(content))
+                except json.decoder.JSONDecodeError:
+                    log.warning(f"invalid json in gcs {label} resource file: {resource_type}")
+                except NotFound:
+                    log.warning(f"gcs {label} resource file not found (may have been deleted): {blob.name}")
+        return result
 
     def put(self, origin: Origin, data: StorageData) -> None:
         log.info("GCS put called")
@@ -88,7 +94,8 @@ class GCSBucket(BaseStorage):
                 base_key = f"{self.source_resources_path}/{resource_type}"
                 if self.resource_per_file:
                     for _id, resource in resource_data.items():
-                        key = f"{base_key}.{_id}.json"
+                        safe_id = self._sanitize_id_for_filename(_id)
+                        key = f"{base_key}.{safe_id}.json"
                         self.bucket.blob(key).upload_from_string(
                             json.dumps({_id: resource}), content_type="application/json"
                         )
@@ -101,10 +108,48 @@ class GCSBucket(BaseStorage):
                 base_key = f"{self.destination_resources_path}/{resource_type}"
                 if self.resource_per_file:
                     for _id, resource in resource_data.items():
-                        key = f"{base_key}.{_id}.json"
+                        safe_id = self._sanitize_id_for_filename(_id)
+                        key = f"{base_key}.{safe_id}.json"
                         self.bucket.blob(key).upload_from_string(
                             json.dumps({_id: resource}), content_type="application/json"
                         )
                 else:
                     key = f"{base_key}.json"
                     self.bucket.blob(key).upload_from_string(json.dumps(resource_data), content_type="application/json")
+
+    def _try_get_blob(self, key: str) -> Optional[Dict]:
+        """Fetch and parse one GCS blob. Returns None on NotFound."""
+        try:
+            content = self.bucket.blob(key).download_as_text()
+            return json.loads(content)
+        except NotFound:
+            return None
+        except json.decoder.JSONDecodeError:
+            log.warning(f"invalid json in gcs resource file: {key}")
+            return None
+
+    def get_by_ids(self, origin: Origin, exact_ids: Dict[str, List[str]]) -> StorageData:
+        """Load specific resources by ID without listing. Constructs keys directly."""
+        data = StorageData()
+        for resource_type, ids in exact_ids.items():
+            for resource_id in ids:
+                src, dst = self.get_single(resource_type, resource_id)
+                if origin in [Origin.SOURCE, Origin.ALL] and src is not None:
+                    data.source[resource_type][resource_id] = src
+                if origin in [Origin.DESTINATION, Origin.ALL] and dst is not None:
+                    data.destination[resource_type][resource_id] = dst
+        return data
+
+    def get_single(self, resource_type: str, resource_id: str) -> Tuple[Optional[Dict], Optional[Dict]]:
+        """Load one resource's source and destination state by ID."""
+        safe_id = self._sanitize_id_for_filename(resource_id)
+
+        src_key = f"{self.source_resources_path}/{resource_type}.{safe_id}.json"
+        src_obj = self._try_get_blob(src_key)
+        src_data = src_obj.get(resource_id) if src_obj else None
+
+        dst_key = f"{self.destination_resources_path}/{resource_type}.{safe_id}.json"
+        dst_obj = self._try_get_blob(dst_key)
+        dst_data = dst_obj.get(resource_id) if dst_obj else None
+
+        return src_data, dst_data

--- a/datadog_sync/utils/storage/local_file.py
+++ b/datadog_sync/utils/storage/local_file.py
@@ -6,6 +6,7 @@
 import json
 import logging
 import os
+from typing import Dict, List, Optional, Tuple
 
 from datadog_sync.constants import (
     Origin,
@@ -36,28 +37,34 @@ class LocalFile(BaseStorage):
         self.source_resources_path = source_resources_path
         self.destination_resources_path = destination_resources_path
 
-    def get(self, origin: Origin) -> StorageData:
+    def get(self, origin: Origin, resource_types=None) -> StorageData:
         data = StorageData()
 
         if origin in [Origin.SOURCE, Origin.ALL] and os.path.exists(self.source_resources_path):
             for file in os.listdir(self.source_resources_path):
-                if file.endswith(".json"):
-                    resource_type = file.split(".")[0]
-                    with open(self.source_resources_path + f"/{file}", "r", encoding="utf-8") as input_file:
-                        try:
-                            data.source[resource_type].update(json.load(input_file))
-                        except json.decoder.JSONDecodeError:
-                            log.warning(f"invalid json in source resource file: {file}")
+                if not file.endswith(".json"):
+                    continue
+                resource_type = file.split(".")[0]
+                if resource_types is not None and resource_type not in resource_types:
+                    continue
+                with open(self.source_resources_path + f"/{file}", "r", encoding="utf-8") as input_file:
+                    try:
+                        data.source[resource_type].update(json.load(input_file))
+                    except json.decoder.JSONDecodeError:
+                        log.warning(f"invalid json in source resource file: {file}")
 
         if origin in [Origin.DESTINATION, Origin.ALL] and os.path.exists(self.destination_resources_path):
             for file in os.listdir(self.destination_resources_path):
-                if file.endswith(".json"):
-                    resource_type = file.split(".")[0]
-                    with open(self.destination_resources_path + f"/{file}", "r", encoding="utf-8") as input_file:
-                        try:
-                            data.destination[resource_type].update(json.load(input_file))
-                        except json.decoder.JSONDecodeError:
-                            log.warning(f"invalid json in destination resource file: {file}")
+                if not file.endswith(".json"):
+                    continue
+                resource_type = file.split(".")[0]
+                if resource_types is not None and resource_type not in resource_types:
+                    continue
+                with open(self.destination_resources_path + f"/{file}", "r", encoding="utf-8") as input_file:
+                    try:
+                        data.destination[resource_type].update(json.load(input_file))
+                    except json.decoder.JSONDecodeError:
+                        log.warning(f"invalid json in destination resource file: {file}")
 
         return data
 
@@ -76,7 +83,8 @@ class LocalFile(BaseStorage):
                 base_filename = f"{self.source_resources_path}/{resource_type}"
                 if self.resource_per_file:
                     for _id, resource in value.items():
-                        filename = f"{base_filename}.{_id.replace(':','.')}.json"  # windows can't handle ":"
+                        safe_id = self._sanitize_id_for_filename(_id)
+                        filename = f"{base_filename}.{safe_id}.json"
                         with open(filename, "w+", encoding="utf-8") as out_file:
                             json.dump({_id: resource}, out_file)
                 else:
@@ -89,10 +97,54 @@ class LocalFile(BaseStorage):
                 base_filename = f"{self.destination_resources_path}/{resource_type}"
                 if self.resource_per_file:
                     for _id, resource in value.items():
-                        filename = f"{base_filename}.{_id.replace(':','.')}.json"  # windows can't handle ":"
+                        safe_id = self._sanitize_id_for_filename(_id)
+                        filename = f"{base_filename}.{safe_id}.json"
                         with open(filename, "w+", encoding="utf-8") as out_file:
                             json.dump({_id: resource}, out_file)
                 else:
                     filename = f"{base_filename}.json"
                     with open(filename, "w+", encoding="utf-8") as out_file:
                         json.dump(value, out_file)
+
+    def get_by_ids(self, origin: Origin, exact_ids: Dict[str, List[str]]) -> StorageData:
+        """Load specific resources by ID. Constructs filenames directly without listing."""
+        data = StorageData()
+        for resource_type, ids in exact_ids.items():
+            for resource_id in ids:
+                src, dst = self.get_single(resource_type, resource_id)
+                if origin in [Origin.SOURCE, Origin.ALL] and src is not None:
+                    data.source[resource_type][resource_id] = src
+                if origin in [Origin.DESTINATION, Origin.ALL] and dst is not None:
+                    data.destination[resource_type][resource_id] = dst
+        return data
+
+    def get_single(self, resource_type: str, resource_id: str) -> Tuple[Optional[Dict], Optional[Dict]]:
+        """Load one resource's source and destination state by ID.
+
+        Constructs the filename using the sanitized ID, reads the file, and
+        returns the content keyed by the original (unsanitized) resource_id.
+        Returns (None, None) if the file does not exist.
+        """
+        safe_id = self._sanitize_id_for_filename(resource_id)
+
+        src_data = None
+        src_path = f"{self.source_resources_path}/{resource_type}.{safe_id}.json"
+        if os.path.exists(src_path):
+            try:
+                with open(src_path, "r", encoding="utf-8") as f:
+                    content = json.load(f)
+                    src_data = content.get(resource_id)
+            except (json.decoder.JSONDecodeError, FileNotFoundError):
+                log.warning(f"invalid json or missing source file: {src_path}")
+
+        dst_data = None
+        dst_path = f"{self.destination_resources_path}/{resource_type}.{safe_id}.json"
+        if os.path.exists(dst_path):
+            try:
+                with open(dst_path, "r", encoding="utf-8") as f:
+                    content = json.load(f)
+                    dst_data = content.get(resource_id)
+            except (json.decoder.JSONDecodeError, FileNotFoundError):
+                log.warning(f"invalid json or missing destination file: {dst_path}")
+
+        return src_data, dst_data

--- a/datadog_sync/utils/storage/local_file.py
+++ b/datadog_sync/utils/storage/local_file.py
@@ -111,10 +111,7 @@ class LocalFile(BaseStorage):
     def get_by_ids(self, origin: Origin, exact_ids: Dict[str, List[str]]) -> StorageData:
         """Load specific resources by ID. Constructs filenames directly without listing."""
         if not self.resource_per_file:
-            raise ValueError(
-                "get_by_ids() requires --resource-per-file. "
-                "Re-run with --resource-per-file enabled."
-            )
+            raise ValueError("get_by_ids() requires --resource-per-file. " "Re-run with --resource-per-file enabled.")
         data = StorageData()
         for resource_type, ids in exact_ids.items():
             for resource_id in ids:

--- a/datadog_sync/utils/storage/local_file.py
+++ b/datadog_sync/utils/storage/local_file.py
@@ -82,6 +82,7 @@ class LocalFile(BaseStorage):
             for resource_type, value in data.source.items():
                 base_filename = f"{self.source_resources_path}/{resource_type}"
                 if self.resource_per_file:
+                    self._check_id_collisions(value, resource_type)
                     for _id, resource in value.items():
                         safe_id = self._sanitize_id_for_filename(_id)
                         filename = f"{base_filename}.{safe_id}.json"
@@ -96,6 +97,7 @@ class LocalFile(BaseStorage):
             for resource_type, value in data.destination.items():
                 base_filename = f"{self.destination_resources_path}/{resource_type}"
                 if self.resource_per_file:
+                    self._check_id_collisions(value, resource_type)
                     for _id, resource in value.items():
                         safe_id = self._sanitize_id_for_filename(_id)
                         filename = f"{base_filename}.{safe_id}.json"
@@ -108,6 +110,11 @@ class LocalFile(BaseStorage):
 
     def get_by_ids(self, origin: Origin, exact_ids: Dict[str, List[str]]) -> StorageData:
         """Load specific resources by ID. Constructs filenames directly without listing."""
+        if not self.resource_per_file:
+            raise ValueError(
+                "get_by_ids() requires --resource-per-file. "
+                "Re-run with --resource-per-file enabled."
+            )
         data = StorageData()
         for resource_type, ids in exact_ids.items():
             for resource_id in ids:

--- a/datadog_sync/utils/storage/local_file.py
+++ b/datadog_sync/utils/storage/local_file.py
@@ -82,8 +82,10 @@ class LocalFile(BaseStorage):
             for resource_type, value in data.source.items():
                 base_filename = f"{self.source_resources_path}/{resource_type}"
                 if self.resource_per_file:
-                    self._check_id_collisions(value, resource_type)
+                    skip_ids = self._check_id_collisions(value, resource_type)
                     for _id, resource in value.items():
+                        if _id in skip_ids:
+                            continue
                         safe_id = self._sanitize_id_for_filename(_id)
                         filename = f"{base_filename}.{safe_id}.json"
                         with open(filename, "w+", encoding="utf-8") as out_file:
@@ -97,8 +99,10 @@ class LocalFile(BaseStorage):
             for resource_type, value in data.destination.items():
                 base_filename = f"{self.destination_resources_path}/{resource_type}"
                 if self.resource_per_file:
-                    self._check_id_collisions(value, resource_type)
+                    skip_ids = self._check_id_collisions(value, resource_type)
                     for _id, resource in value.items():
+                        if _id in skip_ids:
+                            continue
                         safe_id = self._sanitize_id_for_filename(_id)
                         filename = f"{base_filename}.{safe_id}.json"
                         with open(filename, "w+", encoding="utf-8") as out_file:

--- a/tests/unit/test_storage_sanitization.py
+++ b/tests/unit/test_storage_sanitization.py
@@ -3,7 +3,6 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019 Datadog, Inc.
 
-import json
 from pathlib import Path
 
 import pytest

--- a/tests/unit/test_storage_sanitization.py
+++ b/tests/unit/test_storage_sanitization.py
@@ -92,3 +92,80 @@ class TestRoundTripColonId:
 
         src, dst = backend.get_single("monitors", "12345")
         assert src == {"id": "12345", "name": "My Monitor"}
+
+
+class TestIdCollisionDetection:
+    def test_collision_is_logged_as_error(self, tmp_path, caplog):
+        """Two IDs that differ only by ':' vs '.' collide on the same filename and trigger an error log."""
+        import logging
+
+        src_path = str(tmp_path / "source")
+        dst_path = str(tmp_path / "dest")
+        Path(src_path).mkdir()
+        Path(dst_path).mkdir()
+
+        backend = LocalFile(
+            source_resources_path=src_path,
+            destination_resources_path=dst_path,
+            resource_per_file=True,
+        )
+        data = StorageData()
+        data.source["monitors"]["foo:bar"] = {"id": "foo:bar"}
+        data.source["monitors"]["foo.bar"] = {"id": "foo.bar"}
+
+        with caplog.at_level(logging.ERROR):
+            backend.put(Origin.SOURCE, data)
+
+        assert any("foo:bar" in r.message and "foo.bar" in r.message for r in caplog.records), (
+            "Expected a collision error mentioning both conflicting IDs"
+        )
+
+    def test_no_collision_no_error(self, tmp_path, caplog):
+        """IDs that don't collide produce no error logs."""
+        import logging
+
+        src_path = str(tmp_path / "source")
+        dst_path = str(tmp_path / "dest")
+        Path(src_path).mkdir()
+        Path(dst_path).mkdir()
+
+        backend = LocalFile(
+            source_resources_path=src_path,
+            destination_resources_path=dst_path,
+            resource_per_file=True,
+        )
+        data = StorageData()
+        data.source["monitors"]["abc-123"] = {"id": "abc-123"}
+        data.source["monitors"]["def-456"] = {"id": "def-456"}
+
+        with caplog.at_level(logging.ERROR):
+            backend.put(Origin.SOURCE, data)
+
+        assert not caplog.records
+
+
+class TestGetByIdsRequiresResourcePerFile:
+    def test_raises_when_resource_per_file_false(self, tmp_path):
+        """get_by_ids() must raise ValueError when resource_per_file=False."""
+        backend = LocalFile(
+            source_resources_path=str(tmp_path / "source"),
+            destination_resources_path=str(tmp_path / "dest"),
+            resource_per_file=False,
+        )
+        with pytest.raises(ValueError, match="--resource-per-file"):
+            backend.get_by_ids(Origin.SOURCE, {"dashboards": ["123"]})
+
+    def test_succeeds_when_resource_per_file_true(self, tmp_path):
+        """get_by_ids() does not raise when resource_per_file=True."""
+        src_path = str(tmp_path / "source")
+        Path(src_path).mkdir()
+        Path(str(tmp_path / "dest")).mkdir()
+
+        backend = LocalFile(
+            source_resources_path=src_path,
+            destination_resources_path=str(tmp_path / "dest"),
+            resource_per_file=True,
+        )
+        # No files exist — should return empty StorageData without raising
+        result = backend.get_by_ids(Origin.SOURCE, {"dashboards": ["123"]})
+        assert result.source == {} or "dashboards" not in result.source or result.source["dashboards"] == {}

--- a/tests/unit/test_storage_sanitization.py
+++ b/tests/unit/test_storage_sanitization.py
@@ -116,9 +116,9 @@ class TestIdCollisionDetection:
         with caplog.at_level(logging.ERROR):
             backend.put(Origin.SOURCE, data)
 
-        assert any("foo:bar" in r.message and "foo.bar" in r.message for r in caplog.records), (
-            "Expected a collision error mentioning both conflicting IDs"
-        )
+        assert any(
+            "foo:bar" in r.message and "foo.bar" in r.message for r in caplog.records
+        ), "Expected a collision error mentioning both conflicting IDs"
 
     def test_no_collision_no_error(self, tmp_path, caplog):
         """IDs that don't collide produce no error logs."""

--- a/tests/unit/test_storage_sanitization.py
+++ b/tests/unit/test_storage_sanitization.py
@@ -95,8 +95,13 @@ class TestRoundTripColonId:
 
 
 class TestIdCollisionDetection:
-    def test_collision_is_logged_as_error(self, tmp_path, caplog):
-        """Two IDs that differ only by ':' vs '.' collide on the same filename and trigger an error log."""
+    def test_collision_is_logged_and_skipped(self, tmp_path, caplog):
+        """Two IDs that differ only by ':' vs '.' collide on the same filename.
+
+        The first ID wins (is written); the second is skipped and an error is logged.
+        The file on disk must contain the first ID's data, not the second's.
+        """
+        import json
         import logging
 
         src_path = str(tmp_path / "source")
@@ -119,6 +124,15 @@ class TestIdCollisionDetection:
         assert any(
             "foo:bar" in r.message and "foo.bar" in r.message for r in caplog.records
         ), "Expected a collision error mentioning both conflicting IDs"
+
+        # Only one file must exist — the second write must have been skipped
+        files = list(Path(src_path).iterdir())
+        assert len(files) == 1, f"Expected 1 file, got {[f.name for f in files]}"
+
+        # The file must contain the first ID's data (foo:bar wins, foo.bar is skipped)
+        content = json.loads(files[0].read_text())
+        assert "foo:bar" in content, "First ID (foo:bar) must be written"
+        assert "foo.bar" not in content, "Second ID (foo.bar) must be skipped"
 
     def test_no_collision_no_error(self, tmp_path, caplog):
         """IDs that don't collide produce no error logs."""

--- a/tests/unit/test_storage_sanitization.py
+++ b/tests/unit/test_storage_sanitization.py
@@ -1,0 +1,95 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+import json
+from pathlib import Path
+
+import pytest
+
+from datadog_sync.constants import Origin
+from datadog_sync.utils.storage._base_storage import BaseStorage, StorageData
+from datadog_sync.utils.storage.local_file import LocalFile
+
+
+class TestSanitizeIdForFilename:
+    def test_sanitize_id_with_colon(self):
+        assert BaseStorage._sanitize_id_for_filename("abc:123") == "abc.123"
+
+    def test_sanitize_id_multiple_colons(self):
+        assert BaseStorage._sanitize_id_for_filename("a:b:c") == "a.b.c"
+
+    def test_sanitize_id_no_colons(self):
+        assert BaseStorage._sanitize_id_for_filename("abc-123_def") == "abc-123_def"
+
+    def test_sanitize_id_empty(self):
+        assert BaseStorage._sanitize_id_for_filename("") == ""
+
+    def test_sanitize_id_non_string_raises(self):
+        with pytest.raises(AttributeError):
+            BaseStorage._sanitize_id_for_filename(None)
+
+    def test_all_backends_produce_same_sanitized_segment(self):
+        resource_id = "resource:123"
+        expected_segment = "resource.123"
+        assert BaseStorage._sanitize_id_for_filename(resource_id) == expected_segment
+
+    def test_sanitize_id_uuid_unchanged(self):
+        """UUIDs (most Datadog resource IDs) are not modified."""
+        uuid = "550e8400-e29b-41d4-a716-446655440000"
+        assert BaseStorage._sanitize_id_for_filename(uuid) == uuid
+
+    def test_sanitize_id_dots_unchanged(self):
+        """Dots in IDs are preserved — only colons are replaced."""
+        assert BaseStorage._sanitize_id_for_filename("abc.def") == "abc.def"
+
+
+class TestRoundTripColonId:
+    def test_round_trip_colon_id_put_then_get_single(self, tmp_path):
+        """Round-trip: put() writes sanitized filename; get_single() reads back via original ID."""
+        src_path = str(tmp_path / "source")
+        dst_path = str(tmp_path / "dest")
+        Path(src_path).mkdir()
+        Path(dst_path).mkdir()
+
+        backend = LocalFile(
+            source_resources_path=src_path,
+            destination_resources_path=dst_path,
+            resource_per_file=True,
+        )
+        data = StorageData()
+        data.source["dashboards"]["dash:123"] = {"id": "dash:123", "title": "Test"}
+        backend.put(Origin.SOURCE, data)
+
+        # Filename must use sanitized ID
+        files = list(Path(src_path).iterdir())
+        assert any("dash.123" in f.name for f in files), "Sanitized filename expected"
+        assert not any("dash:123" in f.name for f in files), "Unsanitized filename must not exist"
+
+        # get_single() must return content using original (unsanitized) ID
+        src, dst = backend.get_single("dashboards", "dash:123")
+        assert src == {"id": "dash:123", "title": "Test"}
+        assert dst is None
+
+    def test_round_trip_no_colon_id_unchanged(self, tmp_path):
+        """IDs without colons are unaffected by sanitization."""
+        src_path = str(tmp_path / "source")
+        dst_path = str(tmp_path / "dest")
+        Path(src_path).mkdir()
+        Path(dst_path).mkdir()
+
+        backend = LocalFile(
+            source_resources_path=src_path,
+            destination_resources_path=dst_path,
+            resource_per_file=True,
+        )
+        data = StorageData()
+        data.source["monitors"]["12345"] = {"id": "12345", "name": "My Monitor"}
+        backend.put(Origin.SOURCE, data)
+
+        files = list(Path(src_path).iterdir())
+        assert any("monitors.12345.json" == f.name for f in files)
+
+        src, dst = backend.get_single("monitors", "12345")
+        assert src == {"id": "12345", "name": "My Monitor"}


### PR DESCRIPTION
## Summary

- Adds `BaseStorage._sanitize_id_for_filename()` shared static method that replaces `:` with `.` for cross-platform filename safety
- Fixes inconsistency where `LocalFile` was sanitizing colons in filenames but S3/GCS/Azure were writing raw IDs (potentially including colons)
- State files are now portable between backends
- Adds `BaseStorage._check_id_collisions()` that detects when two resource IDs sanitize to the same filename — logs an error and returns the colliding IDs so callers can skip them, preventing silent overwrites
- Adds abstract `get_by_ids()` and `get_single()` methods to `BaseStorage` with implementations in all four backends (needed by the upcoming `--minimize-reads` feature); both require `--resource-per-file`

**Why colons are problematic:**
- GCS: [explicitly recommends avoiding `:`](https://cloud.google.com/storage/docs/objects)
- S3: [requires special handling in some URL contexts](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html)
- Azure: [reserved URL characters must be percent-encoded](https://learn.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata)
- Windows: colons are invalid in filenames

**Migration:** Existing S3/GCS/Azure state files with `:` in keys will be orphaned. Next `import` run rewrites them with sanitized keys. Since most Datadog resource IDs are UUIDs or integers without colons, practical impact is minimal.

## Test plan
- [x] `pytest tests/unit/test_storage_sanitization.py` — 14 tests, all pass
- [x] `pytest tests/unit/` — full regression, 350 tests pass
- [x] Round-trip test: `test_round_trip_colon_id_put_then_get_single` verifies sanitized filename on disk, read back via original ID
- [x] Collision test: `test_collision_is_logged_and_skipped` verifies only one file is written (first ID wins, second is skipped) and error is logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)