### PR TITLE
feat(import): add --minimize-reads for type-scoped state loading

### DIFF
--- a/datadog_sync/commands/_import.py
+++ b/datadog_sync/commands/_import.py
@@ -3,9 +3,10 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019 Datadog, Inc.
 
-from click import command
+from click import command, option
 
 from datadog_sync.commands.shared.options import (
+    CustomOptionClass,
     common_options,
     destination_auth_options,
     force_missing_dependencies_options,
@@ -22,6 +23,18 @@ from datadog_sync.constants import Command
 @common_options
 @force_missing_dependencies_options
 @storage_options
+@option(
+    "--minimize-reads",
+    required=False,
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Minimize cloud storage reads by loading only needed resources. "
+    "Uses ID-targeted fetching when filters specify exact IDs, "
+    "otherwise falls back to type-scoped loading. "
+    "Requires --resource-per-file and --resources.",
+    cls=CustomOptionClass,
+)
 def _import(**kwargs):
     """Import Datadog resources."""
     run_cmd(Command.IMPORT, **kwargs)

--- a/datadog_sync/commands/sync.py
+++ b/datadog_sync/commands/sync.py
@@ -37,8 +37,7 @@ from datadog_sync.constants import Command
     "Uses ID-targeted fetching when filters specify exact IDs, "
     "otherwise falls back to type-scoped loading. "
     "Requires --resource-per-file and --resources. "
-    "Must not be combined with --cleanup. "
-    "Only available on the sync command.",
+    "Must not be combined with --cleanup.",
     cls=CustomOptionClass,
 )
 def sync(**kwargs):

--- a/tests/unit/test_minimize_reads_type_scoped.py
+++ b/tests/unit/test_minimize_reads_type_scoped.py
@@ -134,14 +134,66 @@ class TestMinimizeReadsCLIValidation:
         assert result.exit_code != 0
         assert "no such option" in result.output.lower()
 
-    def test_minimize_reads_not_available_on_import_command(self, runner):
-        """--minimize-reads must not be accepted by the import command."""
+    def test_minimize_reads_accepted_on_import_command(self, runner):
+        """--minimize-reads must be accepted by the import command and listed in --help."""
+        result = runner.invoke(cli, ["import", "--help"])
+        assert result.exit_code == 0
+        assert "--minimize-reads" in result.output
+
+    def test_import_minimize_reads_requires_resource_per_file(self, runner):
+        """--minimize-reads on import without --resource-per-file must fail with error."""
         result = runner.invoke(
             cli,
-            ["import", "--minimize-reads", "--source-api-key=x"],
+            [
+                "import",
+                "--minimize-reads",
+                "--resources=roles",
+                "--source-api-key=x",
+                "--source-app-key=y",
+            ],
         )
         assert result.exit_code != 0
-        assert "no such option" in result.output.lower()
+        assert "resource-per-file" in (result.output + str(result.exception)).lower()
+
+    def test_import_minimize_reads_requires_resources_flag(self, runner):
+        """--minimize-reads on import without --resources must fail with error."""
+        result = runner.invoke(
+            cli,
+            [
+                "import",
+                "--minimize-reads",
+                "--resource-per-file",
+                "--source-api-key=x",
+                "--source-app-key=y",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "resources" in (result.output + str(result.exception)).lower()
+
+    def test_import_does_not_accept_cleanup_option(self, runner):
+        """Pin: import does not register --cleanup, so click rejects it at parse time
+        and the --minimize-reads + --cleanup combination is unreachable via the import CLI."""
+        result = runner.invoke(
+            cli,
+            [
+                "import",
+                "--minimize-reads",
+                "--resource-per-file",
+                "--resources=roles",
+                "--cleanup=Force",
+                "--source-api-key=x",
+                "--source-app-key=y",
+            ],
+        )
+        assert result.exit_code != 0
+        # Assert on the Error: line only, so a future click message change that drops
+        # "no such option" or "cleanup" is loud, and a regression that ACCEPTS --cleanup
+        # on import (no Error: line at all) is loud too.
+        error_lines = [line for line in result.output.splitlines() if line.lower().startswith("error:")]
+        assert error_lines, "expected click to emit an Error: line for unknown option"
+        joined_error = " ".join(error_lines).lower()
+        assert "no such option" in joined_error
+        assert "cleanup" in joined_error
 
     def test_minimize_reads_cannot_be_combined_with_cleanup(self, runner):
         """--minimize-reads + --cleanup must be rejected before any I/O."""


### PR DESCRIPTION
## What this PR adds

This PR adds `--minimize-reads` to the `datadog-sync import` subcommand. The option, its validation, and the underlying loading-strategy code already exist (introduced for `sync` in #544 / #545) — only the click decorator was missing on import.

When enabled, import scopes the bucket state-load to the requested resource types (type-scoped) or to filter-extracted exact IDs (ID-targeted), instead of scanning every file under both source and destination prefixes.

## The problem this solves

`State.__init__` calls `load_state(Origin.ALL)`, which reads every file under both prefixes (`utils/state.py:77`, `utils/storage/gcs_bucket.py:56-84`). On reasonably-populated buckets the state-load dominates per-run wall-clock regardless of how many records the run actually fetches — the boot-time read of prior runs' files becomes the bottleneck.

Observed shape on a ~22k-file source bucket, importing one resource type at a time:

| Resource type | Records imported | Wall-clock | Per-record cost |
|---|---|---|---|
| authn_mappings | 3 | 41 min | 825 sec/record (~99.97% state-load overhead) |
| dashboard_lists | 381 | 42 min | 6.6 sec/record |
| dashboards | 14,000 | 53 min | 230 ms/record |

Three records, 41 minutes — nearly all of it the unscoped bucket scan. `--minimize-reads` fixes this for `sync` already; this PR makes the same fix reachable from `import`, which is the entry point most automation uses for incremental refreshes.

## How to enable

```
datadog-sync import --minimize-reads --resource-per-file --resources=<types> ...
```

Constraints enforced in `utils/configuration.py:412-417` (unchanged in this PR):
- requires `--resource-per-file`
- requires `--resources`

`--cleanup` is not registered on the import command (it lives in `_diffs_options`, applied only to `sync`/`diffs`), so the `--minimize-reads + --cleanup` rule cannot be violated through the import CLI. Click rejects `import --cleanup=...` at parse time. Locked in by `test_import_does_not_accept_cleanup_option`.

## What does not change

- `sync` command behaviour
- `utils/configuration.py` validation logic
- `State` constructor or storage layer
- Default behaviour for import — the flag is opt-in (`default=False`)

## Code summary

- **`commands/_import.py`**: add `--minimize-reads` `@option(...)` decorator; import `option` and `CustomOptionClass`.
- **`commands/sync.py`**: drop now-stale `"Only available on the sync command."` line from help text.
- **`tests/unit/test_minimize_reads_type_scoped.py`**: flip the pre-existing negative test that asserted import rejected the flag; add positive `--help` check, two validation-mirror tests, and a click-level guard for `--cleanup` on import.

## Test plan

- [x] `pytest tests/unit/` — 500 passed
- [x] `--minimize-reads` listed in `datadog-sync import --help`
- [x] `import --minimize-reads` without `--resource-per-file` → UsageError
- [x] `import --minimize-reads` without `--resources` → UsageError
- [x] `import --minimize-reads --cleanup=Force` → click "no such option" (parse-time rejection)
- [x] `sync --help` still renders correctly after help-text edit
- [x] CI green across macOS / Linux x86 / Linux arm / Windows

## Rollout

Flag is opt-in (`default=False`). Reverting the commit removes the option from `import --help` but doesn't break any caller that wasn't using it. No on-disk or wire-format effect.

## Out of scope

- `migrate` subcommand still lacks `--minimize-reads`. Adding it requires confirming that the apply phase's existing minimize-reads handling covers the migrate flow. Follow-up.
- Parallelising `_list_and_load` (the per-type file walk is still sequential). Separate effort.
