### PR TITLE
fix(tests): keep VCR cassette open during setup_and_teardown teardown

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -47,7 +47,7 @@ class BaseResourcesTestClass:
         os.chdir(my_tmpdir)
 
     @pytest.fixture(autouse=True, scope="function")
-    def setup_and_teardown(self, request, caplog: pytest.LogCaptureFixture):
+    def setup_and_teardown(self, request, caplog: pytest.LogCaptureFixture, vcr):
         """Set up before each test and clean up after each test."""
         # Clean up resources from any previous tests
         self.clean_resource_files()
@@ -55,7 +55,7 @@ class BaseResourcesTestClass:
         # Run the test
         yield
 
-        # Clean up resources respecting the resources_to_preserve_filter
+        # vcr dependency keeps the cassette open so teardown HTTP calls are served from the recording.
         runner = CliRunner()
         self.test_resource_cleanup(runner, caplog)
 


### PR DESCRIPTION
## Summary

- `setup_and_teardown` (class autouse) and `vcr` (plugin autouse) had no explicit dependency, so pytest could finalize `vcr` first — closing the cassette and unpatching `aiohttp` before the teardown phase ran.
- The teardown then made real HTTP calls that timed out after 30 s in CI (`TimeoutError while getting resources users`).
- Fix: add `vcr` as an explicit parameter to `setup_and_teardown`, which guarantees pytest keeps the cassette open until after teardown completes.

## Test plan

- [ ] CI integration tests pass (specifically `TestNotebooksResources.test_resource_import` teardown — the test that was failing with a 30 s timeout in #567's CI run)
- [ ] No other integration test teardowns regress (all other resource types use the same `BaseResourcesTestClass`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)