### PR TITLE
Exclude new field for now

### DIFF
--- a/datadog_sync/model/synthetics_tests.py
+++ b/datadog_sync/model/synthetics_tests.py
@@ -44,6 +44,7 @@ class SyntheticsTests(BaseResource):
         },
         base_path="/api/v1/synthetics/tests",
         excluded_attributes=[
+            "options.bits_ai_auto_investigate",
             "created_at",
             "creator",
             "created_by",


### PR DESCRIPTION
### What does this PR do?
Exclude this new field that might not be being used everywhere.
