### PR TITLE
fix(synthetics_global_variables): key on (name, type) to resolve 409 conflict

### DIFF
--- a/datadog_sync/model/synthetics_global_variables.py
+++ b/datadog_sync/model/synthetics_global_variables.py
@@ -33,7 +33,11 @@ class SyntheticsGlobalVariables(BaseResource):
             "editor",
         ],
         tagging_config=TaggingConfig(path="tags"),
-        resource_mapping_key="name",
+        # Datadog enforces uniqueness on (name, type) — two variables can share
+        # a name only when their types differ (e.g. "variable" vs "secret_token").
+        # Keying by name alone collapses same-name/different-type entries in
+        # _existing_resources_map and triggers a 409 on the unmapped source.
+        resource_mapping_key=lambda r: f"{r['name']}:{r['type']}",
     )
     # Additional SyntheticsGlobalVariables specific attributes
 

--- a/tests/unit/test_synthetics_global_variables.py
+++ b/tests/unit/test_synthetics_global_variables.py
@@ -1,0 +1,160 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+"""Tests for the synthetics_global_variables composite (name, type) mapping key.
+
+The Datadog API enforces uniqueness on the (name, type) tuple — two global
+variables can share a name as long as their types differ (e.g. "variable" vs
+"secret_token"). Keying ``_existing_resources_map`` by ``name`` alone caused
+last-write-wins map collisions and a production 409 Conflict on sync.
+
+Tests 1, 2, 3a, 5 are red against ``resource_mapping_key="name"`` and green
+after the fix to ``lambda r: f"{r['name']}:{r['type']}"``.
+Tests 3b and 4 are green/green guards.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+from datadog_sync.model.synthetics_global_variables import SyntheticsGlobalVariables
+
+
+def _make_variable(name, type_, var_id, description="d", value_value="v"):
+    """Build a synthetics global variable dict shaped like the GET response.
+
+    Pre-populates ``value.value`` so ``_inject_secret_value`` short-circuits
+    on the ``if "value" not in resource.get("value", {})`` guard at
+    synthetics_global_variables.py:62 — no source_client.get call.
+    """
+    return {
+        "id": var_id,
+        "name": name,
+        "type": type_,
+        "description": description,
+        "tags": [],
+        "value": {"value": value_value, "secure": False, "options": {}},
+    }
+
+
+class TestCompositeKeyResolution:
+    """3a: composite key resolves to "<name>:<type>" string.
+    3b: missing type returns None silently (green/green guard)."""
+
+    def test_composite_key_resolves_to_string(self, mock_config):
+        """3a (red→green): full input yields composite "X:variable"."""
+        instance = SyntheticsGlobalVariables(mock_config)
+        resource = _make_variable("X", "variable", "abc")
+        assert instance.get_resource_mapping_key(resource) == "X:variable"
+
+    def test_missing_type_returns_none(self, mock_config):
+        """3b (green/green): missing ``type`` returns None — pins the silent
+        KeyError handling at base_resource.py:111-115. Behavior unchanged by
+        the fix; guards against future refactors dropping the try/except or
+        an API rename moving ``type`` under ``attributes``.
+        """
+        instance = SyntheticsGlobalVariables(mock_config)
+        resource = {"name": "X"}
+        assert instance.get_resource_mapping_key(resource) is None
+
+
+class TestMapExistingResourcesRetainsBothTypes:
+    """1: ``map_existing_resources()`` keeps both same-name variants under
+    distinct composite keys."""
+
+    def test_two_same_name_different_type_both_in_map(self, mock_config):
+        """1 (red→green): destination has X/variable and X/secret_token.
+        Under old ``resource_mapping_key="name"`` the map collapses to one
+        entry. Under the composite key both entries are retained.
+        """
+        instance = SyntheticsGlobalVariables(mock_config)
+        dest_resources = [
+            _make_variable("X", "variable", "dest-1"),
+            _make_variable("X", "secret_token", "dest-2"),
+        ]
+        instance.get_resources = AsyncMock(return_value=dest_resources)
+
+        asyncio.run(instance.map_existing_resources())
+
+        assert len(instance._existing_resources_map) == 2
+        assert instance._existing_resources_map["X:variable"]["id"] == "dest-1"
+        assert instance._existing_resources_map["X:secret_token"]["id"] == "dest-2"
+
+
+class TestRoutingByCompositeKey:
+    """2: routing picks the right destination entry by (name, type)."""
+
+    def test_source_routes_to_matching_type_destination(self, mock_config):
+        """2 (red→green): ``_existing_resources_map`` has both entries, source
+        is X/secret_token — must remap to dest-2 and PUT, not POST.
+        """
+        instance = SyntheticsGlobalVariables(mock_config)
+        dest_variable = _make_variable("X", "variable", "dest-1")
+        dest_secret = _make_variable("X", "secret_token", "dest-2")
+        instance._existing_resources_map = {
+            "X:variable": dest_variable,
+            "X:secret_token": dest_secret,
+        }
+
+        mock_config.destination_client.post = AsyncMock(return_value=dest_secret)
+        mock_config.destination_client.put = AsyncMock(return_value=dest_secret)
+
+        source = _make_variable("X", "secret_token", "src-A")
+        asyncio.run(instance.create_resource("src-A", source))
+
+        assert mock_config.state.destination["synthetics_global_variables"]["src-A"]["id"] == "dest-2"
+        mock_config.destination_client.post.assert_not_called()
+        mock_config.destination_client.put.assert_called_once()
+        put_path = mock_config.destination_client.put.call_args[0][0]
+        assert put_path == "/api/v1/synthetics/variables/dest-2"
+
+
+class TestUniqueNameStillPosts:
+    """4: green/green regression — a name not in the map still POSTs."""
+
+    def test_unique_name_routes_to_post(self, mock_config):
+        """4 (green/green): source name "Y" has no match — POST is called
+        once and the response lands in state. Behavior unchanged by the fix
+        when there is no type collision.
+        """
+        instance = SyntheticsGlobalVariables(mock_config)
+        instance._existing_resources_map = {}
+
+        source = _make_variable("Y", "variable", "src-Y")
+        response = _make_variable("Y", "variable", "dest-Y")
+        mock_config.destination_client.post = AsyncMock(return_value=response)
+        mock_config.destination_client.put = AsyncMock()
+
+        _, resp = asyncio.run(instance.create_resource("src-Y", source))
+
+        mock_config.destination_client.post.assert_called_once()
+        mock_config.destination_client.put.assert_not_called()
+        assert resp["id"] == "dest-Y"
+
+
+class TestPartialCollisionPosts:
+    """5: the literal production bug — destination has X/variable, source is
+    X/secret_token. Under old name-only key this incorrectly hit PUT on the
+    wrong type and the API returned 409. Under the composite key the source
+    correctly falls through to POST as a new variable."""
+
+    def test_partial_collision_routes_to_post(self, mock_config):
+        """5 (red→green): destination only has the X/variable entry. Source
+        is X/secret_token. Must POST (new variable), not PUT (wrong type).
+        """
+        instance = SyntheticsGlobalVariables(mock_config)
+        instance._existing_resources_map = {
+            "X:variable": _make_variable("X", "variable", "dest-1"),
+        }
+
+        source = _make_variable("X", "secret_token", "src-A")
+        response = _make_variable("X", "secret_token", "dest-new")
+        mock_config.destination_client.post = AsyncMock(return_value=response)
+        mock_config.destination_client.put = AsyncMock()
+
+        _, resp = asyncio.run(instance.create_resource("src-A", source))
+
+        mock_config.destination_client.post.assert_called_once()
+        mock_config.destination_client.put.assert_not_called()
+        assert resp["id"] == "dest-new"


### PR DESCRIPTION
## Summary

Resolves intermittent 409 Conflict on \`datadog-sync sync\` for \`synthetics_global_variables\`:

> 409 — \"Synthetics variable with same name and type already exists\"

**Root cause.** \`datadog_sync/model/synthetics_global_variables.py:36\` keyed \`_existing_resources_map\` by \`name\` only, but the Datadog API enforces uniqueness on the \`(name, type)\` tuple. When the destination had two variables sharing a name across different types (e.g. \`type=variable\` and \`type=secret_token\`), only one survived the last-write-wins collision in the prefetch map. The source variable matching the other type fell through to \`POST\` and hit the 409.

**Fix.** Switch \`resource_mapping_key\` to a composite lambda \`lambda r: f\"{r['name']}:{r['type']}\"\`. The existing prefetch + remap path in \`create_resource\` then resolves conflicts before any POST is issued — no new try/except, no new API call. This mirrors the pattern \`Teams\` already uses at \`datadog_sync/model/teams.py:34\` for its \`(name, handle)\` uniqueness, with the key difference that Synthetics is v1-flat (lambda reads \`r['name']\` / \`r['type']\` directly, not \`attributes.name\` / \`attributes.handle\`).

## Tests

Six unit tests in \`tests/unit/test_synthetics_global_variables.py\`:

1. \`map_existing_resources\` retains both same-name variants under distinct composite keys (red→green).
2. Routing assertion — source X/secret_token remaps to the correct destination ID and PUTs, post never called (red→green).
3a. Composite key resolves to \`\"X:variable\"\` on full input (red→green).
3b. Missing \`type\` returns \`None\` silently — guards \`base_resource.py:111-115\` silent-fail path against future refactors.
4. Unique-name regression — green/green, no behavior change for non-colliding names.
5. Partial-collision (the literal production bug shape) — source X/secret_token with destination only having X/variable correctly POSTs.

All 6 pass; full \`tests/unit/\` suite (576 tests) green; \`tox -e ruff,black\` clean.

## Cassette note

Existing integration test \`tests/integration/resources/test_synthetics_global_variable.py\` is **unaffected**: the destination state fixture at \`resources/destination/synthetics_global_variables.json\` contains a single variable with a unique name, so the new composite key collapses to the same single-entry map as the old name-only key. No cassette re-record required. *(The current cassettes have pre-existing playback failures on \`main\` unrelated to this fix.)*

## Out of scope

- **No 409 try/except fallback** in \`create_resource\`. Users/roles don't have one; the prefetch path is sufficient. A future PR can layer a 409-race handler if observed in production.
- **Type change between syncs.** If a source variable's \`type\` is manually flipped between syncs, the composite key won't match the cached entry and the code will POST a new variable. Acceptable per current semantics — \`type\` is part of identity at the API level.

## Test plan

- [x] \`tox -e py313 -- tests/unit/test_synthetics_global_variables.py\` — 6/6 pass
- [x] \`tox -e py313 -- tests/unit/\` — 576/576 pass
- [x] \`tox -e ruff,black\` — clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)