### PR TITLE
fix(roles): guard built-in Datadog roles from create and update

### DIFF
--- a/datadog_sync/model/roles.py
+++ b/datadog_sync/model/roles.py
@@ -93,6 +93,11 @@ class Roles(BaseResource):
         # this method uses role name from matching
         role_name = resource["attributes"]["name"]
 
+        if role_name in BUILTIN_ROLE_NAMES:
+            raise SkipResource(
+                _id, self.resource_type, f"'{role_name}' is a built-in Datadog role and cannot be created"
+            )
+
         # remove the 'managed' attribute since it can not be passed into creation
         resource["attributes"].pop("managed", None)
 
@@ -167,6 +172,12 @@ class Roles(BaseResource):
     async def update_resource(self, _id: str, resource: Dict) -> Tuple[str, Dict]:
         destination_client = self.config.destination_client
         role_name = resource["attributes"]["name"]
+
+        if role_name in BUILTIN_ROLE_NAMES:
+            raise SkipResource(
+                _id, self.resource_type, f"'{role_name}' is a built-in Datadog role and cannot be updated"
+            )
+
         resource["id"] = self.config.state.destination[self.resource_type][_id]["id"]
 
         # Retry loop to handle multiple invalid permissions

--- a/datadog_sync/model/roles.py
+++ b/datadog_sync/model/roles.py
@@ -93,7 +93,7 @@ class Roles(BaseResource):
         # this method uses role name from matching
         role_name = resource["attributes"]["name"]
 
-        if role_name in BUILTIN_ROLE_NAMES:
+        if role_name in BUILTIN_ROLE_NAMES and role_name not in self._existing_resources_map:
             raise SkipResource(
                 _id, self.resource_type, f"'{role_name}' is a built-in Datadog role and cannot be created"
             )
@@ -155,6 +155,9 @@ class Roles(BaseResource):
         matching_destination_role = self._existing_resources_map[role_name]
         role_copy = copy.deepcopy(resource)
         role_copy.update(matching_destination_role)
+
+        if role_name in BUILTIN_ROLE_NAMES:
+            return _id, role_copy
 
         # role is managed at the destination, do nothing
         if "managed" in matching_destination_role["attributes"] and matching_destination_role["attributes"]["managed"]:

--- a/tests/unit/test_roles.py
+++ b/tests/unit/test_roles.py
@@ -1,0 +1,100 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+"""
+Unit tests for roles resource handling.
+
+These tests verify that the 3 built-in Datadog roles (Admin, Read Only,
+Standard) are skipped at create, update, and delete — they cannot be
+mutated via the API and must short-circuit cleanly with SkipResource.
+"""
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from datadog_sync.model.roles import BUILTIN_ROLE_NAMES, Roles
+from datadog_sync.utils.resource_utils import SkipResource
+
+
+def _make_roles():
+    mock_config = MagicMock()
+    mock_config.state = MagicMock()
+    mock_config.allow_partial_permissions_roles = []
+    return Roles(mock_config)
+
+
+class TestRolesBuiltinGuardCreate:
+    @pytest.mark.parametrize("role_name", sorted(BUILTIN_ROLE_NAMES))
+    def test_create_skips_builtin_role(self, role_name):
+        roles = _make_roles()
+        resource = {"attributes": {"name": role_name}}
+        with pytest.raises(SkipResource) as exc_info:
+            asyncio.run(roles.create_resource("source-id", resource))
+        assert role_name in str(exc_info.value)
+        assert "cannot be created" in str(exc_info.value)
+
+    def test_create_does_not_skip_non_builtin_role(self):
+        roles = _make_roles()
+        roles._existing_resources_map = {}
+        roles.config.destination_client.post = AsyncMock(return_value={"data": {"id": "new-id"}})
+        resource = {"attributes": {"name": "Custom Engineering Role"}, "relationships": {}}
+        # Should not raise SkipResource
+        result_id, result = asyncio.run(roles.create_resource("source-id", resource))
+        assert result_id == "source-id"
+        roles.config.destination_client.post.assert_awaited_once()
+
+
+class TestRolesBuiltinGuardUpdate:
+    @pytest.mark.parametrize("role_name", sorted(BUILTIN_ROLE_NAMES))
+    def test_update_skips_builtin_role(self, role_name):
+        roles = _make_roles()
+        resource = {"attributes": {"name": role_name}}
+        with pytest.raises(SkipResource) as exc_info:
+            asyncio.run(roles.update_resource("source-id", resource))
+        assert role_name in str(exc_info.value)
+        assert "cannot be updated" in str(exc_info.value)
+
+    def test_update_does_not_skip_non_builtin_role(self):
+        roles = _make_roles()
+        roles.config.state.destination = {"roles": {"source-id": {"id": "dest-id"}}}
+        roles.config.destination_client.patch = AsyncMock(return_value={"data": {"id": "dest-id"}})
+        resource = {"attributes": {"name": "Custom Engineering Role"}, "relationships": {}}
+        # Should not raise SkipResource
+        result_id, result = asyncio.run(roles.update_resource("source-id", resource))
+        assert result_id == "source-id"
+        roles.config.destination_client.patch.assert_awaited_once()
+
+
+class TestRolesBuiltinGuardDelete:
+    @pytest.mark.parametrize("role_name", sorted(BUILTIN_ROLE_NAMES))
+    def test_delete_skips_builtin_role(self, role_name):
+        roles = _make_roles()
+        roles.config.state.destination = {"roles": {"source-id": {"id": "dest-id", "attributes": {"name": role_name}}}}
+        with pytest.raises(SkipResource) as exc_info:
+            asyncio.run(roles.delete_resource("source-id"))
+        assert role_name in str(exc_info.value)
+        assert "cannot be deleted" in str(exc_info.value)
+
+    def test_delete_does_not_skip_non_builtin_role(self):
+        roles = _make_roles()
+        roles.config.state.destination = {
+            "roles": {"source-id": {"id": "dest-id", "attributes": {"name": "Custom Engineering Role"}}}
+        }
+        roles.config.destination_client.delete = AsyncMock(return_value=None)
+        # Should not raise SkipResource
+        asyncio.run(roles.delete_resource("source-id"))
+        roles.config.destination_client.delete.assert_awaited_once()
+
+
+class TestBuiltinRoleNamesConstant:
+    def test_contains_expected_builtin_roles(self):
+        assert BUILTIN_ROLE_NAMES == frozenset(
+            {
+                "Datadog Admin Role",
+                "Datadog Read Only Role",
+                "Datadog Standard Role",
+            }
+        )

--- a/tests/unit/test_roles.py
+++ b/tests/unit/test_roles.py
@@ -7,8 +7,9 @@
 Unit tests for roles resource handling.
 
 These tests verify that the 3 built-in Datadog roles (Admin, Read Only,
-Standard) are skipped at create, update, and delete — they cannot be
-mutated via the API and must short-circuit cleanly with SkipResource.
+Standard) are skipped at create, update, and delete when they would be
+mutated via the API. Existing destination built-ins still need to map
+source IDs to destination IDs so dependent resources can be assigned.
 """
 
 import asyncio
@@ -35,6 +36,30 @@ class TestRolesBuiltinGuardCreate:
             asyncio.run(roles.create_resource("source-id", resource))
         assert role_name in str(exc_info.value)
         assert "cannot be created" in str(exc_info.value)
+
+    def test_create_maps_existing_builtin_role_without_api_call(self):
+        roles = _make_roles()
+        destination_role = {
+            "id": "destination-role-id",
+            "attributes": {"name": "Datadog Admin Role", "managed": True},
+            "relationships": {"permissions": {"data": []}},
+        }
+        roles._existing_resources_map = {"Datadog Admin Role": destination_role}
+        roles.config.state.destination = {"roles": {}}
+        roles.config.destination_client.post = AsyncMock()
+        roles.config.destination_client.patch = AsyncMock()
+
+        resource = {
+            "id": "source-role-id",
+            "attributes": {"name": "Datadog Admin Role", "managed": True},
+            "relationships": {"permissions": {"data": []}},
+        }
+
+        asyncio.run(roles._create_resource("source-role-id", resource))
+
+        assert roles.config.state.destination["roles"]["source-role-id"] == destination_role
+        roles.config.destination_client.post.assert_not_awaited()
+        roles.config.destination_client.patch.assert_not_awaited()
 
     def test_create_does_not_skip_non_builtin_role(self):
         roles = _make_roles()


### PR DESCRIPTION
## Summary
The 3 built-in Datadog roles (`Datadog Admin Role`, `Datadog Read Only Role`, `Datadog Standard Role`) cannot be created, updated, or deleted via the API. Previously only `delete_resource` raised `SkipResource` for these names; `create_resource` and `update_resource` would still attempt the request and fail (the existing `managed` attribute check only short-circuited when the destination role happened to carry it).

This PR adds name-based `BUILTIN_ROLE_NAMES` guards across all three CRUD paths in `datadog_sync/model/roles.py`:

- **`delete_resource`** — unchanged; existing guard still raises `SkipResource`.
- **`update_resource`** — raises `SkipResource` at the top. Safe because the handler only invokes update when state mapping already exists (see `resources_handler.py:247`), so skipping preserves the existing mapping.
- **`create_resource`** — does **not** unconditionally skip. Built-in roles always exist at the destination, and dependent resources (users, restriction policies, authn mappings, etc.) resolve role IDs via `state.destination["roles"][source_id]`. Skipping outright would break those dependents. Instead:
  - Raise `SkipResource` only if the built-in is somehow not present at the destination (defensive).
  - Otherwise fall through to the existing "role already exists at destination" branch and short-circuit *before* the diff/update logic, returning the destination role data so the wrapper records the mapping into state without making any API call.

## Test plan
- [x] `tox -e ruff,black` clean
- [x] `tox -e py313 -- tests/unit/test_roles.py` — 14/14 pass
- [x] Full unit suite — 569/569 pass (no regressions)
- [x] Integration cassettes for `test_roles` contain zero POST/PATCH/DELETE; the two update-related integration tests are already `@pytest.mark.skip` (RBAC disabled in test org), so no integration impact
- [x] New unit test `test_create_maps_existing_builtin_role_without_api_call` exercises the load-bearing case: state mapping is recorded via `_create_resource`, `post`/`patch` never awaited
- [x] Green/green coverage: non-built-in roles still create/update/delete normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)