### PR TITLE
feat(import): add ImportState + --skip-state-load flag for write-only import

### DIFF
--- a/datadog_sync/commands/_import.py
+++ b/datadog_sync/commands/_import.py
@@ -3,9 +3,10 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019 Datadog, Inc.
 
-from click import command
+from click import command, option
 
 from datadog_sync.commands.shared.options import (
+    CustomOptionClass,
     common_options,
     destination_auth_options,
     force_missing_dependencies_options,
@@ -22,6 +23,19 @@ from datadog_sync.constants import Command
 @common_options
 @force_missing_dependencies_options
 @storage_options
+@option(
+    "--skip-state-load",
+    required=False,
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Skip loading prior state from storage. Import discards prior source "
+    "state per type and writes fresh API results, so the boot-time read is "
+    "dead weight; this flag lets you reclaim that cost on populated buckets. "
+    "Requires --resource-per-file and --resources. Not available on other "
+    "commands.",
+    cls=CustomOptionClass,
+)
 def _import(**kwargs):
     """Import Datadog resources."""
     run_cmd(Command.IMPORT, **kwargs)

--- a/datadog_sync/model/synthetics_private_locations.py
+++ b/datadog_sync/model/synthetics_private_locations.py
@@ -49,7 +49,7 @@ class SyntheticsPrivateLocations(BaseResource):
             raise SkipResource(import_id, self.resource_type, "Managed location.")
 
         pl = await source_client.get(self.resource_config.base_path + f"/{import_id}")
-        self.config.state.source[self.resource_type][import_id] = pl
+        self.config.state.set_source(self.resource_type, import_id, pl)
 
         return import_id, pl
 

--- a/datadog_sync/utils/base_resource.py
+++ b/datadog_sync/utils/base_resource.py
@@ -244,7 +244,12 @@ class BaseResource(abc.ABC):
                     f"Error while adding default tags to resource {self.resource_type}. {str(e)}"
                 )
 
-        self.config.state.source[self.resource_type][str(_id)] = r
+        # Use the SourceStateWriter protocol method so this works against both
+        # State (which loaded prior data on construction) and ImportState
+        # (write-only; constructed via --skip-state-load). Direct
+        # `state.source[type][id] = r` would only work on State and would
+        # AttributeError on ImportState, which has no .source accessor.
+        self.config.state.set_source(self.resource_type, str(_id), r)
         return str(_id)
 
     @abc.abstractmethod

--- a/datadog_sync/utils/configuration.py
+++ b/datadog_sync/utils/configuration.py
@@ -43,6 +43,7 @@ from datadog_sync.utils.base_resource import BaseResource
 from datadog_sync.utils.log import Log
 from datadog_sync.utils.filter import Filter, process_filters, EXACT_MATCH_OPERATOR
 from datadog_sync.utils.resource_utils import CustomClientHTTPError
+from datadog_sync.utils.import_state import ImportState
 from datadog_sync.utils.state import State
 from datadog_sync.utils.storage.storage_types import StorageType
 
@@ -61,7 +62,15 @@ class Configuration(object):
     create_global_downtime: bool
     validate: bool
     send_metrics: bool
-    state: State
+    # Typed as Union so the field accepts both State (the common case — all
+    # commands except --skip-state-load-on-import use this) and ImportState
+    # (a write-only specialization for the import command with --skip-state-load).
+    # State has the full read+write surface; ImportState exposes only the write
+    # methods declared by the SourceStateWriter protocol. Sync/diffs/migrate/
+    # reset/prune code paths assume State; that's enforced at runtime by the
+    # Click decorator (which only registers --skip-state-load on import) plus a
+    # defensive isinstance check in _handle_deprecated.
+    state: Union[State, ImportState]
     verify_ddr_status: bool
     backup_before_reset: bool
     show_progress_bar: bool
@@ -411,6 +420,7 @@ def build_config(cmd: Command, **kwargs: Optional[Any]) -> Configuration:
 
     resource_per_file = kwargs.get(RESOURCE_PER_FILE, False)
     minimize_reads = kwargs.get("minimize_reads", False)
+    skip_state_load = kwargs.get("skip_state_load", False)
 
     # Validate --minimize-reads constraints
     if minimize_reads:
@@ -420,6 +430,27 @@ def build_config(cmd: Command, **kwargs: Optional[Any]) -> Configuration:
             raise click.UsageError("--minimize-reads requires --resources")
         if kwargs.get("cleanup") and kwargs["cleanup"].lower() in ("true", "force"):
             raise click.UsageError("--minimize-reads cannot be combined with --cleanup")
+
+    # Validate --skip-state-load constraints.
+    # The Click decorator lives on `_import.py` only, so the flag is never
+    # parsed for other commands; this defensive check guards against future
+    # refactors that might re-add it elsewhere.
+    if skip_state_load:
+        if cmd != Command.IMPORT:
+            raise click.UsageError("--skip-state-load is only valid on the import command")
+        if not resource_per_file:
+            raise click.UsageError("--skip-state-load requires --resource-per-file")
+        if not kwargs.get("resources", None):
+            raise click.UsageError("--skip-state-load requires --resources")
+        if minimize_reads:
+            # Both flags target the same cost (preload from storage). --skip-state-load
+            # is strictly cheaper for import (no load at all) so combining them is
+            # almost certainly a misconfiguration; reject rather than silently let
+            # one shadow the other.
+            raise click.UsageError(
+                "--skip-state-load and --minimize-reads cannot be combined; "
+                "--skip-state-load skips the load entirely (recommended for import)"
+            )
 
     # Determine loading strategy for minimize-reads
     _state_resource_types = None  # type-scoped; None = full load (existing behavior)
@@ -435,16 +466,28 @@ def build_config(cmd: Command, **kwargs: Optional[Any]) -> Configuration:
             logger.debug("minimize-reads: ID-targeted not eligible — filters are not all id+ExactMatch+OR")
             _state_resource_types = raw_types
 
-    # Initialize state
-    state = State(
-        type_=storage_type,
-        source_resources_path=source_resources_path,
-        destination_resources_path=destination_resources_path,
-        config=config,
-        resource_per_file=resource_per_file,
-        resource_types=_state_resource_types,  # None = full load or ID-targeted
-        exact_ids=_state_exact_ids,  # None = not using ID-targeted
-    )
+    # Initialize state. --skip-state-load constructs an ImportState (write-only,
+    # no source/destination accessors, no boot-time load); otherwise the regular
+    # State class loads from storage on construction.
+    if skip_state_load:
+        state = ImportState(
+            type_=storage_type,
+            source_resources_path=source_resources_path,
+            destination_resources_path=destination_resources_path,
+            config=config,
+            resource_per_file=resource_per_file,
+        )
+        logger.info("skip-state-load: ImportState constructed (no preload)")
+    else:
+        state = State(
+            type_=storage_type,
+            source_resources_path=source_resources_path,
+            destination_resources_path=destination_resources_path,
+            config=config,
+            resource_per_file=resource_per_file,
+            resource_types=_state_resource_types,  # None = full load or ID-targeted
+            exact_ids=_state_exact_ids,  # None = not using ID-targeted
+        )
 
     if _state_exact_ids is not None:
         total = sum(len(v) for v in _state_exact_ids.values())
@@ -655,6 +698,21 @@ def _handle_deprecated(config: Configuration, resources_arg_passed: bool):
             sys.exit(1)
 
     else:
+        # The else-branch below reads config.state.source / destination to fall
+        # back on legacy resource state files when --resources is not set.
+        # ImportState has no .source / .destination accessors and would
+        # AttributeError here. In practice this branch is unreachable when
+        # --skip-state-load is set because --skip-state-load requires
+        # --resources (validated in build_config), which forces
+        # resources_arg_passed=True and selects the if-branch above. The
+        # explicit isinstance guard makes that invariant a local property of
+        # this function instead of an implicit cross-function contract, so
+        # future relaxation of the --resources requirement cannot silently
+        # introduce a crash here. The conflict checks in the if-branch (above)
+        # do NOT read state, so they continue to apply to ImportState callers.
+        if isinstance(config.state, ImportState):
+            return
+
         # Use logs_custom_pipeline resource if its state files exist.
         # Otherwise fall back on logs_pipelines
         if (

--- a/datadog_sync/utils/import_state.py
+++ b/datadog_sync/utils/import_state.py
@@ -1,0 +1,91 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+"""Write-only state container for the import command.
+
+State.__init__ unconditionally loads existing state from storage; on populated
+buckets this can dominate per-run wall-clock even when the run only writes new
+data. The import command never reads prior state — it discards in-memory source
+state per type (resources_handler.py: `state.clear_source_type(...)`), fetches
+fresh resources from the API, and writes the result via `dump_state`. So the
+boot-time read is dead weight for import.
+
+ImportState skips the load entirely. It exposes only write methods — no `source`
+or `destination` property. Any attempt to read state on an ImportState instance
+raises AttributeError at the language level rather than silently returning empty
+data.
+
+Suitable for: the import command.
+Not suitable for: sync, diffs, migrate, reset, prune (all need to read prior
+state). Those commands continue to use the regular State class, which loads on
+construction. The Click decorator for --skip-state-load is registered only on
+the import subcommand; the CLI parser rejects it elsewhere.
+"""
+
+import logging
+import time
+from typing import Any, Dict, List, Set
+
+from datadog_sync.constants import LOGGER_NAME, Origin, RESOURCE_PER_FILE
+from datadog_sync.utils.storage._base_storage import BaseStorage, StorageData, build_storage_backend
+from datadog_sync.utils.storage.storage_types import StorageType
+
+
+log = logging.getLogger(LOGGER_NAME)
+
+
+class ImportState:
+    """Write-only state for the import command. Reads are not supported.
+
+    Construction performs NO state load from storage — `_data` starts empty.
+    No `source` or `destination` property is exposed: attempting to read state
+    raises AttributeError. Writers use `set_source` and `clear_source_type`;
+    `dump_state(Origin.SOURCE)` flushes in-memory writes to storage.
+    """
+
+    def __init__(self, type_: StorageType = StorageType.LOCAL_FILE, **kwargs: object) -> None:
+        init_start = time.perf_counter()
+        resource_per_file = kwargs.get(RESOURCE_PER_FILE, False)
+        self._storage: BaseStorage = build_storage_backend(type_, **kwargs)
+        self._data: StorageData = StorageData()
+        self._authoritative_source_types: Set[str] = set()
+        log.info(
+            "sync-cli-timing phase=state_init storage_type=%s resource_per_file=%s skip_state_load=True wall_ms=%d",
+            type_.name,
+            resource_per_file,
+            int((time.perf_counter() - init_start) * 1000),
+        )
+
+    def set_source(self, resource_type: str, _id: str, resource: Dict[str, Any]) -> None:
+        """Append/overwrite one resource in the in-memory source state."""
+        self._data.source[resource_type][_id] = resource
+
+    def clear_source_type(self, resource_type: str) -> None:
+        """Clear the in-memory source dict for one resource type."""
+        self._data.source[resource_type].clear()
+
+    def mark_source_authoritative(self, resource_types: List[str]) -> None:
+        self._authoritative_source_types.update(resource_types)
+
+    def clear_source_authoritative(self, resource_types: List[str]) -> None:
+        for resource_type in resource_types:
+            self._authoritative_source_types.discard(resource_type)
+
+    def dump_state(self, origin: Origin = Origin.SOURCE) -> None:
+        """Flush in-memory writes to storage. Defaults to SOURCE-only.
+
+        Rejects Origin.DESTINATION / Origin.ALL: import never populates
+        destination state, so dumping it would write an empty dict and
+        could be misinterpreted by readers as "no destination data".
+        """
+        if origin != Origin.SOURCE:
+            raise ValueError(f"ImportState.dump_state only supports Origin.SOURCE; got {origin}")
+        dump_start = time.perf_counter()
+        self._storage.put(origin, self._data)
+        log.info(
+            "sync-cli-timing phase=dump_state origin=%s wall_ms=%d",
+            origin.value,
+            int((time.perf_counter() - dump_start) * 1000),
+        )

--- a/datadog_sync/utils/resources_handler.py
+++ b/datadog_sync/utils/resources_handler.py
@@ -5,7 +5,9 @@
 
 from __future__ import annotations
 import asyncio
+import logging
 import sys
+import time
 from collections import defaultdict
 from copy import deepcopy
 from time import sleep
@@ -14,7 +16,7 @@ from typing import Dict, TYPE_CHECKING, List, Optional, Set, Tuple
 from click import UsageError, confirm
 from pprint import pformat
 
-from datadog_sync.constants import TRUE, FALSE, FORCE, Command, Origin, Status
+from datadog_sync.constants import LOGGER_NAME, TRUE, FALSE, FORCE, Command, Origin, Status
 from datadog_sync.utils.resource_utils import (
     CustomClientHTTPError,
     ResourceConnectionError,
@@ -31,6 +33,9 @@ from datadog_sync.utils.workers import Workers
 if TYPE_CHECKING:
     from datadog_sync.utils.configuration import Configuration
     from graphlib import TopologicalSorter
+
+
+_timing_log = logging.getLogger(LOGGER_NAME)
 
 
 class ResourcesHandler:
@@ -382,6 +387,7 @@ class ResourcesHandler:
 
         # Get all resources for each resource type
         tmp_storage = defaultdict(list)
+        api_discovery_start_ns = time.perf_counter_ns()
         await self.worker.init_workers(self._import_get_resources_cb, None, len(self.config.resources_arg), tmp_storage)
         for resource_type in self.config.resources_arg:
             self.worker.work_queue.put_nowait(resource_type)
@@ -391,6 +397,13 @@ class ResourcesHandler:
             await self.worker.schedule_workers()
         get_failures = self.worker.counter.failure
         self.config.logger.info(f"Finished getting resources. {self.worker.counter}")
+        _timing_log.info(
+            "sync-cli-timing phase=api_discovery resource_types=%d successes=%d " "failures=%d wall_ms=%d",
+            len(self.config.resources_arg),
+            self.worker.counter.successes,
+            get_failures,
+            (time.perf_counter_ns() - api_discovery_start_ns) // 1_000_000,
+        )
 
         # When --id-file is set, cap second-pass workers to the same
         # max_concurrent_reads value used for first-pass fetches. This prevents the
@@ -400,6 +413,7 @@ class ResourcesHandler:
 
         # Begin importing individual resource items
         self.config.logger.info("importing individual resource items")
+        per_resource_start_ns = time.perf_counter_ns()
         await self.worker.init_workers(self._import_resource, None, second_pass_cap)
         total = 0
         for k, v in tmp_storage.items():
@@ -420,6 +434,11 @@ class ResourcesHandler:
                 import_failures,
             )
         self.config.logger.info(f"finished importing individual resource items: {self.worker.counter}.")
+        _timing_log.info(
+            "sync-cli-timing phase=import_per_resource total_records=%d wall_ms=%d",
+            total,
+            (time.perf_counter_ns() - per_resource_start_ns) // 1_000_000,
+        )
 
         # If a per-type transient-failure budget was breached during the id-file
         # path, exit non-zero with a rate-limit-shaped log marker so downstream
@@ -439,7 +458,9 @@ class ResourcesHandler:
         self.config.logger.info("getting resources", resource_type=resource_type)
 
         r_class = self.config.resources[resource_type]
-        self.config.state.source[resource_type].clear()
+        # Use SourceStateWriter protocol method; works on both State and
+        # ImportState (the latter has no .source accessor).
+        self.config.state.clear_source_type(resource_type)
 
         # The --id-file path replaces the unfiltered list call with per-ID GETs
         # bounded by --max-concurrent-reads. Monitors only in v1.

--- a/datadog_sync/utils/source_state_writer.py
+++ b/datadog_sync/utils/source_state_writer.py
@@ -1,0 +1,47 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+"""Protocol for the write-only source-state surface shared by State and ImportState.
+
+The import command never reads existing state — it discards prior data, fetches
+fresh resources from the API, and writes the new state. Both State (which loads
+on construction) and ImportState (which skips the load) implement this protocol;
+code on the import path can be typed against the protocol so it does not depend
+on read accessors that ImportState does not expose.
+"""
+
+from typing import Any, Dict, List, Protocol, runtime_checkable
+
+from datadog_sync.constants import Origin
+
+
+@runtime_checkable
+class SourceStateWriter(Protocol):
+    """Write-only state surface used by the import command path.
+
+    State satisfies this by exposing both reads (via .source / .destination
+    properties) and these write methods. ImportState satisfies this by exposing
+    only the write methods (no .source / .destination properties at all).
+    """
+
+    def set_source(self, resource_type: str, _id: str, resource: Dict[str, Any]) -> None:
+        """Append or overwrite one resource in the in-memory source state."""
+        ...
+
+    def clear_source_type(self, resource_type: str) -> None:
+        """Clear the in-memory source dict for one resource type."""
+        ...
+
+    def mark_source_authoritative(self, resource_types: List[str]) -> None:
+        """Mark resource types as having a complete source load (for stale-file pruning)."""
+        ...
+
+    def clear_source_authoritative(self, resource_types: List[str]) -> None:
+        """Clear authoritative markers, e.g. before a re-import."""
+        ...
+
+    def dump_state(self, origin: Origin = Origin.SOURCE) -> None:
+        """Flush in-memory state to storage. Import callers should leave the default."""
+        ...

--- a/datadog_sync/utils/state.py
+++ b/datadog_sync/utils/state.py
@@ -3,22 +3,11 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019 Datadog, Inc.
 import logging
+import time
 from typing import Any, Dict, List, Set, Tuple
 
-from datadog_sync.constants import (
-    Origin,
-    DESTINATION_PATH_DEFAULT,
-    DESTINATION_PATH_PARAM,
-    LOGGER_NAME,
-    RESOURCE_PER_FILE,
-    SOURCE_PATH_DEFAULT,
-    SOURCE_PATH_PARAM,
-)
-from datadog_sync.utils.storage._base_storage import BaseStorage, StorageData
-from datadog_sync.utils.storage.aws_s3_bucket import AWSS3Bucket
-from datadog_sync.utils.storage.azure_blob_container import AzureBlobContainer
-from datadog_sync.utils.storage.gcs_bucket import GCSBucket
-from datadog_sync.utils.storage.local_file import LocalFile
+from datadog_sync.constants import LOGGER_NAME, Origin, RESOURCE_PER_FILE
+from datadog_sync.utils.storage._base_storage import BaseStorage, StorageData, build_storage_backend
 from datadog_sync.utils.storage.storage_types import StorageType
 
 log = logging.getLogger(LOGGER_NAME)
@@ -26,6 +15,7 @@ log = logging.getLogger(LOGGER_NAME)
 
 class State:
     def __init__(self, type_: StorageType = StorageType.LOCAL_FILE, **kwargs: object) -> None:
+        init_start = time.perf_counter()
         self._resource_types = kwargs.get("resource_types", None)  # type-scoped loading
         self._exact_ids = kwargs.get("exact_ids", None)  # ID-targeted loading
         self._minimize_reads = self._resource_types is not None or self._exact_ids is not None
@@ -33,49 +23,16 @@ class State:
         self._bulk_loaded_types: set = set()  # tracks types bulk-loaded by ensure_resource_type_loaded
         self._authoritative_source_types: Set[str] = set()
         resource_per_file = kwargs.get(RESOURCE_PER_FILE, False)
-        source_resources_path = kwargs.get(SOURCE_PATH_PARAM, SOURCE_PATH_DEFAULT)
-        destination_resources_path = kwargs.get(DESTINATION_PATH_PARAM, DESTINATION_PATH_DEFAULT)
-        if type_ == StorageType.LOCAL_FILE:
-            self._storage: BaseStorage = LocalFile(
-                source_resources_path=source_resources_path,
-                destination_resources_path=destination_resources_path,
-                resource_per_file=resource_per_file,
-            )
-        elif type_ == StorageType.AWS_S3_BUCKET:
-            config = kwargs.get("config", {})
-            if not config:
-                raise ValueError("AWS configuration not found")
-            self._storage: BaseStorage = AWSS3Bucket(
-                source_resources_path=source_resources_path,
-                destination_resources_path=destination_resources_path,
-                config=config,
-                resource_per_file=resource_per_file,
-            )
-        elif type_ == StorageType.GCS_BUCKET:
-            config = kwargs.get("config", {})
-            if not config:
-                raise ValueError("GCS configuration not found")
-            self._storage: BaseStorage = GCSBucket(
-                source_resources_path=source_resources_path,
-                destination_resources_path=destination_resources_path,
-                config=config,
-                resource_per_file=resource_per_file,
-            )
-        elif type_ == StorageType.AZURE_BLOB_CONTAINER:
-            config = kwargs.get("config", {})
-            if not config:
-                raise ValueError("Azure configuration not found")
-            self._storage: BaseStorage = AzureBlobContainer(
-                source_resources_path=source_resources_path,
-                destination_resources_path=destination_resources_path,
-                config=config,
-                resource_per_file=resource_per_file,
-            )
-        else:
-            raise NotImplementedError(f"Storage type {type_} not implemented")
-
+        self._storage: BaseStorage = build_storage_backend(type_, **kwargs)
         self._data: StorageData = StorageData()
         self.load_state()
+        log.info(
+            "sync-cli-timing phase=state_init storage_type=%s resource_per_file=%s minimize_reads=%s wall_ms=%d",
+            type_.name,
+            resource_per_file,
+            self._minimize_reads,
+            int((time.perf_counter() - init_start) * 1000),
+        )
 
     @property
     def source(self):
@@ -95,13 +52,46 @@ class State:
             self._authoritative_source_types.discard(resource_type)
 
     def load_state(self, origin: Origin = Origin.ALL) -> None:
+        load_start = time.perf_counter()
         self._authoritative_source_types.clear()
         if self._exact_ids is not None:
             # ID-targeted: fetch only specified resources by constructing keys directly
+            strategy = "id_targeted"
             self._data = self._storage.get_by_ids(origin, self._exact_ids)
         else:
             # Type-scoped (resource_types set) or full load (resource_types=None)
+            strategy = "type_scoped" if self._resource_types is not None else "full"
             self._data = self._storage.get(origin, resource_types=self._resource_types)
+        log.info(
+            "sync-cli-timing phase=load_state origin=%s strategy=%s wall_ms=%d",
+            origin.value,
+            strategy,
+            int((time.perf_counter() - load_start) * 1000),
+        )
+
+    def set_source(self, resource_type: str, _id: str, resource: Dict[str, Any]) -> None:
+        """Append/overwrite one resource in the in-memory source state.
+
+        Provided to satisfy the SourceStateWriter protocol so import-path code
+        can be written against the protocol and work with either State or
+        ImportState. State's implementation mutates the underlying dict;
+        ImportState's implementation does the same on an unloaded data store.
+
+        Intended for the import command path only. Sync/diffs/migrate code
+        continues to read and write `self.source[type][_id]` directly via the
+        property accessors. This method is not a sync-path API and adding new
+        sync-path callers is discouraged; the existing direct dict access is
+        the established pattern for those code paths.
+        """
+        self._data.source[resource_type][_id] = resource
+
+    def clear_source_type(self, resource_type: str) -> None:
+        """Clear the in-memory source dict for one resource type.
+
+        Provided to satisfy the SourceStateWriter protocol; see set_source for
+        intent. Intended for the import command path only.
+        """
+        self._data.source[resource_type].clear()
 
     def ensure_resource_type_loaded(self, resource_type: str) -> None:
         """Bulk-load all resources of a type into state for full-scan lookups.
@@ -179,7 +169,13 @@ class State:
             self._data.destination[resource_type][resource_id] = dst
 
     def dump_state(self, origin: Origin = Origin.ALL) -> None:
+        dump_start = time.perf_counter()
         self._storage.put(origin, self._data)
+        log.info(
+            "sync-cli-timing phase=dump_state origin=%s wall_ms=%d",
+            origin.value,
+            int((time.perf_counter() - dump_start) * 1000),
+        )
 
     def get_all_resources(self, resources_types: List[str]) -> Dict[Tuple[str, str], Any]:
         """Returns all resources of the given types.

--- a/datadog_sync/utils/storage/_base_storage.py
+++ b/datadog_sync/utils/storage/_base_storage.py
@@ -9,10 +9,75 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
-from datadog_sync.constants import LOGGER_NAME, Origin
+from datadog_sync.constants import (
+    DESTINATION_PATH_DEFAULT,
+    DESTINATION_PATH_PARAM,
+    LOGGER_NAME,
+    Origin,
+    RESOURCE_PER_FILE,
+    SOURCE_PATH_DEFAULT,
+    SOURCE_PATH_PARAM,
+)
 
 
 log = logging.getLogger(LOGGER_NAME)
+
+
+def build_storage_backend(type_, **kwargs) -> "BaseStorage":
+    """Construct the concrete BaseStorage subclass for a given StorageType.
+
+    Shared by State and ImportState so the per-backend init logic does not
+    drift across the two state classes. Imports the backend modules lazily
+    so this module stays importable in environments that lack one cloud SDK.
+    """
+    # Lazy imports avoid a hard dependency on every cloud SDK at module-load
+    # time; users who only need LocalFile shouldn't need boto3 / google-cloud
+    # / azure-storage-blob installed.
+    from datadog_sync.utils.storage.aws_s3_bucket import AWSS3Bucket
+    from datadog_sync.utils.storage.azure_blob_container import AzureBlobContainer
+    from datadog_sync.utils.storage.gcs_bucket import GCSBucket
+    from datadog_sync.utils.storage.local_file import LocalFile
+    from datadog_sync.utils.storage.storage_types import StorageType
+
+    resource_per_file = kwargs.get(RESOURCE_PER_FILE, False)
+    source_resources_path = kwargs.get(SOURCE_PATH_PARAM, SOURCE_PATH_DEFAULT)
+    destination_resources_path = kwargs.get(DESTINATION_PATH_PARAM, DESTINATION_PATH_DEFAULT)
+
+    if type_ == StorageType.LOCAL_FILE:
+        return LocalFile(
+            source_resources_path=source_resources_path,
+            destination_resources_path=destination_resources_path,
+            resource_per_file=resource_per_file,
+        )
+    config = kwargs.get("config", {})
+    if type_ == StorageType.AWS_S3_BUCKET:
+        if not config:
+            raise ValueError("AWS configuration not found")
+        return AWSS3Bucket(
+            source_resources_path=source_resources_path,
+            destination_resources_path=destination_resources_path,
+            config=config,
+            resource_per_file=resource_per_file,
+        )
+    if type_ == StorageType.GCS_BUCKET:
+        if not config:
+            raise ValueError("GCS configuration not found")
+        return GCSBucket(
+            source_resources_path=source_resources_path,
+            destination_resources_path=destination_resources_path,
+            config=config,
+            resource_per_file=resource_per_file,
+        )
+    if type_ == StorageType.AZURE_BLOB_CONTAINER:
+        if not config:
+            raise ValueError("Azure configuration not found")
+        return AzureBlobContainer(
+            source_resources_path=source_resources_path,
+            destination_resources_path=destination_resources_path,
+            config=config,
+            resource_per_file=resource_per_file,
+        )
+    raise NotImplementedError(f"Storage type {type_} not implemented")
 
 
 @dataclass

--- a/datadog_sync/utils/storage/aws_s3_bucket.py
+++ b/datadog_sync/utils/storage/aws_s3_bucket.py
@@ -5,6 +5,7 @@
 
 import json
 import logging
+import time
 from collections import defaultdict
 from typing import Dict, Optional, Set, Tuple
 
@@ -24,7 +25,6 @@ log = logging.getLogger(LOGGER_NAME)
 
 
 class AWSS3Bucket(BaseStorage):
-
     def __init__(
         self,
         source_resources_path=SOURCE_PATH_DEFAULT,
@@ -78,89 +78,161 @@ class AWSS3Bucket(BaseStorage):
         When resource_types is None: single broad listing (existing behavior).
         When resource_types is set: one listing per type using type-specific prefix,
         reducing both list and get_object calls from O(all_resources) to O(requested_resources).
+
+        Emits a `sync-cli-timing phase=list_and_load` log line per call (from
+        a finally block, so the line fires even when a list_objects_v2 or
+        get_object call raises). aborted=1 indicates the call exited via an
+        uncaught exception; aborted=0 indicates normal return. SDK-internal
+        retries below this layer are not visible; only outer-loop exceptions
+        caught here are counted in transient_errors.
         """
+        call_start_ns = time.perf_counter_ns()
         result = defaultdict(dict)
-        # Scoped: iterate one type at a time using tight prefix "{base}/{type}."
-        # Unscoped: single broad listing — existing behavior
-        prefixes = [f"{base_prefix}/{rt}." for rt in resource_types] if resource_types is not None else [base_prefix]
-        for prefix in prefixes:
-            continuation_token = None
-            while True:
-                list_kwargs = {"Bucket": self.bucket_name, "Prefix": prefix}
-                if continuation_token:
-                    list_kwargs["ContinuationToken"] = continuation_token
+        list_ns = 0
+        download_ns = 0
+        pages_listed = 0
+        objects_listed = 0
+        objects_downloaded = 0
+        transient_errors = 0
+        aborted = 1
+        try:
+            # Scoped: iterate one type at a time using tight prefix "{base}/{type}."
+            # Unscoped: single broad listing — existing behavior
+            prefixes = (
+                [f"{base_prefix}/{rt}." for rt in resource_types] if resource_types is not None else [base_prefix]
+            )
+            for prefix in prefixes:
+                continuation_token = None
+                while True:
+                    list_kwargs = {"Bucket": self.bucket_name, "Prefix": prefix}
+                    if continuation_token:
+                        list_kwargs["ContinuationToken"] = continuation_token
 
-                response = self.client.list_objects_v2(**list_kwargs)
+                    list_start_ns = time.perf_counter_ns()
+                    response = self.client.list_objects_v2(**list_kwargs)
+                    list_ns += time.perf_counter_ns() - list_start_ns
+                    pages_listed += 1
 
-                if "Contents" in response:
-                    for item in response["Contents"]:
-                        key = item["Key"]
-                        if not key.endswith(".json"):
-                            continue
-                        resource_type = key.split(".")[0].split("/")[-1]
-                        obj = self.client.get_object(Bucket=self.bucket_name, Key=key)
-                        try:
-                            result[resource_type].update(json.load(obj["Body"]))
-                        except json.decoder.JSONDecodeError:
-                            log.warning(f"invalid json in aws {label} resource file: {resource_type}")
+                    if "Contents" in response:
+                        for item in response["Contents"]:
+                            key = item["Key"]
+                            objects_listed += 1
+                            if not key.endswith(".json"):
+                                continue
+                            resource_type = key.split(".")[0].split("/")[-1]
+                            dl_start_ns = time.perf_counter_ns()
+                            try:
+                                obj = self.client.get_object(Bucket=self.bucket_name, Key=key)
+                                result[resource_type].update(json.load(obj["Body"]))
+                                objects_downloaded += 1
+                            except json.decoder.JSONDecodeError:
+                                log.warning(f"invalid json in aws {label} resource file: {resource_type}")
+                                transient_errors += 1
+                            except ClientError as e:
+                                # NoSuchKey: race-delete between list and get. Count
+                                # alongside the GCS/Azure equivalent, warn, continue.
+                                # Other ClientErrors (auth, throttling) escape to the
+                                # outer try/finally and are logged as aborted=1.
+                                if e.response.get("Error", {}).get("Code") == "NoSuchKey":
+                                    log.warning(f"aws {label} resource file not found (may have been deleted): {key}")
+                                    transient_errors += 1
+                                else:
+                                    raise
+                            download_ns += time.perf_counter_ns() - dl_start_ns
 
-                if response.get("IsTruncated"):
-                    continuation_token = response.get("NextContinuationToken")
-                else:
-                    break
+                    if response.get("IsTruncated"):
+                        continuation_token = response.get("NextContinuationToken")
+                    else:
+                        break
+            aborted = 0
+        finally:
+            log.info(
+                "sync-cli-timing phase=list_and_load backend=aws_s3 label=%s pages_listed=%d "
+                "blobs_listed=%d blobs_downloaded=%d transient_errors=%d aborted=%d "
+                "list_ms=%d download_ms=%d wall_ms=%d",
+                label,
+                pages_listed,
+                objects_listed,
+                objects_downloaded,
+                transient_errors,
+                aborted,
+                list_ns // 1_000_000,
+                download_ns // 1_000_000,
+                (time.perf_counter_ns() - call_start_ns) // 1_000_000,
+            )
         return result
 
     def put(self, origin: Origin, data: StorageData) -> None:
         log.info("AWS S3 put called")
-        if origin in [Origin.SOURCE, Origin.ALL]:
-            for resource_type, resource_data in data.source.items():
-                base_key = f"{self.source_resources_path}/{resource_type}"
-                if self.resource_per_file:
-                    skip_ids = self._check_id_collisions(resource_data, resource_type)
-                    for _id, resource in resource_data.items():
-                        if _id in skip_ids:
-                            continue
-                        safe_id = self._sanitize_id_for_filename(_id)
-                        key = f"{base_key}.{safe_id}.json"
-                        binary_data = bytes(json.dumps({_id: resource}), "UTF-8")
+        call_start_ns = time.perf_counter_ns()
+        blobs_written_source = 0
+        blobs_written_destination = 0
+        aborted = 1
+        try:
+            if origin in [Origin.SOURCE, Origin.ALL]:
+                for resource_type, resource_data in data.source.items():
+                    base_key = f"{self.source_resources_path}/{resource_type}"
+                    if self.resource_per_file:
+                        skip_ids = self._check_id_collisions(resource_data, resource_type)
+                        for _id, resource in resource_data.items():
+                            if _id in skip_ids:
+                                continue
+                            safe_id = self._sanitize_id_for_filename(_id)
+                            key = f"{base_key}.{safe_id}.json"
+                            binary_data = bytes(json.dumps({_id: resource}), "UTF-8")
+                            self.client.put_object(
+                                Body=binary_data,
+                                Bucket=self.bucket_name,
+                                Key=key,
+                            )
+                            blobs_written_source += 1
+                    else:
+                        key = f"{base_key}.json"
+                        binary_data = bytes(json.dumps(resource_data), "UTF-8")
                         self.client.put_object(
                             Body=binary_data,
                             Bucket=self.bucket_name,
                             Key=key,
                         )
-                else:
-                    key = f"{base_key}.json"
-                    binary_data = bytes(json.dumps(resource_data), "UTF-8")
-                    self.client.put_object(
-                        Body=binary_data,
-                        Bucket=self.bucket_name,
-                        Key=key,
-                    )
+                        blobs_written_source += 1
 
-        if origin in [Origin.DESTINATION, Origin.ALL]:
-            for resource_type, resource_data in data.destination.items():
-                base_key = f"{self.destination_resources_path}/{resource_type}"
-                if self.resource_per_file:
-                    skip_ids = self._check_id_collisions(resource_data, resource_type)
-                    for _id, resource in resource_data.items():
-                        if _id in skip_ids:
-                            continue
-                        safe_id = self._sanitize_id_for_filename(_id)
-                        key = f"{base_key}.{safe_id}.json"
-                        binary_data = bytes(json.dumps({_id: resource}), "UTF-8")
+            if origin in [Origin.DESTINATION, Origin.ALL]:
+                for resource_type, resource_data in data.destination.items():
+                    base_key = f"{self.destination_resources_path}/{resource_type}"
+                    if self.resource_per_file:
+                        skip_ids = self._check_id_collisions(resource_data, resource_type)
+                        for _id, resource in resource_data.items():
+                            if _id in skip_ids:
+                                continue
+                            safe_id = self._sanitize_id_for_filename(_id)
+                            key = f"{base_key}.{safe_id}.json"
+                            binary_data = bytes(json.dumps({_id: resource}), "UTF-8")
+                            self.client.put_object(
+                                Body=binary_data,
+                                Bucket=self.bucket_name,
+                                Key=key,
+                            )
+                            blobs_written_destination += 1
+                    else:
+                        key = f"{base_key}.json"
+                        binary_data = bytes(json.dumps(resource_data), "UTF-8")
                         self.client.put_object(
                             Body=binary_data,
                             Bucket=self.bucket_name,
                             Key=key,
                         )
-                else:
-                    key = f"{base_key}.json"
-                    binary_data = bytes(json.dumps(resource_data), "UTF-8")
-                    self.client.put_object(
-                        Body=binary_data,
-                        Bucket=self.bucket_name,
-                        Key=key,
-                    )
+                        blobs_written_destination += 1
+            aborted = 0
+        finally:
+            log.info(
+                "sync-cli-timing phase=put backend=aws_s3 origin=%s "
+                "blobs_written_source=%d blobs_written_destination=%d aborted=%d wall_ms=%d",
+                origin.value,
+                blobs_written_source,
+                blobs_written_destination,
+                aborted,
+                (time.perf_counter_ns() - call_start_ns) // 1_000_000,
+            )
 
     def _path_for(self, origin: Origin) -> str:
         if origin == Origin.SOURCE:

--- a/datadog_sync/utils/storage/azure_blob_container.py
+++ b/datadog_sync/utils/storage/azure_blob_container.py
@@ -5,6 +5,7 @@
 
 import json
 import logging
+import time
 from collections import defaultdict
 from typing import Dict, Optional, Set, Tuple
 
@@ -25,7 +26,6 @@ log = logging.getLogger(LOGGER_NAME)
 
 
 class AzureBlobContainer(BaseStorage):
-
     def __init__(
         self,
         source_resources_path=SOURCE_PATH_DEFAULT,
@@ -80,52 +80,161 @@ class AzureBlobContainer(BaseStorage):
         return data
 
     def _list_and_load(self, base_prefix: str, resource_types, label: str):
-        """List and load Azure blobs, optionally scoped to resource_types."""
+        """List and load Azure blobs, optionally scoped to resource_types.
+
+        Emits a `sync-cli-timing phase=list_and_load` log line per call (from
+        a finally block, so the line fires even when list_blobs or
+        download_blob raises). aborted=1 indicates the call exited via an
+        uncaught exception. SDK-internal retries below this layer are not
+        visible; only outer-loop exceptions caught here are counted in
+        transient_errors.
+
+        Uses ItemPaged.by_page() introspection when the real Azure SDK iterator
+        is in use; falls back to single-page counting against mocks that return
+        a flat list.
+        """
+        call_start_ns = time.perf_counter_ns()
         result = defaultdict(dict)
-        prefixes = [f"{base_prefix}/{rt}." for rt in resource_types] if resource_types is not None else [base_prefix]
-        for prefix in prefixes:
-            for blob in self.container_client.list_blobs(name_starts_with=prefix):
-                if not blob.name.endswith(".json"):
-                    continue
-                resource_type = blob.name.split(".")[0].split("/")[-1]
-                try:
-                    content = self.container_client.download_blob(blob.name).readall().decode("utf-8")
-                    result[resource_type].update(json.loads(content))
-                except json.decoder.JSONDecodeError:
-                    log.warning(f"invalid json in azure {label} resource file: {resource_type}")
+        list_ns = 0
+        download_ns = 0
+        pages_listed = 0
+        blobs_listed = 0
+        blobs_downloaded = 0
+        transient_errors = 0
+        aborted = 1
+        try:
+            prefixes = (
+                [f"{base_prefix}/{rt}." for rt in resource_types] if resource_types is not None else [base_prefix]
+            )
+            for prefix in prefixes:
+                iterator = self.container_client.list_blobs(name_starts_with=prefix)
+                by_page = getattr(iterator, "by_page", None)
+                if by_page is not None:
+                    list_resume_ns = time.perf_counter_ns()
+                    for page in by_page():
+                        pages_listed += 1
+                        list_ns += time.perf_counter_ns() - list_resume_ns
+                        for blob in page:
+                            blobs_listed += 1
+                            if not blob.name.endswith(".json"):
+                                continue
+                            resource_type = blob.name.split(".")[0].split("/")[-1]
+                            dl_start_ns = time.perf_counter_ns()
+                            try:
+                                content = self.container_client.download_blob(blob.name).readall().decode("utf-8")
+                                result[resource_type].update(json.loads(content))
+                                blobs_downloaded += 1
+                            except json.decoder.JSONDecodeError:
+                                log.warning(f"invalid json in azure {label} resource file: {resource_type}")
+                                transient_errors += 1
+                            except ResourceNotFoundError:
+                                # Race-delete between list_blobs and download_blob.
+                                # Matches GCS NotFound / AWS NoSuchKey handling.
+                                log.warning(
+                                    f"azure {label} resource file not found (may have been deleted): {blob.name}"
+                                )
+                                transient_errors += 1
+                            download_ns += time.perf_counter_ns() - dl_start_ns
+                        list_resume_ns = time.perf_counter_ns()
+                else:
+                    # Test-mock fallback: flat-list iterator with no by_page accessor.
+                    pages_listed += 1
+                    list_resume_ns = time.perf_counter_ns()
+                    for blob in iterator:
+                        list_ns += time.perf_counter_ns() - list_resume_ns
+                        blobs_listed += 1
+                        if not blob.name.endswith(".json"):
+                            list_resume_ns = time.perf_counter_ns()
+                            continue
+                        resource_type = blob.name.split(".")[0].split("/")[-1]
+                        dl_start_ns = time.perf_counter_ns()
+                        try:
+                            content = self.container_client.download_blob(blob.name).readall().decode("utf-8")
+                            result[resource_type].update(json.loads(content))
+                            blobs_downloaded += 1
+                        except json.decoder.JSONDecodeError:
+                            log.warning(f"invalid json in azure {label} resource file: {resource_type}")
+                            transient_errors += 1
+                        except ResourceNotFoundError:
+                            # Race-delete between list_blobs and download_blob.
+                            # Matches GCS NotFound / AWS NoSuchKey handling.
+                            log.warning(f"azure {label} resource file not found (may have been deleted): {blob.name}")
+                            transient_errors += 1
+                        download_ns += time.perf_counter_ns() - dl_start_ns
+                        list_resume_ns = time.perf_counter_ns()
+            aborted = 0
+        finally:
+            log.info(
+                "sync-cli-timing phase=list_and_load backend=azure_blob label=%s pages_listed=%d "
+                "blobs_listed=%d blobs_downloaded=%d transient_errors=%d aborted=%d "
+                "list_ms=%d download_ms=%d wall_ms=%d",
+                label,
+                pages_listed,
+                blobs_listed,
+                blobs_downloaded,
+                transient_errors,
+                aborted,
+                list_ns // 1_000_000,
+                download_ns // 1_000_000,
+                (time.perf_counter_ns() - call_start_ns) // 1_000_000,
+            )
         return result
 
     def put(self, origin: Origin, data: StorageData) -> None:
         log.info("Azure Blob Storage put called")
-        if origin in [Origin.SOURCE, Origin.ALL]:
-            for resource_type, resource_data in data.source.items():
-                base_key = f"{self.source_resources_path}/{resource_type}"
-                if self.resource_per_file:
-                    skip_ids = self._check_id_collisions(resource_data, resource_type)
-                    for _id, resource in resource_data.items():
-                        if _id in skip_ids:
-                            continue
-                        safe_id = self._sanitize_id_for_filename(_id)
-                        key = f"{base_key}.{safe_id}.json"
-                        self.container_client.upload_blob(name=key, data=json.dumps({_id: resource}), overwrite=True)
-                else:
-                    key = f"{base_key}.json"
-                    self.container_client.upload_blob(name=key, data=json.dumps(resource_data), overwrite=True)
+        call_start_ns = time.perf_counter_ns()
+        blobs_written_source = 0
+        blobs_written_destination = 0
+        aborted = 1
+        try:
+            if origin in [Origin.SOURCE, Origin.ALL]:
+                for resource_type, resource_data in data.source.items():
+                    base_key = f"{self.source_resources_path}/{resource_type}"
+                    if self.resource_per_file:
+                        skip_ids = self._check_id_collisions(resource_data, resource_type)
+                        for _id, resource in resource_data.items():
+                            if _id in skip_ids:
+                                continue
+                            safe_id = self._sanitize_id_for_filename(_id)
+                            key = f"{base_key}.{safe_id}.json"
+                            self.container_client.upload_blob(
+                                name=key, data=json.dumps({_id: resource}), overwrite=True
+                            )
+                            blobs_written_source += 1
+                    else:
+                        key = f"{base_key}.json"
+                        self.container_client.upload_blob(name=key, data=json.dumps(resource_data), overwrite=True)
+                        blobs_written_source += 1
 
-        if origin in [Origin.DESTINATION, Origin.ALL]:
-            for resource_type, resource_data in data.destination.items():
-                base_key = f"{self.destination_resources_path}/{resource_type}"
-                if self.resource_per_file:
-                    skip_ids = self._check_id_collisions(resource_data, resource_type)
-                    for _id, resource in resource_data.items():
-                        if _id in skip_ids:
-                            continue
-                        safe_id = self._sanitize_id_for_filename(_id)
-                        key = f"{base_key}.{safe_id}.json"
-                        self.container_client.upload_blob(name=key, data=json.dumps({_id: resource}), overwrite=True)
-                else:
-                    key = f"{base_key}.json"
-                    self.container_client.upload_blob(name=key, data=json.dumps(resource_data), overwrite=True)
+            if origin in [Origin.DESTINATION, Origin.ALL]:
+                for resource_type, resource_data in data.destination.items():
+                    base_key = f"{self.destination_resources_path}/{resource_type}"
+                    if self.resource_per_file:
+                        skip_ids = self._check_id_collisions(resource_data, resource_type)
+                        for _id, resource in resource_data.items():
+                            if _id in skip_ids:
+                                continue
+                            safe_id = self._sanitize_id_for_filename(_id)
+                            key = f"{base_key}.{safe_id}.json"
+                            self.container_client.upload_blob(
+                                name=key, data=json.dumps({_id: resource}), overwrite=True
+                            )
+                            blobs_written_destination += 1
+                    else:
+                        key = f"{base_key}.json"
+                        self.container_client.upload_blob(name=key, data=json.dumps(resource_data), overwrite=True)
+                        blobs_written_destination += 1
+            aborted = 0
+        finally:
+            log.info(
+                "sync-cli-timing phase=put backend=azure_blob origin=%s "
+                "blobs_written_source=%d blobs_written_destination=%d aborted=%d wall_ms=%d",
+                origin.value,
+                blobs_written_source,
+                blobs_written_destination,
+                aborted,
+                (time.perf_counter_ns() - call_start_ns) // 1_000_000,
+            )
 
     def _path_for(self, origin: Origin) -> str:
         if origin == Origin.SOURCE:

--- a/datadog_sync/utils/storage/gcs_bucket.py
+++ b/datadog_sync/utils/storage/gcs_bucket.py
@@ -5,6 +5,7 @@
 
 import json
 import logging
+import time
 from collections import defaultdict
 from typing import Dict, Optional, Set, Tuple
 
@@ -24,7 +25,6 @@ log = logging.getLogger(LOGGER_NAME)
 
 
 class GCSBucket(BaseStorage):
-
     def __init__(
         self,
         source_resources_path=SOURCE_PATH_DEFAULT,
@@ -66,58 +66,171 @@ class GCSBucket(BaseStorage):
         return data
 
     def _list_and_load(self, base_prefix: str, resource_types, label: str):
-        """List and load GCS blobs, optionally scoped to resource_types."""
+        """List and load GCS blobs, optionally scoped to resource_types.
+
+        Emits a `sync-cli-timing phase=list_and_load` log line per call (from
+        a finally block, so the line fires even when an SDK call raises and
+        the exception propagates out). Fields:
+        - list_ms vs download_ms: split between time spent in the listing
+          iterator and time spent in per-blob downloads. The primary signal
+          for diagnosing reader/writer races on a bucket prefix being written
+          concurrently — high list_ms with low download_ms suggests pagination
+          cost (potentially elevated under concurrent writes), while the
+          inverse points to per-blob fetch cost.
+        - pages_listed, blobs_listed, blobs_downloaded: shape counters.
+        - transient_errors: per-blob exceptions caught here
+          (json.JSONDecodeError, NotFound). SDK-internal retries below this
+          layer are not visible.
+        - aborted: 1 if the call exited via an uncaught exception (e.g. a 5xx
+          from list_blobs / download_as_text that escaped this layer's narrow
+          except clauses), 0 on normal return. Lets operators distinguish
+          a successful empty call from a failed call that yielded zero blobs.
+
+        Uses iterator.pages introspection when the real google-cloud-storage
+        HTTPIterator is in use; falls back to single-page counting against
+        mocks that return a flat list.
+        """
+        call_start_ns = time.perf_counter_ns()
         result = defaultdict(dict)
         prefixes = [f"{base_prefix}/{rt}." for rt in resource_types] if resource_types is not None else [base_prefix]
-        for prefix in prefixes:
-            for blob in self.bucket.list_blobs(prefix=prefix):
-                if not blob.name.endswith(".json"):
-                    continue
-                resource_type = blob.name.split(".")[0].split("/")[-1]
-                try:
-                    content = self.bucket.blob(blob.name).download_as_text()
-                    result[resource_type].update(json.loads(content))
-                except json.decoder.JSONDecodeError:
-                    log.warning(f"invalid json in gcs {label} resource file: {resource_type}")
-                except NotFound:
-                    log.warning(f"gcs {label} resource file not found (may have been deleted): {blob.name}")
+        list_ns = 0
+        download_ns = 0
+        pages_listed = 0
+        blobs_listed = 0
+        blobs_downloaded = 0
+        transient_errors = 0
+        aborted = 1
+        try:
+            for prefix in prefixes:
+                iterator = self.bucket.list_blobs(prefix=prefix)
+                pages_iter = getattr(iterator, "pages", None)
+                if pages_iter is not None:
+                    # Real HTTPIterator: iterate page-by-page for accurate page count.
+                    list_resume_ns = time.perf_counter_ns()
+                    for page in pages_iter:
+                        pages_listed += 1
+                        list_ns += time.perf_counter_ns() - list_resume_ns
+                        for blob in page:
+                            blobs_listed += 1
+                            if not blob.name.endswith(".json"):
+                                continue
+                            resource_type = blob.name.split(".")[0].split("/")[-1]
+                            dl_start_ns = time.perf_counter_ns()
+                            try:
+                                content = self.bucket.blob(blob.name).download_as_text()
+                                result[resource_type].update(json.loads(content))
+                                blobs_downloaded += 1
+                            except json.decoder.JSONDecodeError:
+                                log.warning(f"invalid json in gcs {label} resource file: {resource_type}")
+                                transient_errors += 1
+                            except NotFound:
+                                log.warning(f"gcs {label} resource file not found (may have been deleted): {blob.name}")
+                                transient_errors += 1
+                            download_ns += time.perf_counter_ns() - dl_start_ns
+                        list_resume_ns = time.perf_counter_ns()
+                else:
+                    # Test-mock fallback: flat-list iterator with no pages accessor.
+                    # Treat the whole iterator as one page; per-blob download timing
+                    # is still accurate.
+                    pages_listed += 1
+                    list_resume_ns = time.perf_counter_ns()
+                    for blob in iterator:
+                        list_ns += time.perf_counter_ns() - list_resume_ns
+                        blobs_listed += 1
+                        if not blob.name.endswith(".json"):
+                            list_resume_ns = time.perf_counter_ns()
+                            continue
+                        resource_type = blob.name.split(".")[0].split("/")[-1]
+                        dl_start_ns = time.perf_counter_ns()
+                        try:
+                            content = self.bucket.blob(blob.name).download_as_text()
+                            result[resource_type].update(json.loads(content))
+                            blobs_downloaded += 1
+                        except json.decoder.JSONDecodeError:
+                            log.warning(f"invalid json in gcs {label} resource file: {resource_type}")
+                            transient_errors += 1
+                        except NotFound:
+                            log.warning(f"gcs {label} resource file not found (may have been deleted): {blob.name}")
+                            transient_errors += 1
+                        download_ns += time.perf_counter_ns() - dl_start_ns
+                        list_resume_ns = time.perf_counter_ns()
+            aborted = 0
+        finally:
+            log.info(
+                "sync-cli-timing phase=list_and_load backend=gcs label=%s pages_listed=%d "
+                "blobs_listed=%d blobs_downloaded=%d transient_errors=%d aborted=%d "
+                "list_ms=%d download_ms=%d wall_ms=%d",
+                label,
+                pages_listed,
+                blobs_listed,
+                blobs_downloaded,
+                transient_errors,
+                aborted,
+                list_ns // 1_000_000,
+                download_ns // 1_000_000,
+                (time.perf_counter_ns() - call_start_ns) // 1_000_000,
+            )
         return result
 
     def put(self, origin: Origin, data: StorageData) -> None:
         log.info("GCS put called")
-        if origin in [Origin.SOURCE, Origin.ALL]:
-            for resource_type, resource_data in data.source.items():
-                base_key = f"{self.source_resources_path}/{resource_type}"
-                if self.resource_per_file:
-                    skip_ids = self._check_id_collisions(resource_data, resource_type)
-                    for _id, resource in resource_data.items():
-                        if _id in skip_ids:
-                            continue
-                        safe_id = self._sanitize_id_for_filename(_id)
-                        key = f"{base_key}.{safe_id}.json"
+        call_start_ns = time.perf_counter_ns()
+        blobs_written_source = 0
+        blobs_written_destination = 0
+        aborted = 1
+        try:
+            if origin in [Origin.SOURCE, Origin.ALL]:
+                for resource_type, resource_data in data.source.items():
+                    base_key = f"{self.source_resources_path}/{resource_type}"
+                    if self.resource_per_file:
+                        skip_ids = self._check_id_collisions(resource_data, resource_type)
+                        for _id, resource in resource_data.items():
+                            if _id in skip_ids:
+                                continue
+                            safe_id = self._sanitize_id_for_filename(_id)
+                            key = f"{base_key}.{safe_id}.json"
+                            self.bucket.blob(key).upload_from_string(
+                                json.dumps({_id: resource}), content_type="application/json"
+                            )
+                            blobs_written_source += 1
+                    else:
+                        key = f"{base_key}.json"
                         self.bucket.blob(key).upload_from_string(
-                            json.dumps({_id: resource}), content_type="application/json"
+                            json.dumps(resource_data), content_type="application/json"
                         )
-                else:
-                    key = f"{base_key}.json"
-                    self.bucket.blob(key).upload_from_string(json.dumps(resource_data), content_type="application/json")
+                        blobs_written_source += 1
 
-        if origin in [Origin.DESTINATION, Origin.ALL]:
-            for resource_type, resource_data in data.destination.items():
-                base_key = f"{self.destination_resources_path}/{resource_type}"
-                if self.resource_per_file:
-                    skip_ids = self._check_id_collisions(resource_data, resource_type)
-                    for _id, resource in resource_data.items():
-                        if _id in skip_ids:
-                            continue
-                        safe_id = self._sanitize_id_for_filename(_id)
-                        key = f"{base_key}.{safe_id}.json"
+            if origin in [Origin.DESTINATION, Origin.ALL]:
+                for resource_type, resource_data in data.destination.items():
+                    base_key = f"{self.destination_resources_path}/{resource_type}"
+                    if self.resource_per_file:
+                        skip_ids = self._check_id_collisions(resource_data, resource_type)
+                        for _id, resource in resource_data.items():
+                            if _id in skip_ids:
+                                continue
+                            safe_id = self._sanitize_id_for_filename(_id)
+                            key = f"{base_key}.{safe_id}.json"
+                            self.bucket.blob(key).upload_from_string(
+                                json.dumps({_id: resource}), content_type="application/json"
+                            )
+                            blobs_written_destination += 1
+                    else:
+                        key = f"{base_key}.json"
                         self.bucket.blob(key).upload_from_string(
-                            json.dumps({_id: resource}), content_type="application/json"
+                            json.dumps(resource_data), content_type="application/json"
                         )
-                else:
-                    key = f"{base_key}.json"
-                    self.bucket.blob(key).upload_from_string(json.dumps(resource_data), content_type="application/json")
+                        blobs_written_destination += 1
+            aborted = 0
+        finally:
+            log.info(
+                "sync-cli-timing phase=put backend=gcs origin=%s "
+                "blobs_written_source=%d blobs_written_destination=%d aborted=%d wall_ms=%d",
+                origin.value,
+                blobs_written_source,
+                blobs_written_destination,
+                aborted,
+                (time.perf_counter_ns() - call_start_ns) // 1_000_000,
+            )
 
     def _path_for(self, origin: Origin) -> str:
         if origin == Origin.SOURCE:

--- a/datadog_sync/utils/storage/local_file.py
+++ b/datadog_sync/utils/storage/local_file.py
@@ -6,6 +6,7 @@
 import json
 import logging
 import os
+import time
 from typing import Dict, Optional, Set, Tuple
 
 from datadog_sync.constants import (
@@ -21,7 +22,6 @@ log = logging.getLogger(LOGGER_NAME)
 
 
 class LocalFile(BaseStorage):
-
     def __init__(
         self,
         source_resources_path=SOURCE_PATH_DEFAULT,
@@ -39,45 +39,96 @@ class LocalFile(BaseStorage):
 
     def get(self, origin: Origin, resource_types=None) -> StorageData:
         data = StorageData()
-
-        if origin in [Origin.SOURCE, Origin.ALL] and os.path.exists(self.source_resources_path):
-            for file in os.listdir(self.source_resources_path):
-                if not file.endswith(".json"):
-                    continue
-                resource_type = file.split(".")[0]
-                if resource_types is not None and resource_type not in resource_types:
-                    continue
-                with open(self.source_resources_path + f"/{file}", "r", encoding="utf-8") as input_file:
-                    try:
-                        data.source[resource_type].update(json.load(input_file))
-                    except json.decoder.JSONDecodeError:
-                        log.warning(f"invalid json in source resource file: {file}")
-
-        if origin in [Origin.DESTINATION, Origin.ALL] and os.path.exists(self.destination_resources_path):
-            for file in os.listdir(self.destination_resources_path):
-                if not file.endswith(".json"):
-                    continue
-                resource_type = file.split(".")[0]
-                if resource_types is not None and resource_type not in resource_types:
-                    continue
-                with open(self.destination_resources_path + f"/{file}", "r", encoding="utf-8") as input_file:
-                    try:
-                        data.destination[resource_type].update(json.load(input_file))
-                    except json.decoder.JSONDecodeError:
-                        log.warning(f"invalid json in destination resource file: {file}")
-
+        if origin in [Origin.SOURCE, Origin.ALL]:
+            self._load_prefix(self.source_resources_path, data.source, resource_types, "source")
+        if origin in [Origin.DESTINATION, Origin.ALL]:
+            self._load_prefix(self.destination_resources_path, data.destination, resource_types, "destination")
         return data
 
+    def _load_prefix(self, base_path: str, target: dict, resource_types, label: str) -> None:
+        """Helper that loads one prefix and emits a `list_and_load` log line
+        matching the cloud-backend schema (label, pages_listed, blobs_listed,
+        blobs_downloaded, transient_errors, aborted, list_ms, download_ms,
+        wall_ms). The log is emitted from a finally block so it fires even when
+        os.listdir / open / json.load raises and the exception propagates out.
+
+        For local files, pages_listed=1 (single os.listdir call), list_ms is
+        the os.listdir wall-clock, download_ms sums the per-file open+json.load.
+        """
+        call_start_ns = time.perf_counter_ns()
+        list_ns = 0
+        download_ns = 0
+        files_listed = 0
+        files_loaded = 0
+        transient_errors = 0
+        aborted = 1
+        try:
+            if os.path.exists(base_path):
+                list_start_ns = time.perf_counter_ns()
+                entries = os.listdir(base_path)
+                list_ns = time.perf_counter_ns() - list_start_ns
+                for file in entries:
+                    files_listed += 1
+                    if not file.endswith(".json"):
+                        continue
+                    resource_type = file.split(".")[0]
+                    if resource_types is not None and resource_type not in resource_types:
+                        continue
+                    dl_start_ns = time.perf_counter_ns()
+                    with open(f"{base_path}/{file}", "r", encoding="utf-8") as input_file:
+                        try:
+                            target[resource_type].update(json.load(input_file))
+                            files_loaded += 1
+                        except json.decoder.JSONDecodeError:
+                            log.warning(f"invalid json in {label} resource file: {file}")
+                            transient_errors += 1
+                    download_ns += time.perf_counter_ns() - dl_start_ns
+            aborted = 0
+        finally:
+            log.info(
+                "sync-cli-timing phase=list_and_load backend=local_file label=%s pages_listed=1 "
+                "blobs_listed=%d blobs_downloaded=%d transient_errors=%d aborted=%d "
+                "list_ms=%d download_ms=%d wall_ms=%d",
+                label,
+                files_listed,
+                files_loaded,
+                transient_errors,
+                aborted,
+                list_ns // 1_000_000,
+                download_ns // 1_000_000,
+                (time.perf_counter_ns() - call_start_ns) // 1_000_000,
+            )
+
     def put(self, origin: Origin, data: StorageData) -> None:
-        if origin in [Origin.SOURCE, Origin.ALL]:
-            os.makedirs(self.source_resources_path, exist_ok=True)
-            self.write_resources_file(Origin.SOURCE, data)
+        call_start_ns = time.perf_counter_ns()
+        blobs_written_source = 0
+        blobs_written_destination = 0
+        aborted = 1
+        try:
+            if origin in [Origin.SOURCE, Origin.ALL]:
+                os.makedirs(self.source_resources_path, exist_ok=True)
+                blobs_written_source = self.write_resources_file(Origin.SOURCE, data)
 
-        if origin in [Origin.DESTINATION, Origin.ALL]:
-            os.makedirs(self.destination_resources_path, exist_ok=True)
-            self.write_resources_file(origin, data)
+            if origin in [Origin.DESTINATION, Origin.ALL]:
+                os.makedirs(self.destination_resources_path, exist_ok=True)
+                blobs_written_destination = self.write_resources_file(origin, data)
+            aborted = 0
+        finally:
+            log.info(
+                "sync-cli-timing phase=put backend=local_file origin=%s "
+                "blobs_written_source=%d blobs_written_destination=%d aborted=%d wall_ms=%d",
+                origin.value,
+                blobs_written_source,
+                blobs_written_destination,
+                aborted,
+                (time.perf_counter_ns() - call_start_ns) // 1_000_000,
+            )
 
-    def write_resources_file(self, origin: Origin, data: StorageData) -> None:
+    def write_resources_file(self, origin: Origin, data: StorageData) -> int:
+        """Write the requested origin's data to disk. Returns the count of
+        files written so callers can include it in their timing log.
+        """
+        written = 0
         if origin in [Origin.SOURCE, Origin.ALL]:
             for resource_type, value in data.source.items():
                 base_filename = f"{self.source_resources_path}/{resource_type}"
@@ -90,10 +141,12 @@ class LocalFile(BaseStorage):
                         filename = f"{base_filename}.{safe_id}.json"
                         with open(filename, "w+", encoding="utf-8") as out_file:
                             json.dump({_id: resource}, out_file)
+                        written += 1
                 else:
                     filename = f"{base_filename}.json"
                     with open(filename, "w+", encoding="utf-8") as out_file:
                         json.dump(value, out_file)
+                    written += 1
 
         if origin in [Origin.DESTINATION, Origin.ALL]:
             for resource_type, value in data.destination.items():
@@ -107,10 +160,13 @@ class LocalFile(BaseStorage):
                         filename = f"{base_filename}.{safe_id}.json"
                         with open(filename, "w+", encoding="utf-8") as out_file:
                             json.dump({_id: resource}, out_file)
+                        written += 1
                 else:
                     filename = f"{base_filename}.json"
                     with open(filename, "w+", encoding="utf-8") as out_file:
                         json.dump(value, out_file)
+                    written += 1
+        return written
 
     def _path_for(self, origin: Origin) -> str:
         if origin == Origin.SOURCE:

--- a/tests/unit/test_import_state.py
+++ b/tests/unit/test_import_state.py
@@ -1,0 +1,897 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+"""Tests for ImportState (write-only state) and the --skip-state-load flag."""
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from datadog_sync.cli import cli
+from datadog_sync.constants import Origin
+from datadog_sync.utils.import_state import ImportState
+from datadog_sync.utils.source_state_writer import SourceStateWriter
+from datadog_sync.utils.state import State
+from datadog_sync.utils.storage._base_storage import StorageData
+from datadog_sync.utils.storage.local_file import LocalFile
+from datadog_sync.utils.storage.storage_types import StorageType
+
+
+@pytest.fixture
+def runner():
+    return CliRunner(mix_stderr=True)
+
+
+class TestImportStateInvariant:
+    """ImportState exposes no source/destination read surface; reads fail at the language level."""
+
+    def test_import_state_has_no_source_attribute(self, tmp_path):
+        state = ImportState(
+            type_=StorageType.LOCAL_FILE,
+            source_resources_path=str(tmp_path / "source"),
+            destination_resources_path=str(tmp_path / "dest"),
+            resource_per_file=True,
+        )
+        assert not hasattr(state, "source")
+        with pytest.raises(AttributeError):
+            _ = state.source  # noqa: F841
+
+    def test_import_state_has_no_destination_attribute(self, tmp_path):
+        state = ImportState(
+            type_=StorageType.LOCAL_FILE,
+            source_resources_path=str(tmp_path / "source"),
+            destination_resources_path=str(tmp_path / "dest"),
+            resource_per_file=True,
+        )
+        assert not hasattr(state, "destination")
+        with pytest.raises(AttributeError):
+            _ = state.destination  # noqa: F841
+
+    def test_import_state_has_no_load_state_method(self, tmp_path):
+        state = ImportState(
+            type_=StorageType.LOCAL_FILE,
+            source_resources_path=str(tmp_path / "source"),
+            destination_resources_path=str(tmp_path / "dest"),
+            resource_per_file=True,
+        )
+        assert not hasattr(state, "load_state")
+
+    def test_import_state_has_no_compute_stale_files(self, tmp_path):
+        state = ImportState(
+            type_=StorageType.LOCAL_FILE,
+            source_resources_path=str(tmp_path / "source"),
+            destination_resources_path=str(tmp_path / "dest"),
+            resource_per_file=True,
+        )
+        assert not hasattr(state, "compute_stale_files")
+
+
+class TestImportStateWriteAPI:
+    """ImportState write methods accumulate in memory and flush via dump_state."""
+
+    def test_set_source_and_dump_writes_to_storage(self, tmp_path):
+        src = tmp_path / "source"
+        dst = tmp_path / "dest"
+        src.mkdir()
+        dst.mkdir()
+
+        state = ImportState(
+            type_=StorageType.LOCAL_FILE,
+            source_resources_path=str(src),
+            destination_resources_path=str(dst),
+            resource_per_file=True,
+        )
+        state.set_source("roles", "role-1", {"id": "role-1", "name": "Admin"})
+        state.set_source("roles", "role-2", {"id": "role-2", "name": "Viewer"})
+        state.dump_state(Origin.SOURCE)
+
+        # Read back via a fresh State to verify the writes are on disk.
+        fresh = State(
+            type_=StorageType.LOCAL_FILE,
+            source_resources_path=str(src),
+            destination_resources_path=str(dst),
+            resource_per_file=True,
+        )
+        assert fresh.source["roles"]["role-1"]["name"] == "Admin"
+        assert fresh.source["roles"]["role-2"]["name"] == "Viewer"
+
+    def test_clear_source_type_is_idempotent_on_empty(self, tmp_path):
+        state = ImportState(
+            type_=StorageType.LOCAL_FILE,
+            source_resources_path=str(tmp_path / "source"),
+            destination_resources_path=str(tmp_path / "dest"),
+            resource_per_file=True,
+        )
+        # No exception on a never-set type
+        state.clear_source_type("monitors")
+        state.clear_source_type("monitors")
+
+    def test_dump_state_rejects_destination(self, tmp_path):
+        state = ImportState(
+            type_=StorageType.LOCAL_FILE,
+            source_resources_path=str(tmp_path / "source"),
+            destination_resources_path=str(tmp_path / "dest"),
+            resource_per_file=True,
+        )
+        with pytest.raises(ValueError, match="only supports Origin.SOURCE"):
+            state.dump_state(Origin.DESTINATION)
+
+    def test_dump_state_rejects_all(self, tmp_path):
+        state = ImportState(
+            type_=StorageType.LOCAL_FILE,
+            source_resources_path=str(tmp_path / "source"),
+            destination_resources_path=str(tmp_path / "dest"),
+            resource_per_file=True,
+        )
+        with pytest.raises(ValueError, match="only supports Origin.SOURCE"):
+            state.dump_state(Origin.ALL)
+
+    def test_authoritative_marks_track_state(self, tmp_path):
+        state = ImportState(
+            type_=StorageType.LOCAL_FILE,
+            source_resources_path=str(tmp_path / "source"),
+            destination_resources_path=str(tmp_path / "dest"),
+            resource_per_file=True,
+        )
+        state.mark_source_authoritative(["users", "roles"])
+        assert state._authoritative_source_types == {"users", "roles"}
+        state.clear_source_authoritative(["users"])
+        assert state._authoritative_source_types == {"roles"}
+
+
+class TestSourceStateWriterProtocol:
+    """Both State and ImportState satisfy SourceStateWriter."""
+
+    def test_state_satisfies_protocol(self, tmp_path):
+        state = State(
+            type_=StorageType.LOCAL_FILE,
+            source_resources_path=str(tmp_path / "source"),
+            destination_resources_path=str(tmp_path / "dest"),
+            resource_per_file=True,
+        )
+        assert isinstance(state, SourceStateWriter)
+
+    def test_import_state_satisfies_protocol(self, tmp_path):
+        state = ImportState(
+            type_=StorageType.LOCAL_FILE,
+            source_resources_path=str(tmp_path / "source"),
+            destination_resources_path=str(tmp_path / "dest"),
+            resource_per_file=True,
+        )
+        assert isinstance(state, SourceStateWriter)
+
+
+class TestPartialImportPreservesUntouchedTypes:
+    """Skip-state-load partial import must not drop blobs for types it did not touch.
+
+    Addresses a senior-review concern: if `dump_state` had REPLACE semantics
+    (rewriting the source snapshot from in-memory state), starting from an
+    empty `state.source` would drop blobs for non-imported types. This test
+    verifies the actual PATCH semantics across the import flow end-to-end.
+    """
+
+    def test_dump_state_with_only_one_type_leaves_other_types_on_disk(self, tmp_path):
+        src = tmp_path / "source"
+        dst = tmp_path / "dest"
+        src.mkdir()
+        dst.mkdir()
+
+        # Pre-populate: write blobs for "roles" and "dashboards" via a regular State.
+        seed = State(
+            type_=StorageType.LOCAL_FILE,
+            source_resources_path=str(src),
+            destination_resources_path=str(dst),
+            resource_per_file=True,
+        )
+        seed.set_source("roles", "role-1", {"id": "role-1", "name": "Admin"})
+        seed.set_source("dashboards", "dash-1", {"id": "dash-1", "title": "Untouched"})
+        seed.dump_state(Origin.SOURCE)
+
+        roles_file = src / "roles.role-1.json"
+        dashboards_file = src / "dashboards.dash-1.json"
+        assert roles_file.exists()
+        assert dashboards_file.exists()
+        original_dashboards_mtime = dashboards_file.stat().st_mtime_ns
+        original_dashboards_content = dashboards_file.read_text()
+
+        # Simulate an import-with-skip-state-load that only touches "roles":
+        # construct a fresh ImportState (no preload), write a single role,
+        # and dump. The dashboards.dash-1.json blob must be untouched.
+        imp = ImportState(
+            type_=StorageType.LOCAL_FILE,
+            source_resources_path=str(src),
+            destination_resources_path=str(dst),
+            resource_per_file=True,
+        )
+        imp.clear_source_type("roles")
+        imp.set_source("roles", "role-1", {"id": "role-1", "name": "AdminUpdated"})
+        imp.dump_state(Origin.SOURCE)
+
+        # roles was rewritten with fresh data:
+        roles_content = json.loads(roles_file.read_text())
+        assert roles_content["role-1"]["name"] == "AdminUpdated"
+
+        # dashboards was NOT touched on disk (mtime + content both unchanged):
+        assert dashboards_file.stat().st_mtime_ns == original_dashboards_mtime
+        assert dashboards_file.read_text() == original_dashboards_content
+
+
+class TestStaleWithinTypeBehaviorUnchanged:
+    """Skip-state-load does not change stale-within-type semantics.
+
+    If a resource was previously imported and is later deleted from the source
+    org, the orphan blob persists on disk in both modes (this is what the
+    separate `prune` command addresses). This test verifies the behavior is
+    identical with and without --skip-state-load.
+    """
+
+    def test_skip_state_load_orphans_match_baseline(self, tmp_path):
+        src = tmp_path / "source"
+        dst = tmp_path / "dest"
+        src.mkdir()
+        dst.mkdir()
+
+        # Pre-populate four users.
+        seed = State(
+            type_=StorageType.LOCAL_FILE,
+            source_resources_path=str(src),
+            destination_resources_path=str(dst),
+            resource_per_file=True,
+        )
+        for uid in ("user-1", "user-2", "user-3", "user-4"):
+            seed.set_source("users", uid, {"id": uid})
+        seed.dump_state(Origin.SOURCE)
+
+        # ImportState-style re-import: only three users come back from the API.
+        imp = ImportState(
+            type_=StorageType.LOCAL_FILE,
+            source_resources_path=str(src),
+            destination_resources_path=str(dst),
+            resource_per_file=True,
+        )
+        imp.clear_source_type("users")
+        for uid in ("user-1", "user-2", "user-3"):
+            imp.set_source("users", uid, {"id": uid})
+        imp.dump_state(Origin.SOURCE)
+
+        # Fetched users were rewritten; user-4 orphan persists on disk.
+        assert (src / "users.user-1.json").exists()
+        assert (src / "users.user-2.json").exists()
+        assert (src / "users.user-3.json").exists()
+        assert (src / "users.user-4.json").exists()  # orphan, by design
+
+
+class TestSkipStateLoadCLIValidation:
+    """End-to-end Click-level validation of --skip-state-load flag combinations.
+
+    Each invocation here passes the minimum args needed to reach build_config's
+    validation block. The patterns mirror existing tests in
+    test_minimize_reads_type_scoped.py.
+    """
+
+    def test_skip_state_load_requires_resources(self, runner):
+        result = runner.invoke(
+            cli,
+            [
+                "import",
+                "--skip-state-load",
+                "--resource-per-file",
+                "--source-api-key=k",
+                "--source-app-key=k",
+                "--destination-api-key=k",
+                "--destination-app-key=k",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "--skip-state-load requires --resources" in result.output
+
+    def test_skip_state_load_requires_resource_per_file(self, runner):
+        result = runner.invoke(
+            cli,
+            [
+                "import",
+                "--skip-state-load",
+                "--resources=users",
+                "--source-api-key=k",
+                "--source-app-key=k",
+                "--destination-api-key=k",
+                "--destination-app-key=k",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "--skip-state-load requires --resource-per-file" in result.output
+
+    def test_skip_state_load_still_rejects_deprecated_resource_conflicts(self, runner, caplog):
+        # _handle_deprecated runs for both State and ImportState callers. The
+        # conflict checks (logs_custom_pipelines + logs_pipelines, downtimes
+        # + downtime_schedules) MUST still fire when --skip-state-load is set,
+        # even though that flag bypasses the read-state fallback branch.
+        # The error goes through config.logger so capture via caplog rather
+        # than result.output (CliRunner does not capture logger writes).
+        import logging
+
+        from datadog_sync.constants import LOGGER_NAME
+
+        with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+            result = runner.invoke(
+                cli,
+                [
+                    "import",
+                    "--skip-state-load",
+                    "--resource-per-file",
+                    "--resources=logs_custom_pipelines,logs_pipelines",
+                    "--source-api-key=k",
+                    "--source-app-key=k",
+                    "--destination-api-key=k",
+                    "--destination-app-key=k",
+                ],
+            )
+        # _handle_deprecated calls sys.exit(1) on conflict, so exit code is 1
+        # specifically (not Click's 2 for parser errors).
+        assert result.exit_code == 1, result.output
+        errors = [r.getMessage() for r in caplog.records if r.levelname == "ERROR"]
+        assert any(
+            "logs_custom_pipelines" in m and "logs_pipelines" in m and "should not" in m and "duplication" in m
+            for m in errors
+        ), errors
+
+    def test_skip_state_load_still_rejects_downtimes_conflict(self, runner, caplog):
+        import logging
+
+        from datadog_sync.constants import LOGGER_NAME
+
+        with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+            result = runner.invoke(
+                cli,
+                [
+                    "import",
+                    "--skip-state-load",
+                    "--resource-per-file",
+                    "--resources=downtimes,downtime_schedules",
+                    "--source-api-key=k",
+                    "--source-app-key=k",
+                    "--destination-api-key=k",
+                    "--destination-app-key=k",
+                ],
+            )
+        assert result.exit_code == 1, result.output
+        errors = [r.getMessage() for r in caplog.records if r.levelname == "ERROR"]
+        assert any(
+            "downtimes" in m and "downtime_schedules" in m and "should not" in m and "duplication" in m for m in errors
+        ), errors
+
+    def test_skip_state_load_rejected_with_minimize_reads(self, runner):
+        # --minimize-reads is registered only on the sync command, so it's
+        # never parseable on import in normal CLI use. To reach the
+        # build_config rejection from a single command invocation, exercise
+        # build_config directly with both kwargs set.
+        from click import UsageError
+        from datadog_sync.constants import Command
+        from datadog_sync.utils.configuration import build_config
+
+        with pytest.raises(UsageError, match="cannot be combined"):
+            build_config(
+                Command.IMPORT,
+                resources="users",
+                resource_per_file=True,
+                skip_state_load=True,
+                minimize_reads=True,
+                source_api_key="k",
+                source_app_key="k",
+                destination_api_key="k",
+                destination_app_key="k",
+                source_api_url="https://example.com",
+                destination_api_url="https://example.com",
+                storage_type="local",
+                source_resources_path="/tmp/src",
+                destination_resources_path="/tmp/dst",
+                max_workers=1,
+                send_metrics=False,
+                verify_ddr_status=False,
+                validate=False,
+                show_progress_bar=False,
+                allow_self_lockout=False,
+                force_missing_dependencies=False,
+                skip_failed_resource_connections=False,
+            )
+
+
+class TestClickDecorationGuard:
+    """`--skip-state-load` is only registered on import; Click rejects it elsewhere."""
+
+    def test_import_help_lists_skip_state_load(self, runner):
+        result = runner.invoke(cli, ["import", "--help"])
+        assert "--skip-state-load" in result.output
+
+    def test_sync_help_does_not_list_skip_state_load(self, runner):
+        result = runner.invoke(cli, ["sync", "--help"])
+        assert "--skip-state-load" not in result.output
+
+    def test_migrate_help_does_not_list_skip_state_load(self, runner):
+        result = runner.invoke(cli, ["migrate", "--help"])
+        assert "--skip-state-load" not in result.output
+
+    def test_diffs_help_does_not_list_skip_state_load(self, runner):
+        result = runner.invoke(cli, ["diffs", "--help"])
+        assert "--skip-state-load" not in result.output
+
+    def test_reset_help_does_not_list_skip_state_load(self, runner):
+        result = runner.invoke(cli, ["reset", "--help"])
+        assert "--skip-state-load" not in result.output
+
+    def test_prune_help_does_not_list_skip_state_load(self, runner):
+        result = runner.invoke(cli, ["prune", "--help"])
+        assert "--skip-state-load" not in result.output
+
+    def test_sync_rejects_skip_state_load(self, runner):
+        result = runner.invoke(cli, ["sync", "--skip-state-load", "--resources=users"])
+        assert result.exit_code != 0
+        assert "No such option" in result.output or "no such option" in result.output.lower()
+
+    def test_migrate_rejects_skip_state_load(self, runner):
+        result = runner.invoke(cli, ["migrate", "--skip-state-load", "--resources=users"])
+        assert result.exit_code != 0
+        assert "No such option" in result.output or "no such option" in result.output.lower()
+
+
+class TestInstrumentationLogs:
+    """Storage backends and state lifecycle emit `sync-cli-timing` log lines."""
+
+    def test_state_init_emits_timing(self, tmp_path, caplog):
+        import logging
+
+        from datadog_sync.constants import LOGGER_NAME
+
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            State(
+                type_=StorageType.LOCAL_FILE,
+                source_resources_path=str(tmp_path / "source"),
+                destination_resources_path=str(tmp_path / "dest"),
+                resource_per_file=True,
+            )
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any("sync-cli-timing phase=state_init" in m for m in msgs), msgs
+
+    def test_import_state_init_emits_timing_with_skip_flag(self, tmp_path, caplog):
+        import logging
+
+        from datadog_sync.constants import LOGGER_NAME
+
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            ImportState(
+                type_=StorageType.LOCAL_FILE,
+                source_resources_path=str(tmp_path / "source"),
+                destination_resources_path=str(tmp_path / "dest"),
+                resource_per_file=True,
+            )
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any("sync-cli-timing phase=state_init" in m and "skip_state_load=True" in m for m in msgs), msgs
+
+    def test_local_file_get_emits_list_and_load_timing(self, tmp_path, caplog):
+        import logging
+
+        from datadog_sync.constants import LOGGER_NAME
+
+        src = tmp_path / "source"
+        dst = tmp_path / "dest"
+        src.mkdir()
+        dst.mkdir()
+        backend = LocalFile(
+            source_resources_path=str(src),
+            destination_resources_path=str(dst),
+            resource_per_file=True,
+        )
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            backend.get(Origin.SOURCE)
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any("sync-cli-timing phase=list_and_load" in m and "backend=local_file" in m for m in msgs), msgs
+
+    def test_local_file_put_emits_timing(self, tmp_path, caplog):
+        import logging
+
+        from datadog_sync.constants import LOGGER_NAME
+
+        src = tmp_path / "source"
+        dst = tmp_path / "dest"
+        src.mkdir()
+        dst.mkdir()
+        backend = LocalFile(
+            source_resources_path=str(src),
+            destination_resources_path=str(dst),
+            resource_per_file=True,
+        )
+        data = StorageData()
+        data.source["users"]["u1"] = {"id": "u1"}
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            backend.put(Origin.SOURCE, data)
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any("sync-cli-timing phase=put" in m and "backend=local_file" in m for m in msgs), msgs
+
+
+# Shared log-schema fields the rollout plan relies on. Each list_and_load log
+# line on a cloud backend must include every key in this set, so downstream
+# parsers can index on a stable schema across backends. `aborted` distinguishes
+# a successful empty result from an uncaught exception that exited mid-call.
+EXPECTED_LIST_AND_LOAD_FIELDS = (
+    "pages_listed=",
+    "blobs_listed=",
+    "blobs_downloaded=",
+    "transient_errors=",
+    "aborted=",
+    "list_ms=",
+    "download_ms=",
+    "wall_ms=",
+)
+
+
+class TestCloudBackendListAndLoadLogSchema:
+    """Each cloud backend's _list_and_load log must include the rollout-plan fields.
+
+    Backend SDK clients are mocked to return one fake blob/object per call.
+    The tests assert (a) the timing log fires once with `phase=list_and_load`,
+    and (b) every required field key is present in the log line.
+    """
+
+    def _log_messages(self, caplog):
+        return [r.getMessage() for r in caplog.records]
+
+    def _find_list_and_load(self, msgs, backend):
+        matches = [m for m in msgs if "sync-cli-timing phase=list_and_load" in m and f"backend={backend}" in m]
+        return matches
+
+    def test_gcs_list_and_load_log_schema(self, caplog):
+        import logging
+        from unittest.mock import MagicMock, patch
+
+        from datadog_sync.constants import LOGGER_NAME
+        from datadog_sync.utils.storage.gcs_bucket import GCSBucket
+
+        fake_blob = MagicMock()
+        fake_blob.name = "resources/source/users.u1.json"
+        fake_download = MagicMock()
+        fake_download.download_as_text.return_value = '{"u1": {"id": "u1"}}'
+        fake_bucket = MagicMock()
+        fake_bucket.list_blobs.return_value = [fake_blob]
+        fake_bucket.blob.return_value = fake_download
+        fake_client = MagicMock()
+        fake_client.bucket.return_value = fake_bucket
+
+        with patch("datadog_sync.utils.storage.gcs_bucket.gcs_storage.Client", return_value=fake_client):
+            backend = GCSBucket(
+                source_resources_path="resources/source",
+                destination_resources_path="resources/destination",
+                config={"gcs_bucket_name": "test-bucket"},
+                resource_per_file=True,
+            )
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            backend._list_and_load("resources/source", None, "source")
+        matches = self._find_list_and_load(self._log_messages(caplog), "gcs")
+        assert len(matches) == 1, matches
+        for field in EXPECTED_LIST_AND_LOAD_FIELDS:
+            assert field in matches[0], f"{field!r} missing from GCS log line: {matches[0]}"
+
+    def test_aws_list_and_load_log_schema(self, caplog):
+        import logging
+        from unittest.mock import MagicMock, patch
+        from io import BytesIO
+
+        from datadog_sync.constants import LOGGER_NAME
+        from datadog_sync.utils.storage.aws_s3_bucket import AWSS3Bucket
+
+        fake_client = MagicMock()
+        fake_client.list_objects_v2.return_value = {
+            "Contents": [{"Key": "resources/source/users.u1.json"}],
+            "IsTruncated": False,
+        }
+        fake_client.get_object.return_value = {"Body": BytesIO(b'{"u1": {"id": "u1"}}')}
+
+        with patch("datadog_sync.utils.storage.aws_s3_bucket.boto3.client", return_value=fake_client):
+            backend = AWSS3Bucket(
+                source_resources_path="resources/source",
+                destination_resources_path="resources/destination",
+                config={"aws_bucket_name": "test-bucket", "aws_region_name": "us-east-1"},
+                resource_per_file=True,
+            )
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            backend._list_and_load("resources/source", None, "source")
+        matches = self._find_list_and_load(self._log_messages(caplog), "aws_s3")
+        assert len(matches) == 1, matches
+        for field in EXPECTED_LIST_AND_LOAD_FIELDS:
+            assert field in matches[0], f"{field!r} missing from AWS log line: {matches[0]}"
+
+    def test_azure_list_and_load_log_schema(self, caplog):
+        import logging
+        from unittest.mock import MagicMock, patch
+
+        from datadog_sync.constants import LOGGER_NAME
+        from datadog_sync.utils.storage.azure_blob_container import AzureBlobContainer
+
+        fake_blob = MagicMock()
+        fake_blob.name = "resources/source/users.u1.json"
+        fake_dl = MagicMock()
+        fake_dl.readall.return_value = b'{"u1": {"id": "u1"}}'
+        fake_container = MagicMock()
+        fake_container.list_blobs.return_value = [fake_blob]
+        fake_container.download_blob.return_value = fake_dl
+
+        with patch.object(AzureBlobContainer, "__init__", lambda self, *a, **kw: None):
+            backend = AzureBlobContainer()
+            backend.source_resources_path = "resources/source"
+            backend.destination_resources_path = "resources/destination"
+            backend.resource_per_file = True
+            backend.container_client = fake_container
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            backend._list_and_load("resources/source", None, "source")
+        matches = self._find_list_and_load(self._log_messages(caplog), "azure_blob")
+        assert len(matches) == 1, matches
+        for field in EXPECTED_LIST_AND_LOAD_FIELDS:
+            assert field in matches[0], f"{field!r} missing from Azure log line: {matches[0]}"
+
+    def test_local_file_list_and_load_log_schema(self, tmp_path, caplog):
+        import logging
+
+        from datadog_sync.constants import LOGGER_NAME
+
+        src = tmp_path / "source"
+        dst = tmp_path / "dest"
+        src.mkdir()
+        dst.mkdir()
+        (src / "users.u1.json").write_text('{"u1": {"id": "u1"}}')
+        backend = LocalFile(
+            source_resources_path=str(src),
+            destination_resources_path=str(dst),
+            resource_per_file=True,
+        )
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            backend.get(Origin.SOURCE)
+        matches = self._find_list_and_load(self._log_messages(caplog), "local_file")
+        assert len(matches) == 1, matches
+        for field in EXPECTED_LIST_AND_LOAD_FIELDS:
+            assert field in matches[0], f"{field!r} missing from LocalFile log line: {matches[0]}"
+
+
+class TestCloudBackendListAndLoadFailureLogging:
+    """If the underlying SDK raises during list/download, the timing log MUST
+    still emit (from the finally block) with aborted=1. Otherwise operators
+    lose visibility into exactly the contention failure mode this PR is meant
+    to measure.
+    """
+
+    def _log_messages(self, caplog):
+        return [r.getMessage() for r in caplog.records]
+
+    def test_gcs_aborted_log_on_list_blobs_exception(self, caplog):
+        import logging
+        from unittest.mock import MagicMock, patch
+
+        from datadog_sync.constants import LOGGER_NAME
+        from datadog_sync.utils.storage.gcs_bucket import GCSBucket
+
+        fake_bucket = MagicMock()
+        fake_bucket.list_blobs.side_effect = RuntimeError("simulated 5xx from GCS list")
+        fake_client = MagicMock()
+        fake_client.bucket.return_value = fake_bucket
+
+        with patch("datadog_sync.utils.storage.gcs_bucket.gcs_storage.Client", return_value=fake_client):
+            backend = GCSBucket(
+                source_resources_path="resources/source",
+                destination_resources_path="resources/destination",
+                config={"gcs_bucket_name": "test-bucket"},
+                resource_per_file=True,
+            )
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            with pytest.raises(RuntimeError):
+                backend._list_and_load("resources/source", None, "source")
+        msgs = self._log_messages(caplog)
+        list_and_load_lines = [m for m in msgs if "phase=list_and_load" in m and "backend=gcs" in m]
+        assert len(list_and_load_lines) == 1, list_and_load_lines
+        assert "aborted=1" in list_and_load_lines[0], list_and_load_lines[0]
+
+    def test_aws_aborted_log_on_list_objects_exception(self, caplog):
+        import logging
+        from unittest.mock import MagicMock, patch
+
+        from datadog_sync.constants import LOGGER_NAME
+        from datadog_sync.utils.storage.aws_s3_bucket import AWSS3Bucket
+
+        fake_client = MagicMock()
+        fake_client.list_objects_v2.side_effect = RuntimeError("simulated 5xx from S3 ListObjects")
+
+        with patch("datadog_sync.utils.storage.aws_s3_bucket.boto3.client", return_value=fake_client):
+            backend = AWSS3Bucket(
+                source_resources_path="resources/source",
+                destination_resources_path="resources/destination",
+                config={"aws_bucket_name": "test-bucket", "aws_region_name": "us-east-1"},
+                resource_per_file=True,
+            )
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            with pytest.raises(RuntimeError):
+                backend._list_and_load("resources/source", None, "source")
+        msgs = self._log_messages(caplog)
+        lines = [m for m in msgs if "phase=list_and_load" in m and "backend=aws_s3" in m]
+        assert len(lines) == 1, lines
+        assert "aborted=1" in lines[0], lines[0]
+
+    def test_azure_aborted_log_on_list_blobs_exception(self, caplog):
+        import logging
+        from unittest.mock import MagicMock, patch
+
+        from datadog_sync.constants import LOGGER_NAME
+        from datadog_sync.utils.storage.azure_blob_container import AzureBlobContainer
+
+        fake_container = MagicMock()
+        fake_container.list_blobs.side_effect = RuntimeError("simulated 5xx from Azure list_blobs")
+
+        with patch.object(AzureBlobContainer, "__init__", lambda self, *a, **kw: None):
+            backend = AzureBlobContainer()
+            backend.source_resources_path = "resources/source"
+            backend.destination_resources_path = "resources/destination"
+            backend.resource_per_file = True
+            backend.container_client = fake_container
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            with pytest.raises(RuntimeError):
+                backend._list_and_load("resources/source", None, "source")
+        msgs = self._log_messages(caplog)
+        lines = [m for m in msgs if "phase=list_and_load" in m and "backend=azure_blob" in m]
+        assert len(lines) == 1, lines
+        assert "aborted=1" in lines[0], lines[0]
+
+    def test_gcs_paged_iterator_path_emits_correct_page_count(self, caplog):
+        # The production HTTPIterator has a .pages attribute returning a
+        # generator of pages. The fallback path (mocks returning flat lists)
+        # is exercised by the happy-path tests above. This test exercises the
+        # real-SDK path with .pages returning two pages.
+        import logging
+        from unittest.mock import MagicMock, patch
+
+        from datadog_sync.constants import LOGGER_NAME
+        from datadog_sync.utils.storage.gcs_bucket import GCSBucket
+
+        blob_a = MagicMock()
+        blob_a.name = "resources/source/users.u1.json"
+        blob_b = MagicMock()
+        blob_b.name = "resources/source/users.u2.json"
+        page1 = [blob_a]
+        page2 = [blob_b]
+
+        # Iterator object with a `.pages` attribute. When the code finds
+        # .pages it MUST iterate by page (not by blob) so the page count is
+        # accurate.
+        iterator = MagicMock()
+        iterator.pages = iter([page1, page2])
+
+        fake_download = MagicMock()
+        fake_download.download_as_text.return_value = '{"u": {"id": "u"}}'
+
+        fake_bucket = MagicMock()
+        fake_bucket.list_blobs.return_value = iterator
+        fake_bucket.blob.return_value = fake_download
+
+        fake_client = MagicMock()
+        fake_client.bucket.return_value = fake_bucket
+
+        with patch("datadog_sync.utils.storage.gcs_bucket.gcs_storage.Client", return_value=fake_client):
+            backend = GCSBucket(
+                source_resources_path="resources/source",
+                destination_resources_path="resources/destination",
+                config={"gcs_bucket_name": "test-bucket"},
+                resource_per_file=True,
+            )
+        with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+            backend._list_and_load("resources/source", None, "source")
+        msgs = self._log_messages(caplog)
+        lines = [m for m in msgs if "phase=list_and_load" in m and "backend=gcs" in m]
+        assert len(lines) == 1, lines
+        assert "pages_listed=2" in lines[0], lines[0]
+        assert "blobs_listed=2" in lines[0], lines[0]
+        assert "blobs_downloaded=2" in lines[0], lines[0]
+        assert "aborted=0" in lines[0], lines[0]
+
+    def test_local_file_aborted_log_on_listdir_exception(self, tmp_path, caplog):
+        import logging
+        from unittest.mock import patch
+
+        from datadog_sync.constants import LOGGER_NAME
+
+        backend = LocalFile(
+            source_resources_path=str(tmp_path / "source"),
+            destination_resources_path=str(tmp_path / "dest"),
+            resource_per_file=True,
+        )
+        # Force os.listdir to raise; the backend has no broader except, so the
+        # exception propagates out — but the finally block must still log.
+        (tmp_path / "source").mkdir()
+        with patch("datadog_sync.utils.storage.local_file.os.listdir", side_effect=PermissionError("denied")):
+            with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+                with pytest.raises(PermissionError):
+                    backend.get(Origin.SOURCE)
+        msgs = self._log_messages(caplog)
+        lines = [m for m in msgs if "phase=list_and_load" in m and "backend=local_file" in m]
+        assert len(lines) >= 1, lines
+        assert "aborted=1" in lines[0], lines[0]
+
+
+class TestBuildConfigDispatch:
+    """`--skip-state-load` constructs ImportState; absence preserves default."""
+
+    @staticmethod
+    def _base_kwargs(tmp_path):
+        return dict(
+            resources="users",
+            resource_per_file=True,
+            source_api_key="k",
+            source_app_key="k",
+            destination_api_key="k",
+            destination_app_key="k",
+            source_api_url="https://example.com",
+            destination_api_url="https://example.com",
+            storage_type="local",
+            source_resources_path=str(tmp_path / "source"),
+            destination_resources_path=str(tmp_path / "dest"),
+            max_workers=1,
+            send_metrics=False,
+            verify_ddr_status=False,
+            validate=False,
+            show_progress_bar=False,
+            allow_self_lockout=False,
+            force_missing_dependencies=False,
+            skip_failed_resource_connections=False,
+        )
+
+    def test_skip_state_load_constructs_import_state(self, tmp_path):
+        from datadog_sync.constants import Command
+        from datadog_sync.utils.configuration import build_config
+
+        cfg = build_config(Command.IMPORT, skip_state_load=True, **self._base_kwargs(tmp_path))
+        assert isinstance(cfg.state, ImportState)
+
+    def test_default_constructs_state(self, tmp_path):
+        from datadog_sync.constants import Command
+        from datadog_sync.utils.configuration import build_config
+
+        cfg = build_config(Command.IMPORT, **self._base_kwargs(tmp_path))
+        assert isinstance(cfg.state, State)
+
+
+class TestRoundTripImportSkipLoadThenRead:
+    """Import with --skip-state-load writes state that a subsequent State()
+    construction (which loads from storage) reads back correctly.
+
+    This is the round-trip test the rollout plan asked for: a fresh import
+    that skips the preload must still produce a bucket layout that a normal
+    sync (or any other state-reading caller) can pick up on the next run.
+    """
+
+    def test_import_state_writes_are_readable_by_fresh_state(self, tmp_path):
+        src = tmp_path / "source"
+        dst = tmp_path / "dest"
+        src.mkdir()
+        dst.mkdir()
+
+        imp = ImportState(
+            type_=StorageType.LOCAL_FILE,
+            source_resources_path=str(src),
+            destination_resources_path=str(dst),
+            resource_per_file=True,
+        )
+        imp.set_source("users", "u1", {"id": "u1", "name": "Alice"})
+        imp.set_source("users", "u2", {"id": "u2", "name": "Bob"})
+        imp.set_source("roles", "r1", {"id": "r1", "name": "Admin"})
+        imp.dump_state(Origin.SOURCE)
+
+        # Fresh State construction triggers a load from storage. The just-written
+        # source state should be visible; destination remains empty (the import
+        # never wrote to destination).
+        fresh = State(
+            type_=StorageType.LOCAL_FILE,
+            source_resources_path=str(src),
+            destination_resources_path=str(dst),
+            resource_per_file=True,
+        )
+        assert fresh.source["users"]["u1"]["name"] == "Alice"
+        assert fresh.source["users"]["u2"]["name"] == "Bob"
+        assert fresh.source["roles"]["r1"]["name"] == "Admin"
+        assert fresh.destination == {}


### PR DESCRIPTION
## Summary

`State.__init__` unconditionally loads existing state from storage. The `import` command discards prior per-type source state before its API fetch (in `_import_get_resources_cb`) and writes fresh data via `dump_state` at the end — the boot-time load is dead weight for that command. On populated buckets the load can dominate per-run wall-clock.

This PR adds an opt-in `--skip-state-load` flag to `import` that constructs a new `ImportState` instead of `State`. `ImportState` exposes only write methods and has no `source` / `destination` property, so any attempt to read state fails at the language level with `AttributeError` rather than silently returning empty data.

Adds diagnostic timing logs around state init, load, dump, and each storage backend's `_list_and_load` and `put`. The logs emit from a `finally` block so they fire even when an SDK call raises mid-iteration, and carry a `list_ms` vs `download_ms` split plus pagination and blob counts. Useful for diagnosing where wall-clock goes on populated buckets.

## What changes

- New `ImportState` class (`utils/import_state.py`) — write-only state for the import command. `set_source`, `clear_source_type`, `dump_state(Origin.SOURCE)`. No read accessors; `dump_state` rejects DESTINATION / ALL.
- New `SourceStateWriter` Protocol (`utils/source_state_writer.py`) — shared write surface implemented by both `State` and `ImportState`.
- New `--skip-state-load` Click option on `import` only. Click rejects the flag on `sync` / `migrate` / `diffs` / `reset` / `prune`; `build_config` adds a redundant validation guard.
- Three import-path writer sites migrated to the protocol methods: `base_resource._import_resource`, `resources_handler._import_get_resources_cb`, `model/synthetics_private_locations.import_resource`.
- Shared `build_storage_backend` helper in `_base_storage.py` so `State` and `ImportState` cannot drift on per-backend init.
- Diagnostic timing instrumentation across `state.py` and all four storage backends, with a `try/finally` so the log emits even when the underlying SDK raises. New fields: `pages_listed`, `blobs_listed`, `blobs_downloaded`, `transient_errors`, `aborted`, `list_ms`, `download_ms`, `wall_ms`. Race-delete semantics (`NoSuchKey` on AWS, `ResourceNotFoundError` on Azure, `NotFound` on GCS) are caught uniformly across backends and counted in `transient_errors`.

## What does not change

- Default behavior. `--skip-state-load` is opt-in (`default=False`); existing callers see no behavior change.
- `sync` / `diffs` / `migrate` / `reset` / `prune` paths. These continue to use `State` with the existing read+write surface.
- Wire format, file layout on disk, or storage backend semantics. `dump_state` patches per-blob exactly as before.

## Constraints

`--skip-state-load` requires `--resource-per-file` and `--resources`, and is not combinable with `--minimize-reads` (which serves a different optimization goal). Validated in `build_config`.

## Test plan

- [x] 556 unit tests pass (514 existing + 42 new in `test_import_state.py`)
- [x] `black --line-length 120` clean
- [x] New coverage: ImportState invariant (no read accessors), write API, Protocol satisfaction by both classes, partial-import preserves untouched types end-to-end, stale-within-type unchanged from baseline, CLI validation errors, Click rejection on all non-import commands, deprecated-resource conflict still rejected with `--skip-state-load`, timing-log schema fields present on all four backends, **aborted=1 fires when each backend's SDK call raises**, paged-iterator branch on GCS, round-trip read of `--skip-state-load`-written state via a fresh `State`.

## Rollout

Flag is opt-in (`default=False`). Reverting the commit removes the option from `import --help` and doesn't break any caller that wasn't using it. No on-disk or wire-format effect.

## Out of scope

- `migrate` does not gain `--skip-state-load` (apply-phase reads destination).
- `sync` keeps its existing state-load path.
- Parallelising `_list_and_load` is a separate effort.
