### PR TITLE
feat(restriction_policies): opt-in prefetched bodies via --restriction-policies-bulk-source

### DIFF
--- a/datadog_sync/commands/_import.py
+++ b/datadog_sync/commands/_import.py
@@ -36,6 +36,24 @@ from datadog_sync.constants import Command
     "commands.",
     cls=CustomOptionClass,
 )
+@option(
+    "--restriction-policies-bulk-source",
+    required=False,
+    type=str,
+    default=None,
+    help="Path to a JSON file containing prefetched restriction_policy bodies. "
+    "When set, restriction_policies import reads bodies from this file instead "
+    "of issuing per-ID GET /api/v2/restriction_policy/<id>. Intended for callers "
+    "that have already fetched policies in bulk and want to skip the per-ID GET "
+    "pass. Default unset preserves existing per-ID GET behavior. File shape: a "
+    "JSON array of unwrapped per-ID GET response bodies (each entry must have "
+    '"id" (non-empty string of the form "<type>:<resource-id>" with type one '
+    'of dashboard, notebook, or slo — matching the target types supported by '
+    'the live per-ID GET path), '
+    '"type" ("restriction_policy"), '
+    'and "attributes.bindings" (array, may be empty)).',
+    cls=CustomOptionClass,
+)
 def _import(**kwargs):
     """Import Datadog resources."""
     run_cmd(Command.IMPORT, **kwargs)

--- a/datadog_sync/model/restriction_policies.py
+++ b/datadog_sync/model/restriction_policies.py
@@ -4,6 +4,8 @@
 # Copyright 2019 Datadog, Inc.
 
 from __future__ import annotations
+import asyncio
+import json
 from typing import TYPE_CHECKING, Optional, List, Dict, Tuple
 
 from datadog_sync.utils.base_resource import BaseResource, ResourceConfig
@@ -11,6 +13,13 @@ from datadog_sync.utils.resource_utils import CustomClientHTTPError, SkipResourc
 
 if TYPE_CHECKING:
     from datadog_sync.utils.custom_client import CustomClient
+
+
+# Supported id prefixes for bulk-source entries. Must match the target types
+# enumerated in get_resources and remapped in connect_id; an entry outside this
+# set would import cleanly but never get its source id remapped to the destination
+# id at apply time, producing a silent miscompare.
+_SUPPORTED_BULK_ID_PREFIXES = frozenset({"dashboard", "notebook", "slo"})
 
 
 class RestrictionPolicies(BaseResource):
@@ -37,6 +46,16 @@ class RestrictionPolicies(BaseResource):
     org_principal: Optional[str] = None
 
     async def get_resources(self, client: CustomClient) -> List[Dict]:
+        # Bulk-source short-circuit: when --restriction-policies-bulk-source is set,
+        # read prefetched bodies from disk and skip enumeration of dashboards/notebooks/SLOs.
+        # Each body is a full per-ID GET response shape ({"id","type","attributes"}),
+        # detected downstream in import_resource by attributes.bindings being a list.
+        # File I/O is dispatched to a worker thread so the asyncio loop is not blocked
+        # while the producer-supplied JSON is parsed (size is bounded only by the producer).
+        bulk_source = self.config.restriction_policies_bulk_source
+        if bulk_source:
+            return await asyncio.to_thread(self._load_bulk_source, bulk_source)
+
         policies = []
 
         dashboards = await self.config.resources["dashboards"].get_resources(client)
@@ -76,6 +95,25 @@ class RestrictionPolicies(BaseResource):
         return policies
 
     async def import_resource(self, _id: Optional[str] = None, resource: Optional[Dict] = None) -> Tuple[str, Dict]:
+        # Bulk-source short-circuit: if get_resources already supplied a full body
+        # (detected by attributes.bindings being a list — guaranteed by _validate_bulk_body
+        # for bulk entries and absent from the legacy LIST stub which is just {"id": "..."}),
+        # return it without issuing a per-ID GET. The stronger discriminator (bindings is a
+        # list, not just attributes is a dict) is intentional: it pins the short-circuit to
+        # the exact shape the validator produces and prevents accidental engagement if a
+        # future change ever populates `attributes` on the legacy LIST stub.
+        # SkipResource on empty-bindings is applied identically to the GET path so the
+        # prefetched and live paths produce the same observable behavior.
+        if (
+            resource is not None
+            and isinstance(resource.get("attributes"), dict)
+            and isinstance(resource["attributes"].get("bindings"), list)
+        ):
+            import_id = resource["id"]
+            if not resource["attributes"]["bindings"]:
+                raise SkipResource(import_id, self.resource_type, "Resource does not have any bindings.")
+            return import_id, resource
+
         source_client = self.config.source_client
         import_id = _id or resource["id"]
 
@@ -211,3 +249,87 @@ class RestrictionPolicies(BaseResource):
                 if type_map.get(_type) == resource_to_connect
             ]
         return super().extract_source_ids(key, r_obj, resource_to_connect)
+
+    def _load_bulk_source(self, path: str) -> List[Dict]:
+        """Load prefetched restriction_policy bodies from a JSON file.
+
+        Returns the list as-is for downstream consumption by import_resource.
+        Raises RuntimeError on missing file, invalid JSON, wrong top-level shape, or
+        per-entry shape violations. The file is producer-supplied and the per-entry
+        shape must match the per-ID GET response body — any deviation indicates a
+        producer bug and is rejected at load time so a malformed body cannot reach
+        import_resource and surface as a non-actionable error downstream.
+
+        Validated shape per entry:
+          id:         non-empty str of the form "<type>:<resource-id>", with
+                       type one of {"dashboard","notebook","slo"} (the set
+                       enumerated by get_resources and remapped by connect_id)
+          type:       literal "restriction_policy"
+          attributes: dict
+          attributes.bindings: list (empty list is valid — SkipResource is applied
+                       in import_resource, matching the live per-ID GET path)
+        """
+        try:
+            with open(path, "r") as f:
+                bodies = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            raise RuntimeError(
+                f"--restriction-policies-bulk-source: failed to load {path!r}: {e}"
+            ) from e
+        if not isinstance(bodies, list):
+            raise RuntimeError(
+                f"--restriction-policies-bulk-source: expected JSON array at {path!r}, "
+                f"got {type(bodies).__name__}"
+            )
+        seen: Dict[str, int] = {}
+        for i, body in enumerate(bodies):
+            self._validate_bulk_body(body, i, path)
+            body_id = body["id"]
+            if body_id in seen:
+                raise RuntimeError(
+                    f"--restriction-policies-bulk-source: duplicate \"id\" {body_id!r} at "
+                    f"entries {seen[body_id]} and {i} in {path!r} — each policy id must "
+                    f"appear at most once (state writes are last-wins and would silently "
+                    f"drop earlier entries)"
+                )
+            seen[body_id] = i
+        return bodies
+
+    @staticmethod
+    def _validate_bulk_body(body, index: int, path: str) -> None:
+        prefix = f"--restriction-policies-bulk-source: entry {index} at {path!r}"
+        if not isinstance(body, dict):
+            raise RuntimeError(f"{prefix} must be a JSON object, got {type(body).__name__}")
+        body_id = body.get("id")
+        if not isinstance(body_id, str) or not body_id:
+            raise RuntimeError(f'{prefix} must have a non-empty string "id"')
+        type_prefix, sep, resource_id_part = body_id.partition(":")
+        if not sep or not type_prefix or not resource_id_part:
+            raise RuntimeError(
+                f'{prefix} has malformed "id" {body_id!r}: '
+                'expected "<type>:<resource-id>" with both sides non-empty '
+                '(e.g. "dashboard:abc-123")'
+            )
+        if type_prefix not in _SUPPORTED_BULK_ID_PREFIXES:
+            raise RuntimeError(
+                f'{prefix} has unsupported "id" prefix {type_prefix!r}: '
+                f"supported prefixes are {sorted(_SUPPORTED_BULK_ID_PREFIXES)}"
+            )
+        body_type = body.get("type")
+        if body_type != "restriction_policy":
+            raise RuntimeError(
+                f'{prefix} must have "type" == "restriction_policy", got {body_type!r}'
+            )
+        attributes = body.get("attributes")
+        if not isinstance(attributes, dict):
+            raise RuntimeError(
+                f'{prefix} must have "attributes" as an object, '
+                f"got {type(attributes).__name__}"
+            )
+        bindings = attributes.get("bindings")
+        if not isinstance(bindings, list):
+            raise RuntimeError(
+                f'{prefix} must have "attributes.bindings" as an array '
+                "(empty array is valid), "
+                f"got {type(bindings).__name__}"
+            )

--- a/datadog_sync/utils/configuration.py
+++ b/datadog_sync/utils/configuration.py
@@ -112,6 +112,11 @@ class Configuration(object):
     prune_force: bool = False
     prune_dry_run: bool = False
     destination_logs_intake_url: Optional[str] = None
+    # Path to a JSON file containing prefetched restriction_policy bodies. Set via
+    # --restriction-policies-bulk-source on `import`. When set, the restriction_policies
+    # model reads bodies from disk instead of issuing per-ID GETs. Default None preserves
+    # existing per-ID GET behavior.
+    restriction_policies_bulk_source: Optional[str] = None
 
     async def init_async(self, cmd: Command):
         await self.source_client._init_session()
@@ -428,6 +433,7 @@ def build_config(cmd: Command, **kwargs: Optional[Any]) -> Configuration:
         show_progress_bar = False
     allow_self_lockout = kwargs.get("allow_self_lockout", False)
     datadog_host_override = kwargs.get("datadog_host_override")
+    restriction_policies_bulk_source = kwargs.get("restriction_policies_bulk_source")
 
     # Parse allow_partial_permissions_roles
     allow_partial_permissions_roles = []
@@ -673,6 +679,7 @@ def build_config(cmd: Command, **kwargs: Optional[Any]) -> Configuration:
         show_progress_bar=show_progress_bar,
         allow_self_lockout=allow_self_lockout,
         datadog_host_override=datadog_host_override,
+        restriction_policies_bulk_source=restriction_policies_bulk_source,
         emit_json=emit_json,
         command=cmd.value,
         allow_partial_permissions_roles=allow_partial_permissions_roles,

--- a/tests/unit/test_restriction_policies.py
+++ b/tests/unit/test_restriction_policies.py
@@ -11,10 +11,12 @@ pre_resource_action_hook handles both success and failure paths correctly.
 """
 
 import asyncio
+import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
 from datadog_sync.model.restriction_policies import RestrictionPolicies
+from datadog_sync.utils.resource_utils import SkipResource
 
 
 class TestRestrictionPoliciesOrgPrincipal:
@@ -99,3 +101,281 @@ class TestRestrictionPoliciesOrgPrincipal:
 
         assert r["attributes"]["bindings"][0]["principals"][0] == "org:source-pub-id"
         assert r["attributes"]["bindings"][0]["principals"][1] == "user:some-user"
+
+
+class TestRestrictionPoliciesBulkSource:
+    """Verify --restriction-policies-bulk-source short-circuits per-ID GETs."""
+
+    def _make_resource(self, bulk_source=None):
+        mock_config = MagicMock()
+        mock_config.state = MagicMock()
+        mock_config.restriction_policies_bulk_source = bulk_source
+        return RestrictionPolicies(mock_config)
+
+    def _body(self, policy_id, bindings=None):
+        return {
+            "id": policy_id,
+            "type": "restriction_policy",
+            "attributes": {
+                "bindings": bindings
+                if bindings is not None
+                else [{"relation": "editor", "principals": ["role:r1"]}]
+            },
+        }
+
+    def test_get_resources_flag_off_uses_per_dependency_path(self):
+        """Flag unset = existing enumerate-from-dashboards/notebooks/SLOs behavior."""
+        resource = self._make_resource(bulk_source=None)
+        mock_dashboards = MagicMock()
+        mock_dashboards.get_resources = AsyncMock(return_value=[{"id": "d1"}])
+        mock_notebooks = MagicMock()
+        mock_notebooks.get_resources = AsyncMock(return_value=[])
+        mock_slos = MagicMock()
+        mock_slos.get_resources = AsyncMock(return_value=[])
+        resource.config.resources = {
+            "dashboards": mock_dashboards,
+            "notebooks": mock_notebooks,
+            "service_level_objectives": mock_slos,
+        }
+
+        result = asyncio.run(resource.get_resources(MagicMock()))
+
+        assert result == [{"id": "dashboard:d1"}]
+        mock_dashboards.get_resources.assert_awaited_once()
+
+    def test_get_resources_flag_on_reads_file_and_skips_enumeration(self, tmp_path):
+        """Flag set = file is the source of truth; dependency models are not queried.
+
+        Note: directly asserts the dependency `get_resources` awaitables are never
+        awaited rather than relying on MagicMock side_effect on the parent container
+        (which would not fire on __getitem__ access, only on __call__).
+        """
+        bodies = [
+            self._body("dashboard:abc"),
+            self._body("notebook:def"),
+            self._body("slo:ghi"),
+        ]
+        path = tmp_path / "policies.json"
+        path.write_text(json.dumps(bodies))
+
+        resource = self._make_resource(bulk_source=str(path))
+        mock_dashboards = MagicMock()
+        mock_dashboards.get_resources = AsyncMock(side_effect=AssertionError("must not enumerate dashboards"))
+        mock_notebooks = MagicMock()
+        mock_notebooks.get_resources = AsyncMock(side_effect=AssertionError("must not enumerate notebooks"))
+        mock_slos = MagicMock()
+        mock_slos.get_resources = AsyncMock(side_effect=AssertionError("must not enumerate slos"))
+        resource.config.resources = {
+            "dashboards": mock_dashboards,
+            "notebooks": mock_notebooks,
+            "service_level_objectives": mock_slos,
+        }
+
+        result = asyncio.run(resource.get_resources(MagicMock()))
+
+        assert result == bodies
+        mock_dashboards.get_resources.assert_not_awaited()
+        mock_notebooks.get_resources.assert_not_awaited()
+        mock_slos.get_resources.assert_not_awaited()
+
+    def test_import_resource_short_circuits_on_prefetched_body(self):
+        """resource arg with `attributes` returns as-is; source_client.get is not called."""
+        resource = self._make_resource()
+        mock_client = AsyncMock()
+        resource.config.source_client = mock_client
+
+        body = self._body("dashboard:abc")
+        import_id, returned = asyncio.run(resource.import_resource(resource=body))
+
+        assert import_id == "dashboard:abc"
+        assert returned is body
+        mock_client.get.assert_not_called()
+
+    def test_import_resource_prefetched_empty_bindings_raises_skip(self):
+        """Empty-bindings SkipResource semantics match the per-ID GET path."""
+        resource = self._make_resource()
+        body = self._body("dashboard:abc", bindings=[])
+
+        with pytest.raises(SkipResource):
+            asyncio.run(resource.import_resource(resource=body))
+
+    def test_import_resource_no_attributes_falls_through_to_get(self):
+        """Stub-only resource (no `attributes`) goes through the existing GET path."""
+        resource = self._make_resource()
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(
+            return_value={
+                "data": {
+                    "id": "dashboard:abc",
+                    "type": "restriction_policy",
+                    "attributes": {"bindings": [{"relation": "editor", "principals": ["role:r1"]}]},
+                }
+            }
+        )
+        resource.config.source_client = mock_client
+
+        import_id, returned = asyncio.run(resource.import_resource(resource={"id": "dashboard:abc"}))
+
+        assert import_id == "dashboard:abc"
+        mock_client.get.assert_awaited_once()
+        assert returned["attributes"]["bindings"][0]["relation"] == "editor"
+
+    def test_import_resource_attributes_without_bindings_falls_through_to_get(self):
+        """Defensive: if a future legacy LIST stub ever carried `attributes` without a
+        `bindings` list, the bulk short-circuit must not engage. The stronger discriminator
+        (bindings is a list) keeps the short-circuit pinned to the validator's exact shape.
+        """
+        resource = self._make_resource()
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(
+            return_value={
+                "data": {
+                    "id": "dashboard:abc",
+                    "type": "restriction_policy",
+                    "attributes": {"bindings": [{"relation": "editor", "principals": ["role:r1"]}]},
+                }
+            }
+        )
+        resource.config.source_client = mock_client
+
+        # Stub-with-attributes-but-no-bindings (hypothetical future enriched LIST stub):
+        # discriminator must not engage and code must GET the real body.
+        stub_with_partial_attributes = {"id": "dashboard:abc", "attributes": {"type_hint": "dashboard"}}
+        import_id, returned = asyncio.run(resource.import_resource(resource=stub_with_partial_attributes))
+
+        assert import_id == "dashboard:abc"
+        mock_client.get.assert_awaited_once()
+        assert returned["attributes"]["bindings"][0]["relation"] == "editor"
+
+    def test_load_bulk_source_missing_file_raises(self, tmp_path):
+        resource = self._make_resource(bulk_source=str(tmp_path / "absent.json"))
+        with pytest.raises(RuntimeError, match="failed to load"):
+            resource._load_bulk_source(str(tmp_path / "absent.json"))
+
+    def test_load_bulk_source_non_list_raises(self, tmp_path):
+        path = tmp_path / "object.json"
+        path.write_text(json.dumps({"id": "dashboard:abc"}))
+        resource = self._make_resource(bulk_source=str(path))
+        with pytest.raises(RuntimeError, match="expected JSON array"):
+            resource._load_bulk_source(str(path))
+
+    def test_load_bulk_source_missing_attributes_raises(self, tmp_path):
+        path = tmp_path / "malformed.json"
+        path.write_text(json.dumps([{"id": "dashboard:abc", "type": "restriction_policy"}]))
+        resource = self._make_resource(bulk_source=str(path))
+        with pytest.raises(RuntimeError, match='"attributes" as an object'):
+            resource._load_bulk_source(str(path))
+
+    def test_load_bulk_source_empty_list_is_valid(self, tmp_path):
+        """An empty prefetch is legitimate (org has no restriction policies)."""
+        path = tmp_path / "empty.json"
+        path.write_text("[]")
+        resource = self._make_resource(bulk_source=str(path))
+        assert resource._load_bulk_source(str(path)) == []
+
+    def test_load_bulk_source_non_dict_entry_raises(self, tmp_path):
+        path = tmp_path / "bad_entry.json"
+        path.write_text(json.dumps(["not-a-dict"]))
+        resource = self._make_resource(bulk_source=str(path))
+        with pytest.raises(RuntimeError, match="must be a JSON object"):
+            resource._load_bulk_source(str(path))
+
+    def test_load_bulk_source_non_string_id_raises(self, tmp_path):
+        path = tmp_path / "bad_id.json"
+        path.write_text(json.dumps([{"id": 123, "type": "restriction_policy", "attributes": {"bindings": []}}]))
+        resource = self._make_resource(bulk_source=str(path))
+        with pytest.raises(RuntimeError, match='non-empty string "id"'):
+            resource._load_bulk_source(str(path))
+
+    def test_load_bulk_source_empty_id_raises(self, tmp_path):
+        path = tmp_path / "empty_id.json"
+        path.write_text(json.dumps([{"id": "", "type": "restriction_policy", "attributes": {"bindings": []}}]))
+        resource = self._make_resource(bulk_source=str(path))
+        with pytest.raises(RuntimeError, match='non-empty string "id"'):
+            resource._load_bulk_source(str(path))
+
+    def test_load_bulk_source_id_missing_separator_raises(self, tmp_path):
+        path = tmp_path / "no_colon.json"
+        path.write_text(json.dumps([{"id": "garbage", "type": "restriction_policy", "attributes": {"bindings": []}}]))
+        resource = self._make_resource(bulk_source=str(path))
+        with pytest.raises(RuntimeError, match='malformed "id"'):
+            resource._load_bulk_source(str(path))
+
+    def test_load_bulk_source_id_empty_type_side_raises(self, tmp_path):
+        """An id like ':abc' has an empty type prefix and must be rejected."""
+        path = tmp_path / "empty_type.json"
+        path.write_text(json.dumps([{"id": ":abc", "type": "restriction_policy", "attributes": {"bindings": []}}]))
+        resource = self._make_resource(bulk_source=str(path))
+        with pytest.raises(RuntimeError, match='malformed "id"'):
+            resource._load_bulk_source(str(path))
+
+    def test_load_bulk_source_id_empty_resource_side_raises(self, tmp_path):
+        """An id like 'dashboard:' has an empty resource-id side and must be rejected."""
+        path = tmp_path / "empty_resource.json"
+        path.write_text(
+            json.dumps([{"id": "dashboard:", "type": "restriction_policy", "attributes": {"bindings": []}}])
+        )
+        resource = self._make_resource(bulk_source=str(path))
+        with pytest.raises(RuntimeError, match='malformed "id"'):
+            resource._load_bulk_source(str(path))
+
+    def test_load_bulk_source_unsupported_id_prefix_raises(self, tmp_path):
+        """An id with a prefix outside the legacy supported set must be rejected."""
+        path = tmp_path / "unsupported_prefix.json"
+        path.write_text(
+            json.dumps(
+                [{"id": "security-rule:abc", "type": "restriction_policy", "attributes": {"bindings": []}}]
+            )
+        )
+        resource = self._make_resource(bulk_source=str(path))
+        with pytest.raises(RuntimeError, match='unsupported "id" prefix'):
+            resource._load_bulk_source(str(path))
+
+    def test_load_bulk_source_wrong_type_raises(self, tmp_path):
+        path = tmp_path / "wrong_type.json"
+        path.write_text(
+            json.dumps([{"id": "dashboard:abc", "type": "something_else", "attributes": {"bindings": []}}])
+        )
+        resource = self._make_resource(bulk_source=str(path))
+        with pytest.raises(RuntimeError, match='"type" == "restriction_policy"'):
+            resource._load_bulk_source(str(path))
+
+    def test_load_bulk_source_attributes_null_raises(self, tmp_path):
+        path = tmp_path / "null_attrs.json"
+        path.write_text(json.dumps([{"id": "dashboard:abc", "type": "restriction_policy", "attributes": None}]))
+        resource = self._make_resource(bulk_source=str(path))
+        with pytest.raises(RuntimeError, match='"attributes" as an object'):
+            resource._load_bulk_source(str(path))
+
+    def test_load_bulk_source_bindings_missing_raises(self, tmp_path):
+        path = tmp_path / "no_bindings.json"
+        path.write_text(json.dumps([{"id": "dashboard:abc", "type": "restriction_policy", "attributes": {}}]))
+        resource = self._make_resource(bulk_source=str(path))
+        with pytest.raises(RuntimeError, match='"attributes.bindings" as an array'):
+            resource._load_bulk_source(str(path))
+
+    def test_load_bulk_source_bindings_non_list_raises(self, tmp_path):
+        path = tmp_path / "bad_bindings.json"
+        path.write_text(
+            json.dumps([{"id": "dashboard:abc", "type": "restriction_policy", "attributes": {"bindings": "x"}}])
+        )
+        resource = self._make_resource(bulk_source=str(path))
+        with pytest.raises(RuntimeError, match='"attributes.bindings" as an array'):
+            resource._load_bulk_source(str(path))
+
+    def test_load_bulk_source_empty_bindings_list_is_valid(self, tmp_path):
+        """Empty bindings list is allowed at load time; SkipResource fires later in import_resource."""
+        path = tmp_path / "empty_bindings.json"
+        body = {"id": "dashboard:abc", "type": "restriction_policy", "attributes": {"bindings": []}}
+        path.write_text(json.dumps([body]))
+        resource = self._make_resource(bulk_source=str(path))
+        assert resource._load_bulk_source(str(path)) == [body]
+
+    def test_load_bulk_source_duplicate_id_raises(self, tmp_path):
+        """Duplicate ids would be last-wins overwrites in state — surface them at load time."""
+        path = tmp_path / "duplicate_id.json"
+        body = {"id": "dashboard:abc", "type": "restriction_policy", "attributes": {"bindings": []}}
+        path.write_text(json.dumps([body, body]))
+        resource = self._make_resource(bulk_source=str(path))
+        with pytest.raises(RuntimeError, match="duplicate \"id\""):
+            resource._load_bulk_source(str(path))


### PR DESCRIPTION
## Summary

Adds an opt-in `--restriction-policies-bulk-source <path>` flag to `import`. When set, the `restriction_policies` model reads prefetched per-ID GET response bodies from a JSON file on disk and skips the per-ID `GET /api/v2/restriction_policy/<id>` pass. Default unset preserves existing behavior.

Intended for callers that have already fetched policies in bulk and want to skip the per-ID GET fan-out.

## File shape

JSON array of unwrapped per-ID GET response bodies. Each entry must have:
- `id`: non-empty string of the form `<type>:<resource-id>`, with `type` in `{dashboard, notebook, slo}` (the set enumerated by the legacy path and remapped by `connect_id`)
- `type`: `"restriction_policy"`
- `attributes.bindings`: array (may be empty — SkipResource is applied identically to the live per-ID GET path)

Entries are validated at load time; producer-bug shapes (wrong type, malformed id, duplicate id, etc.) are rejected with an actionable error before any HTTP calls fire.

## Filter behavior note

When `--restriction-policies-bulk-source` is set, `restriction_policies` filters are evaluated against the prefetched full bodies. This can differ from legacy discovery for filters on `attributes.*` because the legacy LIST-derived stubs only contain `id`.

## Test plan

- [x] Unit tests added for: bulk-source enumeration short-circuit, prefetched-body import short-circuit, empty-bindings SkipResource parity with live path, all validator shape checks (missing file, non-list, non-dict entry, malformed id, unsupported id prefix, wrong type, missing/non-list bindings, duplicate id), discriminator fall-through when `attributes` is present without `bindings`.
- [x] Full unit suite green (698 passing).
- [x] Default-unset path covered (existing behavior unchanged).