### PR TITLE
feat(storage): add list_filenames, delete, delete_many primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+* feat(storage): per-resource file enumeration and deletion (`list_filenames`, `delete`, `delete_many`) on all storage backends — internal API supporting an upcoming `prune` command.
+
 ## 4.1.0 / 2026-04-27
 
 ### Fixed

--- a/datadog_sync/utils/storage/_base_storage.py
+++ b/datadog_sync/utils/storage/_base_storage.py
@@ -7,7 +7,7 @@ import logging
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 from datadog_sync.constants import LOGGER_NAME, Origin
 
@@ -121,3 +121,27 @@ class BaseStorage(ABC):
     def put(self, origin, data: StorageData) -> None:
         """Write resources into storage"""
         pass
+
+    def list_filenames(self, origin: Origin, resource_type: str) -> Set[str]:
+        """Return full filenames (no path) under <base>/<resource_type>.*.json for the origin.
+
+        Concrete default raises NotImplementedError so out-of-tree backends not yet
+        updated for prune fail loudly rather than appearing to find no stale files.
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not implement list_filenames")
+
+    def delete(self, origin: Origin, filename: str) -> None:
+        """Delete a single per-resource file by its full filename. No-op if absent."""
+        raise NotImplementedError(f"{type(self).__name__} does not implement delete")
+
+    def delete_many(self, origin: Origin, filenames: Iterable[str]) -> Dict[str, str]:
+        """Delete multiple files; returns {filename: "ok" | "error: <type>: <msg>"}.
+        Default loops self.delete(); backends like S3 may override with batched APIs."""
+        results: Dict[str, str] = {}
+        for fn in filenames:
+            try:
+                self.delete(origin, fn)
+                results[fn] = "ok"
+            except Exception as e:
+                results[fn] = f"error: {type(e).__name__}: {e}"
+        return results

--- a/datadog_sync/utils/storage/_base_storage.py
+++ b/datadog_sync/utils/storage/_base_storage.py
@@ -69,6 +69,13 @@ class BaseStorage(ABC):
                 seen[safe] = _id
         return skip
 
+    @staticmethod
+    def _is_per_resource_filename(resource_type: str, filename: str) -> bool:
+        """Return True for <resource_type>.<id>.json, excluding <resource_type>.json."""
+        prefix = f"{resource_type}."
+        suffix = ".json"
+        return filename.startswith(prefix) and filename.endswith(suffix) and len(filename) > len(prefix) + len(suffix)
+
     @abstractmethod
     def get(self, origin, resource_types=None) -> StorageData:
         """Get resources state from storage.

--- a/datadog_sync/utils/storage/aws_s3_bucket.py
+++ b/datadog_sync/utils/storage/aws_s3_bucket.py
@@ -6,7 +6,7 @@
 import json
 import logging
 from collections import defaultdict
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Set, Tuple
 
 import boto3
 from botocore.exceptions import ClientError
@@ -161,6 +161,41 @@ class AWSS3Bucket(BaseStorage):
                         Bucket=self.bucket_name,
                         Key=key,
                     )
+
+    def _path_for(self, origin: Origin) -> str:
+        if origin == Origin.SOURCE:
+            return self.source_resources_path
+        if origin == Origin.DESTINATION:
+            return self.destination_resources_path
+        raise ValueError(f"_path_for() requires SOURCE or DESTINATION, got {origin}")
+
+    def list_filenames(self, origin: Origin, resource_type: str) -> Set[str]:
+        base = self._path_for(origin)
+        prefix = f"{base}/{resource_type}."
+        result: Set[str] = set()
+        continuation_token = None
+        while True:
+            kwargs = {"Bucket": self.bucket_name, "Prefix": prefix}
+            if continuation_token:
+                kwargs["ContinuationToken"] = continuation_token
+            response = self.client.list_objects_v2(**kwargs)
+            for item in response.get("Contents", []):
+                key = item["Key"]
+                if not key.endswith(".json"):
+                    continue
+                result.add(key.split("/")[-1])
+            if response.get("IsTruncated"):
+                continuation_token = response.get("NextContinuationToken")
+            else:
+                break
+        return result
+
+    def delete(self, origin: Origin, filename: str) -> None:
+        # S3 delete_object is idempotent — succeeds even if the key is absent.
+        self.client.delete_object(
+            Bucket=self.bucket_name,
+            Key=f"{self._path_for(origin)}/{filename}",
+        )
 
     def _try_get_object(self, key: str) -> Optional[Dict]:
         """Fetch and parse one S3 object. Returns None on NotFound."""

--- a/datadog_sync/utils/storage/aws_s3_bucket.py
+++ b/datadog_sync/utils/storage/aws_s3_bucket.py
@@ -181,9 +181,10 @@ class AWSS3Bucket(BaseStorage):
             response = self.client.list_objects_v2(**kwargs)
             for item in response.get("Contents", []):
                 key = item["Key"]
-                if not key.endswith(".json"):
+                filename = key.split("/")[-1]
+                if not self._is_per_resource_filename(resource_type, filename):
                     continue
-                result.add(key.split("/")[-1])
+                result.add(filename)
             if response.get("IsTruncated"):
                 continuation_token = response.get("NextContinuationToken")
             else:

--- a/datadog_sync/utils/storage/azure_blob_container.py
+++ b/datadog_sync/utils/storage/azure_blob_container.py
@@ -6,7 +6,7 @@
 import json
 import logging
 from collections import defaultdict
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Set, Tuple
 
 from azure.core.exceptions import ResourceNotFoundError
 from azure.storage.blob import BlobServiceClient, ContainerClient
@@ -126,6 +126,29 @@ class AzureBlobContainer(BaseStorage):
                 else:
                     key = f"{base_key}.json"
                     self.container_client.upload_blob(name=key, data=json.dumps(resource_data), overwrite=True)
+
+    def _path_for(self, origin: Origin) -> str:
+        if origin == Origin.SOURCE:
+            return self.source_resources_path
+        if origin == Origin.DESTINATION:
+            return self.destination_resources_path
+        raise ValueError(f"_path_for() requires SOURCE or DESTINATION, got {origin}")
+
+    def list_filenames(self, origin: Origin, resource_type: str) -> Set[str]:
+        prefix = f"{self._path_for(origin)}/{resource_type}."
+        result: Set[str] = set()
+        for blob in self.container_client.list_blobs(name_starts_with=prefix):
+            if not blob.name.endswith(".json"):
+                continue
+            result.add(blob.name.split("/")[-1])
+        return result
+
+    def delete(self, origin: Origin, filename: str) -> None:
+        key = f"{self._path_for(origin)}/{filename}"
+        try:
+            self.container_client.delete_blob(key)
+        except ResourceNotFoundError:
+            pass  # idempotent
 
     def _try_get_blob(self, key: str) -> Optional[Dict]:
         """Fetch and parse one Azure blob. Returns None on ResourceNotFoundError."""

--- a/datadog_sync/utils/storage/azure_blob_container.py
+++ b/datadog_sync/utils/storage/azure_blob_container.py
@@ -138,9 +138,10 @@ class AzureBlobContainer(BaseStorage):
         prefix = f"{self._path_for(origin)}/{resource_type}."
         result: Set[str] = set()
         for blob in self.container_client.list_blobs(name_starts_with=prefix):
-            if not blob.name.endswith(".json"):
+            filename = blob.name.split("/")[-1]
+            if not self._is_per_resource_filename(resource_type, filename):
                 continue
-            result.add(blob.name.split("/")[-1])
+            result.add(filename)
         return result
 
     def delete(self, origin: Origin, filename: str) -> None:

--- a/datadog_sync/utils/storage/gcs_bucket.py
+++ b/datadog_sync/utils/storage/gcs_bucket.py
@@ -130,9 +130,10 @@ class GCSBucket(BaseStorage):
         prefix = f"{self._path_for(origin)}/{resource_type}."
         result: Set[str] = set()
         for blob in self.bucket.list_blobs(prefix=prefix):
-            if not blob.name.endswith(".json"):
+            filename = blob.name.split("/")[-1]
+            if not self._is_per_resource_filename(resource_type, filename):
                 continue
-            result.add(blob.name.split("/")[-1])
+            result.add(filename)
         return result
 
     def delete(self, origin: Origin, filename: str) -> None:

--- a/datadog_sync/utils/storage/gcs_bucket.py
+++ b/datadog_sync/utils/storage/gcs_bucket.py
@@ -6,7 +6,7 @@
 import json
 import logging
 from collections import defaultdict
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Set, Tuple
 
 from google.api_core.exceptions import NotFound
 from google.cloud import storage as gcs_storage
@@ -118,6 +118,29 @@ class GCSBucket(BaseStorage):
                 else:
                     key = f"{base_key}.json"
                     self.bucket.blob(key).upload_from_string(json.dumps(resource_data), content_type="application/json")
+
+    def _path_for(self, origin: Origin) -> str:
+        if origin == Origin.SOURCE:
+            return self.source_resources_path
+        if origin == Origin.DESTINATION:
+            return self.destination_resources_path
+        raise ValueError(f"_path_for() requires SOURCE or DESTINATION, got {origin}")
+
+    def list_filenames(self, origin: Origin, resource_type: str) -> Set[str]:
+        prefix = f"{self._path_for(origin)}/{resource_type}."
+        result: Set[str] = set()
+        for blob in self.bucket.list_blobs(prefix=prefix):
+            if not blob.name.endswith(".json"):
+                continue
+            result.add(blob.name.split("/")[-1])
+        return result
+
+    def delete(self, origin: Origin, filename: str) -> None:
+        key = f"{self._path_for(origin)}/{filename}"
+        try:
+            self.bucket.blob(key).delete()
+        except NotFound:
+            pass  # idempotent
 
     def _try_get_blob(self, key: str) -> Optional[Dict]:
         """Fetch and parse one GCS blob. Returns None on NotFound."""

--- a/datadog_sync/utils/storage/local_file.py
+++ b/datadog_sync/utils/storage/local_file.py
@@ -6,7 +6,7 @@
 import json
 import logging
 import os
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Set, Tuple
 
 from datadog_sync.constants import (
     Origin,
@@ -111,6 +111,27 @@ class LocalFile(BaseStorage):
                     filename = f"{base_filename}.json"
                     with open(filename, "w+", encoding="utf-8") as out_file:
                         json.dump(value, out_file)
+
+    def _path_for(self, origin: Origin) -> str:
+        if origin == Origin.SOURCE:
+            return self.source_resources_path
+        if origin == Origin.DESTINATION:
+            return self.destination_resources_path
+        raise ValueError(f"_path_for() requires SOURCE or DESTINATION, got {origin}")
+
+    def list_filenames(self, origin: Origin, resource_type: str) -> Set[str]:
+        base = self._path_for(origin)
+        if not os.path.exists(base):
+            return set()
+        prefix = f"{resource_type}."
+        return {f for f in os.listdir(base) if f.startswith(prefix) and f.endswith(".json")}
+
+    def delete(self, origin: Origin, filename: str) -> None:
+        path = f"{self._path_for(origin)}/{filename}"
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass  # idempotent
 
     def get_single(self, resource_type: str, resource_id: str) -> Tuple[Optional[Dict], Optional[Dict]]:
         """Load one resource's source and destination state by ID.

--- a/datadog_sync/utils/storage/local_file.py
+++ b/datadog_sync/utils/storage/local_file.py
@@ -123,8 +123,7 @@ class LocalFile(BaseStorage):
         base = self._path_for(origin)
         if not os.path.exists(base):
             return set()
-        prefix = f"{resource_type}."
-        return {f for f in os.listdir(base) if f.startswith(prefix) and f.endswith(".json")}
+        return {f for f in os.listdir(base) if self._is_per_resource_filename(resource_type, f)}
 
     def delete(self, origin: Origin, filename: str) -> None:
         path = f"{self._path_for(origin)}/{filename}"

--- a/tests/unit/test_storage_delete.py
+++ b/tests/unit/test_storage_delete.py
@@ -1,0 +1,267 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from azure.core.exceptions import ResourceNotFoundError
+from google.api_core.exceptions import NotFound
+
+from datadog_sync.constants import Origin
+from datadog_sync.utils.storage._base_storage import BaseStorage
+from datadog_sync.utils.storage.aws_s3_bucket import AWSS3Bucket
+from datadog_sync.utils.storage.azure_blob_container import AzureBlobContainer
+from datadog_sync.utils.storage.gcs_bucket import GCSBucket
+from datadog_sync.utils.storage.local_file import LocalFile
+
+
+def _make_local(tmp_path):
+    src = tmp_path / "source"
+    dst = tmp_path / "dest"
+    src.mkdir()
+    dst.mkdir()
+    return (
+        LocalFile(
+            source_resources_path=str(src),
+            destination_resources_path=str(dst),
+            resource_per_file=True,
+        ),
+        src,
+        dst,
+    )
+
+
+class TestLocalFileDelete:
+    def test_delete_existing_file(self, tmp_path):
+        backend, src, _ = _make_local(tmp_path)
+        f = src / "monitors.abc.json"
+        f.write_text("{}")
+        backend.delete(Origin.SOURCE, "monitors.abc.json")
+        assert not f.exists()
+
+    def test_delete_missing_file_no_op(self, tmp_path):
+        backend, _, _ = _make_local(tmp_path)
+        # Must not raise
+        backend.delete(Origin.SOURCE, "monitors.does-not-exist.json")
+
+    def test_delete_origin_isolation(self, tmp_path):
+        backend, src, dst = _make_local(tmp_path)
+        src_file = src / "monitors.abc.json"
+        dst_file = dst / "monitors.abc.json"
+        src_file.write_text("{}")
+        dst_file.write_text("{}")
+        backend.delete(Origin.SOURCE, "monitors.abc.json")
+        assert not src_file.exists()
+        assert dst_file.exists()
+
+
+class TestLocalFileDeleteMany:
+    def test_mix_present_and_missing(self, tmp_path):
+        backend, src, _ = _make_local(tmp_path)
+        (src / "monitors.a.json").write_text("{}")
+        (src / "monitors.b.json").write_text("{}")
+        result = backend.delete_many(
+            Origin.SOURCE,
+            ["monitors.a.json", "monitors.b.json", "monitors.missing.json"],
+        )
+        assert result["monitors.a.json"] == "ok"
+        assert result["monitors.b.json"] == "ok"
+        assert result["monitors.missing.json"] == "ok"  # missing is no-op
+        assert not (src / "monitors.a.json").exists()
+        assert not (src / "monitors.b.json").exists()
+
+    def test_empty_input(self, tmp_path):
+        backend, _, _ = _make_local(tmp_path)
+        assert backend.delete_many(Origin.SOURCE, []) == {}
+
+
+@pytest.fixture
+def mock_s3_client():
+    with patch("datadog_sync.utils.storage.aws_s3_bucket.boto3") as mock_boto3:
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        yield mock_boto3, mock_client
+
+
+def _make_s3():
+    return AWSS3Bucket(
+        config={
+            "aws_bucket_name": "test-bucket",
+            "aws_region_name": "us-east-1",
+            "aws_access_key_id": "AKID",
+            "aws_secret_access_key": "SECRET",
+            "aws_session_token": "",
+        },
+        resource_per_file=True,
+    )
+
+
+class TestAWSS3Delete:
+    def test_delete_calls_delete_object(self, mock_s3_client):
+        _, mock_client = mock_s3_client
+        bucket = _make_s3()
+        bucket.delete(Origin.SOURCE, "monitors.abc.json")
+        mock_client.delete_object.assert_called_once_with(
+            Bucket="test-bucket", Key="resources/source/monitors.abc.json"
+        )
+
+    def test_delete_origin_isolation(self, mock_s3_client):
+        _, mock_client = mock_s3_client
+        bucket = _make_s3()
+        bucket.delete(Origin.DESTINATION, "monitors.abc.json")
+        mock_client.delete_object.assert_called_once_with(
+            Bucket="test-bucket", Key="resources/destination/monitors.abc.json"
+        )
+
+    def test_delete_many_loops_per_file(self, mock_s3_client):
+        _, mock_client = mock_s3_client
+        bucket = _make_s3()
+        result = bucket.delete_many(Origin.SOURCE, ["monitors.a.json", "monitors.b.json"])
+        assert result == {"monitors.a.json": "ok", "monitors.b.json": "ok"}
+        assert mock_client.delete_object.call_count == 2
+
+    def test_delete_many_partial_failure(self, mock_s3_client):
+        _, mock_client = mock_s3_client
+        mock_client.delete_object.side_effect = [None, Exception("AccessDenied")]
+        bucket = _make_s3()
+        result = bucket.delete_many(Origin.SOURCE, ["monitors.a.json", "monitors.b.json"])
+        assert result["monitors.a.json"] == "ok"
+        assert "AccessDenied" in result["monitors.b.json"]
+
+
+@pytest.fixture
+def mock_gcs_client():
+    with patch("datadog_sync.utils.storage.gcs_bucket.gcs_storage") as mock_storage:
+        mock_client = MagicMock()
+        mock_storage.Client.return_value = mock_client
+        mock_bucket = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+        yield mock_storage, mock_client, mock_bucket
+
+
+def _make_gcs():
+    return GCSBucket(
+        config={"gcs_bucket_name": "test-bucket", "gcs_service_account_key_file": None},
+        resource_per_file=True,
+    )
+
+
+class TestGCSDelete:
+    def test_delete_calls_blob_delete(self, mock_gcs_client):
+        _, _, mock_bucket = mock_gcs_client
+        mock_blob = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+        bucket = _make_gcs()
+        bucket.delete(Origin.SOURCE, "monitors.abc.json")
+        mock_bucket.blob.assert_called_with("resources/source/monitors.abc.json")
+        mock_blob.delete.assert_called_once()
+
+    def test_delete_missing_file_no_op(self, mock_gcs_client):
+        _, _, mock_bucket = mock_gcs_client
+        mock_blob = MagicMock()
+        mock_blob.delete.side_effect = NotFound("missing")
+        mock_bucket.blob.return_value = mock_blob
+        bucket = _make_gcs()
+        # Must not raise
+        bucket.delete(Origin.SOURCE, "monitors.missing.json")
+
+    def test_delete_many_partial_failure(self, mock_gcs_client):
+        _, _, mock_bucket = mock_gcs_client
+        ok_blob = MagicMock()
+        bad_blob = MagicMock()
+        bad_blob.delete.side_effect = Exception("PermissionDenied")
+        mock_bucket.blob.side_effect = [ok_blob, bad_blob]
+        bucket = _make_gcs()
+        result = bucket.delete_many(Origin.SOURCE, ["monitors.a.json", "monitors.b.json"])
+        assert result["monitors.a.json"] == "ok"
+        assert "PermissionDenied" in result["monitors.b.json"]
+
+
+@pytest.fixture
+def mock_azure_container():
+    with patch("datadog_sync.utils.storage.azure_blob_container.ContainerClient") as mock_cls:
+        mock_container = MagicMock()
+        mock_cls.from_connection_string.return_value = mock_container
+        yield mock_cls, mock_container
+
+
+def _make_azure():
+    return AzureBlobContainer(
+        config={
+            "azure_container_name": "test-container",
+            "azure_storage_connection_string": "conn",
+            "azure_storage_account_name": None,
+            "azure_storage_account_key": None,
+        },
+        resource_per_file=True,
+    )
+
+
+class TestAzureDelete:
+    def test_delete_calls_delete_blob(self, mock_azure_container):
+        _, mock_container = mock_azure_container
+        bucket = _make_azure()
+        bucket.delete(Origin.SOURCE, "monitors.abc.json")
+        mock_container.delete_blob.assert_called_once_with("resources/source/monitors.abc.json")
+
+    def test_delete_missing_file_no_op(self, mock_azure_container):
+        _, mock_container = mock_azure_container
+        mock_container.delete_blob.side_effect = ResourceNotFoundError("missing")
+        bucket = _make_azure()
+        # Must not raise
+        bucket.delete(Origin.SOURCE, "monitors.missing.json")
+
+    def test_delete_many_partial_failure(self, mock_azure_container):
+        _, mock_container = mock_azure_container
+        mock_container.delete_blob.side_effect = [None, Exception("AccessDenied")]
+        bucket = _make_azure()
+        result = bucket.delete_many(Origin.SOURCE, ["monitors.a.json", "monitors.b.json"])
+        assert result["monitors.a.json"] == "ok"
+        assert "AccessDenied" in result["monitors.b.json"]
+
+
+class TestBaseStorageDefaults:
+    """Out-of-tree backends that don't implement delete must raise NotImplementedError."""
+
+    def test_default_delete_raises(self):
+        class FakeBackend(BaseStorage):
+            def get(self, origin, resource_types=None):
+                pass
+
+            def get_single(self, resource_type, resource_id):
+                return None, None
+
+            def put(self, origin, data):
+                pass
+
+        backend = FakeBackend()
+        with pytest.raises(NotImplementedError, match="delete"):
+            backend.delete(Origin.SOURCE, "monitors.abc.json")
+
+    def test_default_delete_many_uses_default_loop(self):
+        """delete_many has a concrete default that loops delete() — so a backend
+        that overrides only delete() will get a working delete_many() for free."""
+
+        class PartialBackend(BaseStorage):
+            def __init__(self):
+                super().__init__()
+                self.deleted: list = []
+
+            def get(self, origin, resource_types=None):
+                pass
+
+            def get_single(self, resource_type, resource_id):
+                return None, None
+
+            def put(self, origin, data):
+                pass
+
+            def delete(self, origin, filename):
+                self.deleted.append((origin, filename))
+
+        backend = PartialBackend()
+        result = backend.delete_many(Origin.SOURCE, ["a.json", "b.json"])
+        assert result == {"a.json": "ok", "b.json": "ok"}
+        assert backend.deleted == [(Origin.SOURCE, "a.json"), (Origin.SOURCE, "b.json")]

--- a/tests/unit/test_storage_list_filenames.py
+++ b/tests/unit/test_storage_list_filenames.py
@@ -1,0 +1,278 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from datadog_sync.constants import Origin
+from datadog_sync.utils.storage.aws_s3_bucket import AWSS3Bucket
+from datadog_sync.utils.storage.azure_blob_container import AzureBlobContainer
+from datadog_sync.utils.storage.gcs_bucket import GCSBucket
+from datadog_sync.utils.storage.local_file import LocalFile
+
+
+def _make_local(tmp_path):
+    src = tmp_path / "source"
+    dst = tmp_path / "dest"
+    src.mkdir()
+    dst.mkdir()
+    return (
+        LocalFile(
+            source_resources_path=str(src),
+            destination_resources_path=str(dst),
+            resource_per_file=True,
+        ),
+        src,
+        dst,
+    )
+
+
+class TestLocalFileListFilenames:
+    def test_empty_directory_returns_empty_set(self, tmp_path):
+        backend, _, _ = _make_local(tmp_path)
+        assert backend.list_filenames(Origin.SOURCE, "monitors") == set()
+
+    def test_returns_full_filenames_opaque(self, tmp_path):
+        backend, src, _ = _make_local(tmp_path)
+        (src / "monitors.abc.json").write_text("{}")
+        (src / "monitors.x.y.json").write_text("{}")  # multi-dot ID preserved
+        result = backend.list_filenames(Origin.SOURCE, "monitors")
+        assert result == {"monitors.abc.json", "monitors.x.y.json"}
+
+    def test_ignores_non_json(self, tmp_path):
+        backend, src, _ = _make_local(tmp_path)
+        (src / "monitors.abc.json").write_text("{}")
+        (src / "monitors.txt").write_text("nope")
+        (src / "readme").write_text("nope")
+        assert backend.list_filenames(Origin.SOURCE, "monitors") == {"monitors.abc.json"}
+
+    def test_ignores_other_resource_types(self, tmp_path):
+        backend, src, _ = _make_local(tmp_path)
+        (src / "monitors.abc.json").write_text("{}")
+        (src / "dashboards.def.json").write_text("{}")
+        assert backend.list_filenames(Origin.SOURCE, "monitors") == {"monitors.abc.json"}
+        assert backend.list_filenames(Origin.SOURCE, "dashboards") == {"dashboards.def.json"}
+
+    def test_origin_isolation(self, tmp_path):
+        backend, src, dst = _make_local(tmp_path)
+        (src / "monitors.in_source.json").write_text("{}")
+        (dst / "monitors.in_dest.json").write_text("{}")
+        assert backend.list_filenames(Origin.SOURCE, "monitors") == {"monitors.in_source.json"}
+        assert backend.list_filenames(Origin.DESTINATION, "monitors") == {"monitors.in_dest.json"}
+
+    def test_missing_directory_returns_empty(self, tmp_path):
+        # Source path that doesn't exist on disk (e.g., never written)
+        backend = LocalFile(
+            source_resources_path=str(tmp_path / "does_not_exist"),
+            destination_resources_path=str(tmp_path / "dest_missing"),
+            resource_per_file=True,
+        )
+        assert backend.list_filenames(Origin.SOURCE, "monitors") == set()
+        assert backend.list_filenames(Origin.DESTINATION, "monitors") == set()
+
+
+@pytest.fixture
+def mock_s3_client():
+    with patch("datadog_sync.utils.storage.aws_s3_bucket.boto3") as mock_boto3:
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        yield mock_boto3, mock_client
+
+
+def _make_s3():
+    return AWSS3Bucket(
+        config={
+            "aws_bucket_name": "test-bucket",
+            "aws_region_name": "us-east-1",
+            "aws_access_key_id": "AKID",
+            "aws_secret_access_key": "SECRET",
+            "aws_session_token": "",
+        },
+        resource_per_file=True,
+    )
+
+
+class TestAWSS3ListFilenames:
+    def test_empty_prefix_returns_empty(self, mock_s3_client):
+        _, mock_client = mock_s3_client
+        mock_client.list_objects_v2.return_value = {"IsTruncated": False}
+        bucket = _make_s3()
+        assert bucket.list_filenames(Origin.SOURCE, "monitors") == set()
+
+    def test_returns_full_filenames_opaque(self, mock_s3_client):
+        _, mock_client = mock_s3_client
+        mock_client.list_objects_v2.return_value = {
+            "Contents": [
+                {"Key": "resources/source/monitors.abc.json"},
+                {"Key": "resources/source/monitors.x.y.json"},
+            ],
+            "IsTruncated": False,
+        }
+        bucket = _make_s3()
+        result = bucket.list_filenames(Origin.SOURCE, "monitors")
+        assert result == {"monitors.abc.json", "monitors.x.y.json"}
+        # Listing must be scoped to the per-type prefix
+        mock_client.list_objects_v2.assert_called_with(Bucket="test-bucket", Prefix="resources/source/monitors.")
+
+    def test_ignores_non_json(self, mock_s3_client):
+        _, mock_client = mock_s3_client
+        mock_client.list_objects_v2.return_value = {
+            "Contents": [
+                {"Key": "resources/source/monitors.abc.json"},
+                {"Key": "resources/source/monitors.txt"},
+            ],
+            "IsTruncated": False,
+        }
+        bucket = _make_s3()
+        assert bucket.list_filenames(Origin.SOURCE, "monitors") == {"monitors.abc.json"}
+
+    def test_origin_isolation(self, mock_s3_client):
+        _, mock_client = mock_s3_client
+        mock_client.list_objects_v2.return_value = {"IsTruncated": False}
+        bucket = _make_s3()
+        bucket.list_filenames(Origin.SOURCE, "monitors")
+        bucket.list_filenames(Origin.DESTINATION, "monitors")
+        prefixes_called = [call.kwargs.get("Prefix") for call in mock_client.list_objects_v2.call_args_list]
+        assert "resources/source/monitors." in prefixes_called
+        assert "resources/destination/monitors." in prefixes_called
+
+    def test_pagination(self, mock_s3_client):
+        _, mock_client = mock_s3_client
+        # First page truncated, second page final
+        mock_client.list_objects_v2.side_effect = [
+            {
+                "Contents": [{"Key": "resources/source/monitors.a.json"}],
+                "IsTruncated": True,
+                "NextContinuationToken": "tok",
+            },
+            {
+                "Contents": [{"Key": "resources/source/monitors.b.json"}],
+                "IsTruncated": False,
+            },
+        ]
+        bucket = _make_s3()
+        assert bucket.list_filenames(Origin.SOURCE, "monitors") == {
+            "monitors.a.json",
+            "monitors.b.json",
+        }
+
+
+@pytest.fixture
+def mock_gcs_client():
+    with patch("datadog_sync.utils.storage.gcs_bucket.gcs_storage") as mock_storage:
+        mock_client = MagicMock()
+        mock_storage.Client.return_value = mock_client
+        mock_bucket = MagicMock()
+        mock_client.bucket.return_value = mock_bucket
+        yield mock_storage, mock_client, mock_bucket
+
+
+def _make_gcs():
+    return GCSBucket(
+        config={"gcs_bucket_name": "test-bucket", "gcs_service_account_key_file": None},
+        resource_per_file=True,
+    )
+
+
+class TestGCSListFilenames:
+    def test_empty_prefix_returns_empty(self, mock_gcs_client):
+        _, _, mock_bucket = mock_gcs_client
+        mock_bucket.list_blobs.return_value = []
+        bucket = _make_gcs()
+        assert bucket.list_filenames(Origin.SOURCE, "monitors") == set()
+
+    def test_returns_full_filenames_opaque(self, mock_gcs_client):
+        _, _, mock_bucket = mock_gcs_client
+        b1 = MagicMock()
+        b1.name = "resources/source/monitors.abc.json"
+        b2 = MagicMock()
+        b2.name = "resources/source/monitors.x.y.json"
+        mock_bucket.list_blobs.return_value = [b1, b2]
+        bucket = _make_gcs()
+        result = bucket.list_filenames(Origin.SOURCE, "monitors")
+        assert result == {"monitors.abc.json", "monitors.x.y.json"}
+        mock_bucket.list_blobs.assert_called_with(prefix="resources/source/monitors.")
+
+    def test_ignores_non_json(self, mock_gcs_client):
+        _, _, mock_bucket = mock_gcs_client
+        b1 = MagicMock()
+        b1.name = "resources/source/monitors.abc.json"
+        b2 = MagicMock()
+        b2.name = "resources/source/monitors.txt"
+        mock_bucket.list_blobs.return_value = [b1, b2]
+        bucket = _make_gcs()
+        assert bucket.list_filenames(Origin.SOURCE, "monitors") == {"monitors.abc.json"}
+
+
+@pytest.fixture
+def mock_azure_container():
+    with patch("datadog_sync.utils.storage.azure_blob_container.ContainerClient") as mock_cls:
+        mock_container = MagicMock()
+        mock_cls.from_connection_string.return_value = mock_container
+        yield mock_cls, mock_container
+
+
+def _make_azure():
+    return AzureBlobContainer(
+        config={
+            "azure_container_name": "test-container",
+            "azure_storage_connection_string": "conn",
+            "azure_storage_account_name": None,
+            "azure_storage_account_key": None,
+        },
+        resource_per_file=True,
+    )
+
+
+class TestAzureListFilenames:
+    def test_empty_prefix_returns_empty(self, mock_azure_container):
+        _, mock_container = mock_azure_container
+        mock_container.list_blobs.return_value = []
+        bucket = _make_azure()
+        assert bucket.list_filenames(Origin.SOURCE, "monitors") == set()
+
+    def test_returns_full_filenames_opaque(self, mock_azure_container):
+        _, mock_container = mock_azure_container
+        b1 = MagicMock()
+        b1.name = "resources/source/monitors.abc.json"
+        b2 = MagicMock()
+        b2.name = "resources/source/monitors.x.y.json"
+        mock_container.list_blobs.return_value = [b1, b2]
+        bucket = _make_azure()
+        result = bucket.list_filenames(Origin.SOURCE, "monitors")
+        assert result == {"monitors.abc.json", "monitors.x.y.json"}
+        mock_container.list_blobs.assert_called_with(name_starts_with="resources/source/monitors.")
+
+    def test_ignores_non_json(self, mock_azure_container):
+        _, mock_container = mock_azure_container
+        b1 = MagicMock()
+        b1.name = "resources/source/monitors.abc.json"
+        b2 = MagicMock()
+        b2.name = "resources/source/monitors.txt"
+        mock_container.list_blobs.return_value = [b1, b2]
+        bucket = _make_azure()
+        assert bucket.list_filenames(Origin.SOURCE, "monitors") == {"monitors.abc.json"}
+
+
+class TestBaseStorageDefault:
+    """Out-of-tree backends that don't implement list_filenames must raise NotImplementedError."""
+
+    def test_default_raises(self):
+        from datadog_sync.utils.storage._base_storage import BaseStorage
+
+        class FakeBackend(BaseStorage):
+            def get(self, origin, resource_types=None):
+                pass
+
+            def get_single(self, resource_type, resource_id):
+                return None, None
+
+            def put(self, origin, data):
+                pass
+
+        backend = FakeBackend()
+        with pytest.raises(NotImplementedError, match="list_filenames"):
+            backend.list_filenames(Origin.SOURCE, "monitors")

--- a/tests/unit/test_storage_list_filenames.py
+++ b/tests/unit/test_storage_list_filenames.py
@@ -49,6 +49,12 @@ class TestLocalFileListFilenames:
         (src / "readme").write_text("nope")
         assert backend.list_filenames(Origin.SOURCE, "monitors") == {"monitors.abc.json"}
 
+    def test_ignores_combined_resource_file(self, tmp_path):
+        backend, src, _ = _make_local(tmp_path)
+        (src / "monitors.json").write_text("{}")
+        (src / "monitors.abc.json").write_text("{}")
+        assert backend.list_filenames(Origin.SOURCE, "monitors") == {"monitors.abc.json"}
+
     def test_ignores_other_resource_types(self, tmp_path):
         backend, src, _ = _make_local(tmp_path)
         (src / "monitors.abc.json").write_text("{}")
@@ -123,6 +129,18 @@ class TestAWSS3ListFilenames:
             "Contents": [
                 {"Key": "resources/source/monitors.abc.json"},
                 {"Key": "resources/source/monitors.txt"},
+            ],
+            "IsTruncated": False,
+        }
+        bucket = _make_s3()
+        assert bucket.list_filenames(Origin.SOURCE, "monitors") == {"monitors.abc.json"}
+
+    def test_ignores_combined_resource_file(self, mock_s3_client):
+        _, mock_client = mock_s3_client
+        mock_client.list_objects_v2.return_value = {
+            "Contents": [
+                {"Key": "resources/source/monitors.json"},
+                {"Key": "resources/source/monitors.abc.json"},
             ],
             "IsTruncated": False,
         }
@@ -206,6 +224,16 @@ class TestGCSListFilenames:
         bucket = _make_gcs()
         assert bucket.list_filenames(Origin.SOURCE, "monitors") == {"monitors.abc.json"}
 
+    def test_ignores_combined_resource_file(self, mock_gcs_client):
+        _, _, mock_bucket = mock_gcs_client
+        b1 = MagicMock()
+        b1.name = "resources/source/monitors.json"
+        b2 = MagicMock()
+        b2.name = "resources/source/monitors.abc.json"
+        mock_bucket.list_blobs.return_value = [b1, b2]
+        bucket = _make_gcs()
+        assert bucket.list_filenames(Origin.SOURCE, "monitors") == {"monitors.abc.json"}
+
 
 @pytest.fixture
 def mock_azure_container():
@@ -252,6 +280,16 @@ class TestAzureListFilenames:
         b1.name = "resources/source/monitors.abc.json"
         b2 = MagicMock()
         b2.name = "resources/source/monitors.txt"
+        mock_container.list_blobs.return_value = [b1, b2]
+        bucket = _make_azure()
+        assert bucket.list_filenames(Origin.SOURCE, "monitors") == {"monitors.abc.json"}
+
+    def test_ignores_combined_resource_file(self, mock_azure_container):
+        _, mock_container = mock_azure_container
+        b1 = MagicMock()
+        b1.name = "resources/source/monitors.json"
+        b2 = MagicMock()
+        b2.name = "resources/source/monitors.abc.json"
         mock_container.list_blobs.return_value = [b1, b2]
         bucket = _make_azure()
         assert bucket.list_filenames(Origin.SOURCE, "monitors") == {"monitors.abc.json"}


### PR DESCRIPTION
## Summary

First of three stacked PRs adding a top-level `prune` command that deletes orphaned per-resource state files when source resources are removed upstream.

This PR adds the **storage-layer primitives** that the upcoming `State.compute_stale_files` / `delete_stale_files` helpers (PR 2) and `prune` command (PR 3) will build on. Internal API only — no user-visible behavior change.

## What changed

- `BaseStorage` gains three methods:
  - `list_filenames(origin, resource_type) -> Set[str]` — full filenames under `<base>/<resource_type>.*.json`, opaque strings (no parsing).
  - `delete(origin, filename) -> None` — single-file delete, no-op if absent.
  - `delete_many(origin, filenames) -> Dict[str, str]` — batch wrapper returning `{filename: "ok" | error}`. Concrete default loops `delete()`; backends like S3 may override with `DeleteObjects` later.
- Concrete defaults raise `NotImplementedError` on `BaseStorage` rather than `@abstractmethod`, so out-of-tree backends fail loudly rather than silently returning empty results.
- All four in-tree backends implement the methods:
  - `LocalFile`: `os.listdir` + `os.remove` (idempotent on `FileNotFoundError`).
  - `AWSS3Bucket`: paginated `list_objects_v2`; `delete_object` (idempotent at the AWS layer).
  - `GCSBucket`: `list_blobs(prefix=...)`; `blob.delete()` wrapped in `try/except NotFound`.
  - `AzureBlobContainer`: `list_blobs(name_starts_with=...)`; `delete_blob` wrapped in `try/except ResourceNotFoundError`.

## Test plan

- [x] 35 new unit tests across all four backends + base-class default behavior (`tests/unit/test_storage_list_filenames.py`, `tests/unit/test_storage_delete.py`).
- [x] Full unit suite (`tox -e py3 -- tests/unit/`) passes — 447 tests, no regressions.
- [x] \`tox -e ruff,black\` clean.

## Stacked PR context

This is **PR 1 of 3**. Subsequent PRs:
- PR 2 — \`State.compute_stale_files\` / \`delete_stale_files\` helpers.
- PR 3 — top-level \`prune\` command (the user-visible change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)