### PR TITLE
feat(id-file): enable authn_mappings + team_memberships

### DIFF
--- a/datadog_sync/commands/shared/options.py
+++ b/datadog_sync/commands/shared/options.py
@@ -184,14 +184,14 @@ _common_options = [
         help="Max number of workers when running operations in multi-threads.",
         cls=CustomOptionClass,
     ),
-    # ID-targeted import flags (monitors only in v1)
+    # ID-targeted import flags (supported allowlisted types only)
     option(
         "--id-file",
         required=False,
         default=None,
         help="Path to JSON file mapping resource types to ID lists, or `-` for stdin. "
         "When set, import command fetches only the specified IDs instead of "
-        "listing all resources. v1 supports monitors only.",
+        "listing all resources. Supported types are enforced by a code-level allowlist.",
         cls=CustomOptionClass,
     ),
     option(

--- a/datadog_sync/model/roles.py
+++ b/datadog_sync/model/roles.py
@@ -398,9 +398,7 @@ class Roles(BaseResource):
         # Reverse map: destination UUID -> permission name (for sync path where source
         # state still holds permission names after import_resource's name rewrite).
         uuid_to_name = (
-            {uuid: name for name, uuid in self.destination_permissions.items()}
-            if self.destination_permissions
-            else {}
+            {uuid: name for name, uuid in self.destination_permissions.items()} if self.destination_permissions else {}
         )
         # A permission entry in source_perms may carry either a name (sync path, pre-remap)
         # or a destination UUID (diffs path, where pre_resource_action_hook just ran on the

--- a/datadog_sync/model/synthetics_private_locations.py
+++ b/datadog_sync/model/synthetics_private_locations.py
@@ -15,6 +15,7 @@ from datadog_sync.utils.resource_utils import SkipResource
 if TYPE_CHECKING:
     from datadog_sync.utils.custom_client import CustomClient
 
+
 class SyntheticsPrivateLocations(BaseResource):
     resource_type = "synthetics_private_locations"
     resource_config = ResourceConfig(

--- a/datadog_sync/model/team_memberships.py
+++ b/datadog_sync/model/team_memberships.py
@@ -78,22 +78,13 @@ class TeamMemberships(BaseResource):
         return all_team_memberships
 
     async def import_resource(self, _id: Optional[str] = None, resource: Optional[Dict] = None) -> Tuple[str, Dict]:
-        source_client = self.config.source_client
-        pagination_config = PaginationConfig(
-            page_size=100,
-            page_number_param="page[number]",
-            page_size_param="page[size]",
-            remaining_func=lambda idx, resp, page_size, page_number: max(
-                0,
-                resp["meta"]["pagination"]["total"] - (page_size * (idx + 1)),
-            ),
-        )
-
-        if _id:
-            resource = await source_client.paginated_request(source_client.get)(
-                self.team_memberships_path.format(_id),
-                pagination_config=pagination_config,
-            )
+        if _id is not None and resource is None:
+            if ":" not in _id:
+                # _id is a bare team UUID from --id-file; fan out to N membership rows.
+                # Dispatch condition: ":" not in _id distinguishes bare team UUID
+                # (from --id-file) from composite team_id:user_id (from 2-arg path).
+                return await self._import_team_memberships_by_team_id(_id)
+            # composite team_id:user_id from get_resources() falls through to existing code
 
         resource = cast(dict, resource)
         if not resource:
@@ -104,6 +95,61 @@ class TeamMemberships(BaseResource):
             raise ValueError("Error creating team membership resource, no id")
 
         return _id, resource
+
+    async def _import_team_memberships_by_team_id(self, team_id: str) -> Tuple[str, Dict]:
+        """Fan-out: fetch all memberships for team_id and write N composite rows to state.
+
+        Delete-before-write ensures stale membership rows for removed users are
+        not retained. Uses ImportState.delete_source (new public method in PR 7)
+        rather than direct dict mutation to preserve ImportState encapsulation.
+
+        Returns the last composite key + resource so the outer _import_resource
+        can call set_source (harmless overwrite for N>0). For N==0 returns the
+        bare team_id + empty dict.
+        """
+        source_client = self.config.source_client
+        pagination_config = PaginationConfig(
+            page_size=100,
+            page_number_param="page[number]",
+            page_size_param="page[size]",
+            remaining_func=lambda idx, resp, page_size, page_number: max(
+                0,
+                resp["meta"]["pagination"]["total"] - (page_size * (idx + 1)),
+            ),
+        )
+        new_members = await source_client.paginated_request(source_client.get)(
+            self.team_memberships_path.format(team_id),
+            pagination_config=pagination_config,
+        )
+
+        # Delete-before-write: remove all existing state rows for this team — both
+        # composite team_id:user_id rows (stale membership rows for removed users)
+        # and the bare team_id key that prior runs may have written for empty teams.
+        existing_keys = [k for k in self.config.state.get_source_keys(self.resource_type)
+                         if k == team_id or k.startswith(f"{team_id}:")]
+        for k in existing_keys:
+            self.config.state.delete_source(self.resource_type, k)
+
+        # Write the refreshed membership rows
+        last_id: Optional[str] = None
+        last_resource: Optional[Dict] = None
+        for member in new_members:
+            member["relationships"]["team"] = {"data": {"type": "team", "id": team_id}}
+            user_id = member["relationships"]["user"]["data"]["id"]
+            composite_id = f"{team_id}:{user_id}"
+            self.config.state.set_source(self.resource_type, composite_id, member)
+            last_id, last_resource = composite_id, member
+
+        if last_id is not None:
+            # Return last composite key; outer _import_resource will overwrite it (harmless).
+            return last_id, last_resource
+
+        # Empty team: raise SkipResource so the outer _import_resource does not call
+        # set_source at all. A bare team_id key with no colon is not a valid membership
+        # row and would linger in state across fan-out cycles (the delete-before-write
+        # prefix match `team_id:` would not catch it). SkipResource is caught by the
+        # batch import path (fetch_one) and treated as a non-error skip.
+        raise SkipResource(team_id, self.resource_type, "team has no members")
 
     async def pre_resource_action_hook(self, _id, resource: Dict) -> None:
         pass

--- a/datadog_sync/model/team_memberships.py
+++ b/datadog_sync/model/team_memberships.py
@@ -4,12 +4,17 @@
 # Copyright 2019 Datadog, Inc.
 
 from __future__ import annotations
+import asyncio
 import copy
 from typing import TYPE_CHECKING, Optional, List, Dict, Tuple, cast
 
 from datadog_sync.utils.base_resource import BaseResource, ResourceConfig
 from datadog_sync.utils.custom_client import PaginationConfig
-from datadog_sync.utils.resource_utils import check_diff, SkipResource
+from datadog_sync.utils.resource_utils import (
+    check_diff,
+    CustomClientHTTPError,
+    SkipResource,
+)
 
 if TYPE_CHECKING:
     from datadog_sync.utils.custom_client import CustomClient
@@ -37,9 +42,9 @@ class TeamMemberships(BaseResource):
     team_memberships_path = "/api/v2/team/{}/memberships"
     # Additional TeamMemberships specific attributes
 
-    async def get_resources(self, client: CustomClient) -> List[Dict]:
-        # get all the teams
-        teams_pagination_config = PaginationConfig(
+    @staticmethod
+    def _memberships_pagination_config() -> PaginationConfig:
+        return PaginationConfig(
             page_size=100,
             page_number_param="page[number]",
             page_size_param="page[size]",
@@ -48,6 +53,21 @@ class TeamMemberships(BaseResource):
                 resp["meta"]["pagination"]["total"] - (page_size * (idx + 1)),
             ),
         )
+
+    async def _get_memberships_for_team(
+        self, client: CustomClient, team_id: str
+    ) -> List[Dict]:
+        members_of_team = await client.paginated_request(client.get)(
+            self.team_memberships_path.format(team_id),
+            pagination_config=self._memberships_pagination_config(),
+        )
+        for member in members_of_team:
+            member["relationships"]["team"] = {"data": {"type": "team", "id": team_id}}
+        return members_of_team
+
+    async def get_resources(self, client: CustomClient) -> List[Dict]:
+        # get all the teams
+        teams_pagination_config = self._memberships_pagination_config()
         teams = await client.paginated_request(client.get)(
             self.resource_config.base_path,
             pagination_config=teams_pagination_config,
@@ -56,35 +76,81 @@ class TeamMemberships(BaseResource):
         # iterate over the teams and create a list of all members of all teams
         all_team_memberships = []
         for team in teams:
-            members_pagination_config = PaginationConfig(
-                page_size=100,
-                page_number_param="page[number]",
-                page_size_param="page[size]",
-                remaining_func=lambda idx, resp, page_size, page_number: max(
-                    0,
-                    resp["meta"]["pagination"]["total"] - (page_size * (idx + 1)),
-                ),
-            )
-            members_of_team = await client.paginated_request(client.get)(
-                self.team_memberships_path.format(team["id"]),
-                pagination_config=members_pagination_config,
-            )
-
-            # add the team relationship
-            for member in members_of_team:
-                member["relationships"]["team"] = {"data": {"type": "team", "id": team["id"]}}
+            members_of_team = await self._get_memberships_for_team(client, team["id"])
             all_team_memberships += members_of_team
 
         return all_team_memberships
 
-    async def import_resource(self, _id: Optional[str] = None, resource: Optional[Dict] = None) -> Tuple[str, Dict]:
+    async def get_resources_by_ids(
+        self,
+        client: CustomClient,
+        ids: List[str],
+        max_concurrent_reads: int = 10,
+    ) -> Tuple[List[Dict], List[str], List[Tuple[str, str, str]]]:
+        """Fan out team IDs into team_memberships resources without mutating state.
+
+        For ``team_memberships``, the id-file payload contains team IDs. Each
+        team ID fans out to zero or more membership resources from
+        ``/api/v2/team/{team_id}/memberships``. This fetch phase must remain
+        side-effect free so second-pass import/filter semantics stay intact.
+        """
+        sem = asyncio.Semaphore(max_concurrent_reads)
+        resources: List[Dict] = []
+        missing: List[str] = []
+        errored: List[Tuple[str, str, str]] = []
+
+        import aiohttp
+
+        async def fetch_one(team_id: str):
+            async with sem:
+                try:
+                    members = await self._get_memberships_for_team(client, team_id)
+                    if not members:
+                        return ("skipped", team_id, "team has no members")
+                    return ("ok", members)
+                except CustomClientHTTPError as e:
+                    if e.status_code == 404:
+                        return ("missing", team_id)
+                    if e.status_code == 429 or e.status_code >= 500:
+                        return ("transient", team_id, f"HTTP {e.status_code}")
+                    return ("permanent", team_id, f"HTTP {e.status_code}")
+                except (asyncio.TimeoutError,):
+                    return ("transient", team_id, "timeout")
+                except aiohttp.ClientError as e:
+                    return (
+                        "transient",
+                        team_id,
+                        f"connection error: {type(e).__name__}",
+                    )
+                except Exception as e:
+                    msg = str(e)
+                    if "retry limit exceeded" in msg:
+                        return ("transient", team_id, msg[:200])
+                    return ("permanent", team_id, msg[:200])
+
+        results = await asyncio.gather(*(fetch_one(i) for i in ids))
+        for result in results:
+            tag = result[0]
+            if tag == "ok":
+                resources.extend(result[1])
+            elif tag == "missing":
+                missing.append(result[1])
+            elif tag == "skipped":
+                errored.append((result[1], "skipped", result[2]))
+            elif tag == "transient":
+                errored.append((result[1], "transient", result[2]))
+            else:
+                errored.append((result[1], "permanent", result[2]))
+        return resources, missing, errored
+
+    async def import_resource(
+        self, _id: Optional[str] = None, resource: Optional[Dict] = None
+    ) -> Tuple[str, Dict]:
         if _id is not None and resource is None:
-            if ":" not in _id:
-                # _id is a bare team UUID from --id-file; fan out to N membership rows.
-                # Dispatch condition: ":" not in _id distinguishes bare team UUID
-                # (from --id-file) from composite team_id:user_id (from 2-arg path).
-                return await self._import_team_memberships_by_team_id(_id)
-            # composite team_id:user_id from get_resources() falls through to existing code
+            raise ValueError(
+                "Error creating team membership resource: direct ID import is not supported. "
+                "Use get_resources_by_ids() with team IDs."
+            )
 
         resource = cast(dict, resource)
         if not resource:
@@ -95,61 +161,6 @@ class TeamMemberships(BaseResource):
             raise ValueError("Error creating team membership resource, no id")
 
         return _id, resource
-
-    async def _import_team_memberships_by_team_id(self, team_id: str) -> Tuple[str, Dict]:
-        """Fan-out: fetch all memberships for team_id and write N composite rows to state.
-
-        Delete-before-write ensures stale membership rows for removed users are
-        not retained. Uses ImportState.delete_source
-        rather than direct dict mutation to preserve ImportState encapsulation.
-
-        Returns the last composite key + resource so the outer _import_resource
-        can call set_source (harmless overwrite for N>0). For N==0 returns the
-        bare team_id + empty dict.
-        """
-        source_client = self.config.source_client
-        pagination_config = PaginationConfig(
-            page_size=100,
-            page_number_param="page[number]",
-            page_size_param="page[size]",
-            remaining_func=lambda idx, resp, page_size, page_number: max(
-                0,
-                resp["meta"]["pagination"]["total"] - (page_size * (idx + 1)),
-            ),
-        )
-        new_members = await source_client.paginated_request(source_client.get)(
-            self.team_memberships_path.format(team_id),
-            pagination_config=pagination_config,
-        )
-
-        # Delete-before-write: remove all existing state rows for this team — both
-        # composite team_id:user_id rows (stale membership rows for removed users)
-        # and the bare team_id key that prior runs may have written for empty teams.
-        existing_keys = [k for k in self.config.state.get_source_keys(self.resource_type)
-                         if k == team_id or k.startswith(f"{team_id}:")]
-        for k in existing_keys:
-            self.config.state.delete_source(self.resource_type, k)
-
-        # Write the refreshed membership rows
-        last_id: Optional[str] = None
-        last_resource: Optional[Dict] = None
-        for member in new_members:
-            member["relationships"]["team"] = {"data": {"type": "team", "id": team_id}}
-            user_id = member["relationships"]["user"]["data"]["id"]
-            composite_id = f"{team_id}:{user_id}"
-            self.config.state.set_source(self.resource_type, composite_id, member)
-            last_id, last_resource = composite_id, member
-
-        if last_id is not None:
-            # Return last composite key; outer _import_resource will overwrite it (harmless).
-            return last_id, last_resource
-
-        # Empty team: raise SkipResource so the outer _import_resource does not call
-        # set_source at all. A bare team_id key with no colon is not a valid membership
-        # row and would linger in state across fan-out cycles (the delete-before-write
-        # prefix match `team_id:` would not catch it). SkipResource is caught by the
-        # batch import path (fetch_one) and treated as a non-error skip.
-        raise SkipResource(team_id, self.resource_type, "team has no members")
 
     async def pre_resource_action_hook(self, _id, resource: Dict) -> None:
         pass
@@ -165,13 +176,17 @@ class TeamMemberships(BaseResource):
         key = self.get_resource_mapping_key(destination_resource)
         existing = self._existing_resources_map.get(key, {}) if key else {}
         if existing:
-            raise SkipResource(_id, self.resource_type, "User is already a member of the team")
+            raise SkipResource(
+                _id, self.resource_type, "User is already a member of the team"
+            )
 
         resp = await destination_client.post(
             self.team_memberships_path.format(resource_team_id),
             {"data": destination_resource},
         )
-        resp["data"]["relationships"]["team"] = {"data": {"type": "team", "id": resource_team_id}}
+        resp["data"]["relationships"]["team"] = {
+            "data": {"type": "team", "id": resource_team_id}
+        }
         return _id, resp["data"]
 
     async def update_resource(self, _id: str, resource: Dict) -> Tuple[str, Dict]:
@@ -187,7 +202,9 @@ class TeamMemberships(BaseResource):
         # skip if there are no differences
         diff = check_diff(self.resource_config, state, existing)
         if not diff:
-            raise SkipResource(resource["id"], self.resource_type, "No differences detected")
+            raise SkipResource(
+                resource["id"], self.resource_type, "No differences detected"
+            )
 
         # update the existing resource
         team_id = existing["relationships"]["team"]["data"]["id"]
@@ -196,7 +213,9 @@ class TeamMemberships(BaseResource):
             self.team_memberships_path.format(team_id) + f"/{user_id}",
             {"data": resource},
         )
-        resp["data"]["relationships"]["team"] = {"data": {"type": "team", "id": team_id}}
+        resp["data"]["relationships"]["team"] = {
+            "data": {"type": "team", "id": team_id}
+        }
         return _id, resp["data"]
 
     async def delete_resource(self, _id: str) -> None:
@@ -208,7 +227,9 @@ class TeamMemberships(BaseResource):
 
         # skip if the membership isn't found in state
         if not state:
-            raise SkipResource(_id, self.resource_type, f"resource {_id} not found for deletion")
+            raise SkipResource(
+                _id, self.resource_type, f"resource {_id} not found for deletion"
+            )
 
         # Use team_id and user_id directly from state to avoid race conditions
         team_id = state["relationships"]["team"]["data"]["id"]
@@ -223,11 +244,15 @@ class TeamMemberships(BaseResource):
             # This can happen during cleanup when teams are deleted concurrently
             if "404" in str(e):
                 raise SkipResource(
-                    _id, self.resource_type, f"resource {_id} or its team not found (may have been already deleted)"
+                    _id,
+                    self.resource_type,
+                    f"resource {_id} or its team not found (may have been already deleted)",
                 )
             raise
 
-    def connect_id(self, key: str, r_obj: Dict, resource_to_connect: str) -> Optional[List[str]]:
+    def connect_id(
+        self, key: str, r_obj: Dict, resource_to_connect: str
+    ) -> Optional[List[str]]:
         failed_connections = []
         _id = r_obj["id"]
         _type = r_obj["type"]

--- a/datadog_sync/model/team_memberships.py
+++ b/datadog_sync/model/team_memberships.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 import asyncio
 import copy
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, List, Dict, Tuple, cast
 
 from datadog_sync.utils.base_resource import BaseResource, ResourceConfig
@@ -22,6 +23,18 @@ if TYPE_CHECKING:
 
 def _team_membership_key(r):
     return f"{r['relationships']['team']['data']['id']}:{r['relationships']['user']['data']['id']}"
+
+
+@dataclass
+class _MembershipFetchError:
+    classification: str
+    reason: str
+
+
+@dataclass
+class _MembershipFetchResult:
+    members: List[Dict]
+    errors: List[_MembershipFetchError]
 
 
 class TeamMemberships(BaseResource):
@@ -54,22 +67,19 @@ class TeamMemberships(BaseResource):
             ),
         )
 
-    async def _get_memberships_for_team(self, client: CustomClient, team_id: str) -> List[Dict]:
-        members_of_team = await client.paginated_request(client.get)(
-            self.team_memberships_path.format(team_id),
-            pagination_config=self._memberships_pagination_config(),
-        )
-        for member in members_of_team:
-            member["relationships"]["team"] = {"data": {"type": "team", "id": team_id}}
-        return members_of_team
+    @staticmethod
+    def _classify_membership_fetch_status(status_code: int) -> str:
+        if status_code == 404:
+            return "missing"
+        if status_code == 429 or status_code >= 500:
+            return "transient"
+        return "permanent"
 
-    async def _get_memberships_for_team_id_targeted(self, client: CustomClient, team_id: str) -> List[Dict]:
-        """Fetch memberships for a single team via direct GET pagination.
+    async def _fetch_memberships_for_team_paginated(self, client: CustomClient, team_id: str) -> _MembershipFetchResult:
+        """Fetch memberships for a single team with explicit partial+error reporting.
 
-        The id-targeted path must classify HTTP failures accurately. Using
-        client.paginated_request(...) can swallow non-5xx errors and return a
-        partial or empty list, which would incorrectly look like a successful
-        empty-team no-op. This method keeps failures loud.
+        Returns all successfully fetched rows plus any classified terminal fetch
+        errors. Callers decide whether partial rows are acceptable.
         """
         pagination = self._memberships_pagination_config()
         page_size = pagination.page_size or 100
@@ -78,14 +88,55 @@ class TeamMemberships(BaseResource):
         idx = 0
         all_members: List[Dict] = []
 
+        # Lazy import: aiohttp is already a sync-cli dependency (custom_client.py)
+        # but importing at module load creates a heavier import graph for tests.
+        import aiohttp
+
         while True:
-            resp = await client.get(
-                self.team_memberships_path.format(team_id),
-                params={
-                    pagination.page_size_param: page_size,
-                    pagination.page_number_param: page_number,
-                },
-            )
+            try:
+                resp = await client.get(
+                    self.team_memberships_path.format(team_id),
+                    params={
+                        pagination.page_size_param: page_size,
+                        pagination.page_number_param: page_number,
+                    },
+                )
+            except CustomClientHTTPError as e:
+                return _MembershipFetchResult(
+                    members=all_members,
+                    errors=[
+                        _MembershipFetchError(
+                            classification=self._classify_membership_fetch_status(e.status_code),
+                            reason=f"HTTP {e.status_code}",
+                        )
+                    ],
+                )
+            except asyncio.TimeoutError:
+                return _MembershipFetchResult(
+                    members=all_members,
+                    errors=[_MembershipFetchError(classification="transient", reason="timeout")],
+                )
+            except aiohttp.ClientError as e:
+                return _MembershipFetchResult(
+                    members=all_members,
+                    errors=[
+                        _MembershipFetchError(
+                            classification="transient",
+                            reason=f"connection error: {type(e).__name__}",
+                        )
+                    ],
+                )
+            except Exception as e:
+                msg = str(e)
+                if "retry limit exceeded" in msg:
+                    return _MembershipFetchResult(
+                        members=all_members,
+                        errors=[_MembershipFetchError(classification="transient", reason=msg[:200])],
+                    )
+                return _MembershipFetchResult(
+                    members=all_members,
+                    errors=[_MembershipFetchError(classification="permanent", reason=msg[:200])],
+                )
 
             if isinstance(resp, dict):
                 members_of_team = resp.get(list_accessor, [])
@@ -93,7 +144,15 @@ class TeamMemberships(BaseResource):
                 members_of_team = resp
 
             if not isinstance(members_of_team, list):
-                raise ValueError("unexpected response shape while listing team memberships")
+                return _MembershipFetchResult(
+                    members=all_members,
+                    errors=[
+                        _MembershipFetchError(
+                            classification="permanent",
+                            reason="unexpected response shape while listing team memberships",
+                        )
+                    ],
+                )
 
             for member in members_of_team:
                 member["relationships"]["team"] = {"data": {"type": "team", "id": team_id}}
@@ -116,7 +175,7 @@ class TeamMemberships(BaseResource):
             page_number = pagination.page_number_func(idx, page_size, page_number)
             idx += 1
 
-        return all_members
+        return _MembershipFetchResult(members=all_members, errors=[])
 
     async def get_resources(self, client: CustomClient) -> List[Dict]:
         # get all the teams
@@ -129,8 +188,13 @@ class TeamMemberships(BaseResource):
         # iterate over the teams and create a list of all members of all teams
         all_team_memberships = []
         for team in teams:
-            members_of_team = await self._get_memberships_for_team(client, team["id"])
-            all_team_memberships += members_of_team
+            fetch_result = await self._fetch_memberships_for_team_paginated(client, team["id"])
+            for err in fetch_result.errors:
+                self.config.logger.warning(
+                    "team_memberships get_resources: partial data for team %s due to %s error: %s"
+                    % (team["id"], err.classification, err.reason)
+                )
+            all_team_memberships += fetch_result.members
 
         return all_team_memberships
 
@@ -152,34 +216,13 @@ class TeamMemberships(BaseResource):
         missing: List[str] = []
         errored: List[Tuple[str, str, str]] = []
 
-        # Lazy import: aiohttp is already a sync-cli dependency (custom_client.py)
-        # but importing at module load creates a heavier import graph for tests.
-        import aiohttp
-
         async def fetch_one(team_id: str):
             async with sem:
-                try:
-                    members = await self._get_memberships_for_team_id_targeted(client, team_id)
-                    return ("ok", members)
-                except CustomClientHTTPError as e:
-                    if e.status_code == 404:
-                        return ("missing", team_id)
-                    if e.status_code == 429 or e.status_code >= 500:
-                        return ("transient", team_id, f"HTTP {e.status_code}")
-                    return ("permanent", team_id, f"HTTP {e.status_code}")
-                except asyncio.TimeoutError:
-                    return ("transient", team_id, "timeout")
-                except aiohttp.ClientError as e:
-                    return (
-                        "transient",
-                        team_id,
-                        f"connection error: {type(e).__name__}",
-                    )
-                except Exception as e:
-                    msg = str(e)
-                    if "retry limit exceeded" in msg:
-                        return ("transient", team_id, msg[:200])
-                    return ("permanent", team_id, msg[:200])
+                fetch_result = await self._fetch_memberships_for_team_paginated(client, team_id)
+                if fetch_result.errors:
+                    first_err = fetch_result.errors[0]
+                    return (first_err.classification, team_id, first_err.reason)
+                return ("ok", fetch_result.members)
 
         results = await asyncio.gather(*(fetch_one(i) for i in ids))
         for result in results:

--- a/datadog_sync/model/team_memberships.py
+++ b/datadog_sync/model/team_memberships.py
@@ -68,8 +68,8 @@ class TeamMemberships(BaseResource):
 
         The id-targeted path must classify HTTP failures accurately. Using
         client.paginated_request(...) can swallow non-5xx errors and return a
-        partial or empty list, which would incorrectly look like a skipped
-        "team has no members" outcome. This method keeps failures loud.
+        partial or empty list, which would incorrectly look like a successful
+        empty-team no-op. This method keeps failures loud.
         """
         pagination = self._memberships_pagination_config()
         page_size = pagination.page_size or 100
@@ -101,6 +101,17 @@ class TeamMemberships(BaseResource):
 
             if len(members_of_team) < page_size:
                 break
+
+            # For exact page boundaries (e.g., total=100 and page_size=100),
+            # stop without probing the next page by honoring meta.pagination.total.
+            # Fall back to short-page stopping if the metadata is missing.
+            if isinstance(resp, dict) and pagination.remaining_func is not None:
+                try:
+                    remaining = pagination.remaining_func(idx, resp, page_size, page_number)
+                    if remaining <= 0:
+                        break
+                except (KeyError, TypeError):
+                    pass
 
             page_number = pagination.page_number_func(idx, page_size, page_number)
             idx += 1
@@ -147,8 +158,6 @@ class TeamMemberships(BaseResource):
             async with sem:
                 try:
                     members = await self._get_memberships_for_team_id_targeted(client, team_id)
-                    if not members:
-                        return ("skipped", team_id, "team has no members")
                     return ("ok", members)
                 except CustomClientHTTPError as e:
                     if e.status_code == 404:

--- a/datadog_sync/model/team_memberships.py
+++ b/datadog_sync/model/team_memberships.py
@@ -100,7 +100,7 @@ class TeamMemberships(BaseResource):
         """Fan-out: fetch all memberships for team_id and write N composite rows to state.
 
         Delete-before-write ensures stale membership rows for removed users are
-        not retained. Uses ImportState.delete_source (new public method in PR 7)
+        not retained. Uses ImportState.delete_source
         rather than direct dict mutation to preserve ImportState encapsulation.
 
         Returns the last composite key + resource so the outer _import_resource

--- a/datadog_sync/model/team_memberships.py
+++ b/datadog_sync/model/team_memberships.py
@@ -82,9 +82,17 @@ class TeamMemberships(BaseResource):
             if ":" not in _id:
                 # _id is a bare team UUID from --id-file; fan out to N membership rows.
                 # Dispatch condition: ":" not in _id distinguishes bare team UUID
-                # (from --id-file) from composite team_id:user_id (from 2-arg path).
+                # (from --id-file) from composite team_id:user_id.
                 return await self._import_team_memberships_by_team_id(_id)
-            # composite team_id:user_id from get_resources() falls through to existing code
+            # _id is a composite team_id:user_id with no resource — not a valid call path.
+            # Individual memberships cannot be looked up by composite key; either pass
+            # a bare team_id to fan out all memberships, or provide resource= for a
+            # specific membership row (as get_resources() does).
+            raise ValueError(
+                f"import_resource(_id={_id!r}) without resource= is not supported for team_memberships. "
+                "Use a bare team_id to fan out all memberships via --id-file, "
+                "or provide resource= for a specific membership row."
+            )
 
         resource = cast(dict, resource)
         if not resource:
@@ -125,8 +133,11 @@ class TeamMemberships(BaseResource):
         # Delete-before-write: remove all existing state rows for this team — both
         # composite team_id:user_id rows (stale membership rows for removed users)
         # and the bare team_id key that prior runs may have written for empty teams.
-        existing_keys = [k for k in self.config.state.get_source_keys(self.resource_type)
-                         if k == team_id or k.startswith(f"{team_id}:")]
+        existing_keys = [
+            k
+            for k in self.config.state.get_source_keys(self.resource_type)
+            if k == team_id or k.startswith(f"{team_id}:")
+        ]
         for k in existing_keys:
             self.config.state.delete_source(self.resource_type, k)
 
@@ -142,6 +153,7 @@ class TeamMemberships(BaseResource):
 
         if last_id is not None:
             # Return last composite key; outer _import_resource will overwrite it (harmless).
+            assert last_resource is not None  # last_resource is always set when last_id is set
             return last_id, last_resource
 
         # Empty team: raise SkipResource so the outer _import_resource does not call

--- a/datadog_sync/model/team_memberships.py
+++ b/datadog_sync/model/team_memberships.py
@@ -152,6 +152,8 @@ class TeamMemberships(BaseResource):
         missing: List[str] = []
         errored: List[Tuple[str, str, str]] = []
 
+        # Lazy import: aiohttp is already a sync-cli dependency (custom_client.py)
+        # but importing at module load creates a heavier import graph for tests.
         import aiohttp
 
         async def fetch_one(team_id: str):
@@ -165,7 +167,7 @@ class TeamMemberships(BaseResource):
                     if e.status_code == 429 or e.status_code >= 500:
                         return ("transient", team_id, f"HTTP {e.status_code}")
                     return ("permanent", team_id, f"HTTP {e.status_code}")
-                except (asyncio.TimeoutError,):
+                except asyncio.TimeoutError:
                     return ("transient", team_id, "timeout")
                 except aiohttp.ClientError as e:
                     return (
@@ -186,12 +188,12 @@ class TeamMemberships(BaseResource):
                 resources.extend(result[1])
             elif tag == "missing":
                 missing.append(result[1])
-            elif tag == "skipped":
-                errored.append((result[1], "skipped", result[2]))
             elif tag == "transient":
                 errored.append((result[1], "transient", result[2]))
-            else:
+            elif tag == "permanent":
                 errored.append((result[1], "permanent", result[2]))
+            else:
+                raise ValueError(f"unexpected team_memberships fetch result tag: {tag}")
         return resources, missing, errored
 
     async def import_resource(self, _id: Optional[str] = None, resource: Optional[Dict] = None) -> Tuple[str, Dict]:

--- a/datadog_sync/model/team_memberships.py
+++ b/datadog_sync/model/team_memberships.py
@@ -63,6 +63,50 @@ class TeamMemberships(BaseResource):
             member["relationships"]["team"] = {"data": {"type": "team", "id": team_id}}
         return members_of_team
 
+    async def _get_memberships_for_team_id_targeted(self, client: CustomClient, team_id: str) -> List[Dict]:
+        """Fetch memberships for a single team via direct GET pagination.
+
+        The id-targeted path must classify HTTP failures accurately. Using
+        client.paginated_request(...) can swallow non-5xx errors and return a
+        partial or empty list, which would incorrectly look like a skipped
+        "team has no members" outcome. This method keeps failures loud.
+        """
+        pagination = self._memberships_pagination_config()
+        page_size = pagination.page_size or 100
+        page_number = pagination.page_number or 0
+        list_accessor = pagination.response_list_accessor or "data"
+        idx = 0
+        all_members: List[Dict] = []
+
+        while True:
+            resp = await client.get(
+                self.team_memberships_path.format(team_id),
+                params={
+                    pagination.page_size_param: page_size,
+                    pagination.page_number_param: page_number,
+                },
+            )
+
+            if isinstance(resp, dict):
+                members_of_team = resp.get(list_accessor, [])
+            else:
+                members_of_team = resp
+
+            if not isinstance(members_of_team, list):
+                raise ValueError("unexpected response shape while listing team memberships")
+
+            for member in members_of_team:
+                member["relationships"]["team"] = {"data": {"type": "team", "id": team_id}}
+            all_members.extend(members_of_team)
+
+            if len(members_of_team) < page_size:
+                break
+
+            page_number = pagination.page_number_func(idx, page_size, page_number)
+            idx += 1
+
+        return all_members
+
     async def get_resources(self, client: CustomClient) -> List[Dict]:
         # get all the teams
         teams_pagination_config = self._memberships_pagination_config()
@@ -102,7 +146,7 @@ class TeamMemberships(BaseResource):
         async def fetch_one(team_id: str):
             async with sem:
                 try:
-                    members = await self._get_memberships_for_team(client, team_id)
+                    members = await self._get_memberships_for_team_id_targeted(client, team_id)
                     if not members:
                         return ("skipped", team_id, "team has no members")
                     return ("ok", members)

--- a/datadog_sync/utils/base_resource.py
+++ b/datadog_sync/utils/base_resource.py
@@ -221,7 +221,7 @@ class BaseResource(abc.ABC):
                     if e.status_code == 429 or e.status_code >= 500:
                         return ("transient", id_, f"HTTP {e.status_code}")
                     return ("permanent", id_, f"HTTP {e.status_code}")
-                except (asyncio.TimeoutError,):
+                except asyncio.TimeoutError:
                     return ("transient", id_, "timeout")
                 except aiohttp.ClientError as e:
                     # Includes ClientConnectionError (DNS, connection refused, TCP reset),

--- a/datadog_sync/utils/configuration.py
+++ b/datadog_sync/utils/configuration.py
@@ -167,7 +167,7 @@ def _unwrap_exact_match_pattern(pattern: str) -> str:
     return pattern[1:-1]
 
 
-_ID_FILE_SUPPORTED_TYPES = frozenset({"monitors"})
+_ID_FILE_SUPPORTED_TYPES = frozenset({"monitors", "authn_mappings", "team_memberships"})
 """Resource types eligible for the --id-file partition path. Monitors only in v1.
 Future expansion (e.g. SLOs) requires per-model verification and adding the
 type here. Do NOT widen by config — code-level allowlist forces explicit review."""

--- a/datadog_sync/utils/configuration.py
+++ b/datadog_sync/utils/configuration.py
@@ -202,7 +202,7 @@ def _parse_id_file(id_file_arg: Optional[str], logger) -> Optional[Dict[str, Lis
             sys.exit(1)
         if k not in _ID_FILE_SUPPORTED_TYPES:
             logger.error(
-                f"--id-file: type {k!r} is not supported in PR4 v1. "
+                f"--id-file: type {k!r} is not supported by this build. "
                 f"Supported types: {sorted(_ID_FILE_SUPPORTED_TYPES)}"
             )
             sys.exit(1)

--- a/datadog_sync/utils/configuration.py
+++ b/datadog_sync/utils/configuration.py
@@ -81,9 +81,12 @@ class Configuration(object):
     allow_partial_permissions_roles: List[str] = field(default_factory=list)
     resources: Dict[str, BaseResource] = field(default_factory=dict)
     resources_arg: List[str] = field(default_factory=list)
-    # --id-file: id-targeted import via stdin or file payload (monitors only in v1).
-    # Other resource types use the legacy list-everything path. Future expansion
-    # (e.g. SLOs) is mechanical via BaseResource.get_resources_by_ids inheritance.
+    # --id-file: id-targeted import via stdin or file payload.
+    # Supported resource types are explicitly allowlisted in
+    # _ID_FILE_SUPPORTED_TYPES (currently monitors, authn_mappings,
+    # team_memberships). Other types use the legacy list-everything path.
+    # Future expansion (e.g. SLOs) is mechanical via
+    # BaseResource.get_resources_by_ids inheritance.
     id_payload: Optional[Dict[str, List[str]]] = None
     max_concurrent_reads: int = 30
     transient_failure_threshold_pct: int = 5
@@ -168,9 +171,12 @@ def _unwrap_exact_match_pattern(pattern: str) -> str:
 
 
 _ID_FILE_SUPPORTED_TYPES = frozenset({"monitors", "authn_mappings", "team_memberships"})
-"""Resource types eligible for the --id-file partition path. Monitors only in v1.
+"""Resource types eligible for the --id-file partition path.
+
+Currently supported: monitors, authn_mappings, team_memberships.
 Future expansion (e.g. SLOs) requires per-model verification and adding the
-type here. Do NOT widen by config — code-level allowlist forces explicit review."""
+type here. Do NOT widen by config — code-level allowlist forces explicit review.
+"""
 
 
 def _parse_id_file(id_file_arg: Optional[str], logger) -> Optional[Dict[str, List[str]]]:

--- a/datadog_sync/utils/import_state.py
+++ b/datadog_sync/utils/import_state.py
@@ -73,7 +73,6 @@ class ImportState:
         for resource_type in resource_types:
             self._authoritative_source_types.discard(resource_type)
 
-
     def delete_source(self, resource_type: str, _id: str) -> None:
         """Remove one resource key from the in-memory source state.
 

--- a/datadog_sync/utils/import_state.py
+++ b/datadog_sync/utils/import_state.py
@@ -29,7 +29,11 @@ import time
 from typing import Any, Dict, List, Set
 
 from datadog_sync.constants import LOGGER_NAME, Origin, RESOURCE_PER_FILE
-from datadog_sync.utils.storage._base_storage import BaseStorage, StorageData, build_storage_backend
+from datadog_sync.utils.storage._base_storage import (
+    BaseStorage,
+    StorageData,
+    build_storage_backend,
+)
 from datadog_sync.utils.storage.storage_types import StorageType
 
 
@@ -45,7 +49,9 @@ class ImportState:
     `dump_state(Origin.SOURCE)` flushes in-memory writes to storage.
     """
 
-    def __init__(self, type_: StorageType = StorageType.LOCAL_FILE, **kwargs: object) -> None:
+    def __init__(
+        self, type_: StorageType = StorageType.LOCAL_FILE, **kwargs: object
+    ) -> None:
         init_start = time.perf_counter()
         resource_per_file = kwargs.get(RESOURCE_PER_FILE, False)
         self._storage: BaseStorage = build_storage_backend(type_, **kwargs)
@@ -58,7 +64,9 @@ class ImportState:
             int((time.perf_counter() - init_start) * 1000),
         )
 
-    def set_source(self, resource_type: str, _id: str, resource: Dict[str, Any]) -> None:
+    def set_source(
+        self, resource_type: str, _id: str, resource: Dict[str, Any]
+    ) -> None:
         """Append/overwrite one resource in the in-memory source state."""
         self._data.source[resource_type][_id] = resource
 
@@ -73,24 +81,6 @@ class ImportState:
         for resource_type in resource_types:
             self._authoritative_source_types.discard(resource_type)
 
-
-    def delete_source(self, resource_type: str, _id: str) -> None:
-        """Remove one resource key from the in-memory source state.
-
-        A no-op if the key does not exist. Used by team_memberships fan-out
-        to clear stale membership rows before writing a refreshed set.
-        """
-        self._data.source[resource_type].pop(_id, None)
-
-    def get_source_keys(self, resource_type: str) -> list:
-        """Return all source state keys for a resource type.
-
-        Returns the keys present in the in-memory source dict. For
-        ImportState (write-only, no prior state loaded), this reflects
-        only what was written in the current session.
-        """
-        return list(self._data.source[resource_type].keys())
-
     def dump_state(self, origin: Origin = Origin.SOURCE) -> None:
         """Flush in-memory writes to storage. Defaults to SOURCE-only.
 
@@ -99,7 +89,9 @@ class ImportState:
         could be misinterpreted by readers as "no destination data".
         """
         if origin != Origin.SOURCE:
-            raise ValueError(f"ImportState.dump_state only supports Origin.SOURCE; got {origin}")
+            raise ValueError(
+                f"ImportState.dump_state only supports Origin.SOURCE; got {origin}"
+            )
         dump_start = time.perf_counter()
         self._storage.put(origin, self._data)
         log.info(

--- a/datadog_sync/utils/import_state.py
+++ b/datadog_sync/utils/import_state.py
@@ -73,6 +73,24 @@ class ImportState:
         for resource_type in resource_types:
             self._authoritative_source_types.discard(resource_type)
 
+
+    def delete_source(self, resource_type: str, _id: str) -> None:
+        """Remove one resource key from the in-memory source state.
+
+        A no-op if the key does not exist. Used by team_memberships fan-out
+        to clear stale membership rows before writing a refreshed set.
+        """
+        self._data.source[resource_type].pop(_id, None)
+
+    def get_source_keys(self, resource_type: str) -> list:
+        """Return all source state keys for a resource type.
+
+        Returns the keys present in the in-memory source dict. For
+        ImportState (write-only, no prior state loaded), this reflects
+        only what was written in the current session.
+        """
+        return list(self._data.source[resource_type].keys())
+
     def dump_state(self, origin: Origin = Origin.SOURCE) -> None:
         """Flush in-memory writes to storage. Defaults to SOURCE-only.
 

--- a/datadog_sync/utils/resources_handler.py
+++ b/datadog_sync/utils/resources_handler.py
@@ -567,7 +567,7 @@ class ResourcesHandler:
         self.config.state.clear_source_type(resource_type)
 
         # The --id-file path replaces the unfiltered list call with per-ID GETs
-        # bounded by --max-concurrent-reads. Monitors only in v1.
+        # bounded by --max-concurrent-reads for supported allowlisted types.
         if self.config.id_payload and resource_type in self.config.id_payload:
             ids = self.config.id_payload[resource_type]
             mcr = self.config.max_concurrent_reads

--- a/datadog_sync/utils/state.py
+++ b/datadog_sync/utils/state.py
@@ -85,6 +85,19 @@ class State:
         """
         self._data.source[resource_type][_id] = resource
 
+
+    def delete_source(self, resource_type: str, _id: str) -> None:
+        """Remove one resource key from the in-memory source state.
+
+        A no-op if the key does not exist. Used by team_memberships fan-out
+        to clear stale membership rows before writing a refreshed set.
+        """
+        self._data.source[resource_type].pop(_id, None)
+
+    def get_source_keys(self, resource_type: str) -> list:
+        """Return all source state keys for a resource type."""
+        return list(self._data.source[resource_type].keys())
+
     def clear_source_type(self, resource_type: str) -> None:
         """Clear the in-memory source dict for one resource type.
 

--- a/datadog_sync/utils/state.py
+++ b/datadog_sync/utils/state.py
@@ -7,20 +7,32 @@ import time
 from typing import Any, Dict, List, Set, Tuple
 
 from datadog_sync.constants import LOGGER_NAME, Origin, RESOURCE_PER_FILE
-from datadog_sync.utils.storage._base_storage import BaseStorage, StorageData, build_storage_backend
+from datadog_sync.utils.storage._base_storage import (
+    BaseStorage,
+    StorageData,
+    build_storage_backend,
+)
 from datadog_sync.utils.storage.storage_types import StorageType
 
 log = logging.getLogger(LOGGER_NAME)
 
 
 class State:
-    def __init__(self, type_: StorageType = StorageType.LOCAL_FILE, **kwargs: object) -> None:
+    def __init__(
+        self, type_: StorageType = StorageType.LOCAL_FILE, **kwargs: object
+    ) -> None:
         init_start = time.perf_counter()
         self._resource_types = kwargs.get("resource_types", None)  # type-scoped loading
         self._exact_ids = kwargs.get("exact_ids", None)  # ID-targeted loading
-        self._minimize_reads = self._resource_types is not None or self._exact_ids is not None
-        self._ensure_attempted: set = set()  # tracks IDs attempted by ensure_resource_loaded
-        self._bulk_loaded_types: set = set()  # tracks types bulk-loaded by ensure_resource_type_loaded
+        self._minimize_reads = (
+            self._resource_types is not None or self._exact_ids is not None
+        )
+        self._ensure_attempted: set = (
+            set()
+        )  # tracks IDs attempted by ensure_resource_loaded
+        self._bulk_loaded_types: set = (
+            set()
+        )  # tracks types bulk-loaded by ensure_resource_type_loaded
         self._authoritative_source_types: Set[str] = set()
         resource_per_file = kwargs.get(RESOURCE_PER_FILE, False)
         self._storage: BaseStorage = build_storage_backend(type_, **kwargs)
@@ -69,7 +81,9 @@ class State:
             int((time.perf_counter() - load_start) * 1000),
         )
 
-    def set_source(self, resource_type: str, _id: str, resource: Dict[str, Any]) -> None:
+    def set_source(
+        self, resource_type: str, _id: str, resource: Dict[str, Any]
+    ) -> None:
         """Append/overwrite one resource in the in-memory source state.
 
         Provided to satisfy the SourceStateWriter protocol so import-path code
@@ -84,19 +98,6 @@ class State:
         the established pattern for those code paths.
         """
         self._data.source[resource_type][_id] = resource
-
-
-    def delete_source(self, resource_type: str, _id: str) -> None:
-        """Remove one resource key from the in-memory source state.
-
-        A no-op if the key does not exist. Used by team_memberships fan-out
-        to clear stale membership rows before writing a refreshed set.
-        """
-        self._data.source[resource_type].pop(_id, None)
-
-    def get_source_keys(self, resource_type: str) -> list:
-        """Return all source state keys for a resource type."""
-        return list(self._data.source[resource_type].keys())
 
     def clear_source_type(self, resource_type: str) -> None:
         """Clear the in-memory source dict for one resource type.
@@ -127,12 +128,17 @@ class State:
         if not self._minimize_reads or resource_type in self._bulk_loaded_types:
             return
         self._bulk_loaded_types.add(resource_type)
-        log.debug("minimize-reads: bulk-loading %s for full-scan lookups", resource_type)
+        log.debug(
+            "minimize-reads: bulk-loading %s for full-scan lookups", resource_type
+        )
         data = self._storage.get(Origin.ALL, resource_types=[resource_type])
         src_loaded = data.source.get(resource_type, {})
         dst_loaded = data.destination.get(resource_type, {})
         if not src_loaded and not dst_loaded:
-            log.debug("minimize-reads: bulk-load for %s returned no data from storage", resource_type)
+            log.debug(
+                "minimize-reads: bulk-load for %s returned no data from storage",
+                resource_type,
+            )
             return
         # Insert-if-absent: never overwrite entries modified during this sync run
         # or loaded earlier by ensure_resource_loaded.
@@ -190,7 +196,9 @@ class State:
             int((time.perf_counter() - dump_start) * 1000),
         )
 
-    def get_all_resources(self, resources_types: List[str]) -> Dict[Tuple[str, str], Any]:
+    def get_all_resources(
+        self, resources_types: List[str]
+    ) -> Dict[Tuple[str, str], Any]:
         """Returns all resources of the given types.
 
         Args:
@@ -233,11 +241,15 @@ class State:
         result: Dict[Tuple[Origin, str], Set[str]] = {}
         for rt in resource_types:
             if rt not in self._authoritative_source_types:
-                raise ValueError(f"authoritative source not loaded for type '{rt}'; refusing to compute stale set")
+                raise ValueError(
+                    f"authoritative source not loaded for type '{rt}'; refusing to compute stale set"
+                )
             ids_dict = self._data.source.get(rt, {})
             skip = BaseStorage._check_id_collisions(ids_dict, rt)
             expected = {
-                f"{rt}.{BaseStorage._sanitize_id_for_filename(_id)}.json" for _id in ids_dict if _id not in skip
+                f"{rt}.{BaseStorage._sanitize_id_for_filename(_id)}.json"
+                for _id in ids_dict
+                if _id not in skip
             }
             for origin in origins:
                 on_disk = self._storage.list_filenames(origin, rt)
@@ -278,11 +290,18 @@ class State:
                 fail = len(results) - ok
                 for fn, status in results.items():
                     if status != "ok":
-                        log.debug("prune: failed to delete %s/%s: %s", origin.value, fn, status)
+                        log.debug(
+                            "prune: failed to delete %s/%s: %s",
+                            origin.value,
+                            fn,
+                            status,
+                        )
                 counts[(origin, rt)] = (ok, fail)
         return counts
 
-    def get_resources_to_cleanup(self, resources_types: List[str]) -> Dict[Tuple[str, str], Any]:
+    def get_resources_to_cleanup(
+        self, resources_types: List[str]
+    ) -> Dict[Tuple[str, str], Any]:
         """Returns all resources to cleanup.
 
         Args:

--- a/datadog_sync/utils/state.py
+++ b/datadog_sync/utils/state.py
@@ -85,7 +85,6 @@ class State:
         """
         self._data.source[resource_type][_id] = resource
 
-
     def delete_source(self, resource_type: str, _id: str) -> None:
         """Remove one resource key from the in-memory source state.
 

--- a/tests/unit/test_authn_mappings_id_file.py
+++ b/tests/unit/test_authn_mappings_id_file.py
@@ -6,6 +6,7 @@
 """Tests for authn_mappings support in _ID_FILE_SUPPORTED_TYPES."""
 
 import asyncio
+import pytest
 from unittest.mock import AsyncMock, MagicMock
 
 from datadog_sync.utils.configuration import _ID_FILE_SUPPORTED_TYPES
@@ -45,9 +46,7 @@ class TestAuthnMappingsIDFileSupport:
         for mapping in [role_mapping, team_mapping]:
             mock_client.get.return_value = {"data": mapping}
             authn = AuthNMappings(config=mock_config)
-            _id, result = asyncio.run(
-                authn.import_resource(_id=mapping["id"])
-            )
+            _id, result = asyncio.run(authn.import_resource(_id=mapping["id"]))
             assert _id == mapping["id"], (
                 f"import_resource({mapping['id']!r}) must return the UUID as _id, "
                 f"regardless of resource_type in the mapping"
@@ -66,9 +65,7 @@ class TestAuthnMappingsIDFileSupport:
         mock_config.source_client = AsyncMock()
         mock_config.source_client.get.return_value = {"data": mapping}
         authn = AuthNMappings(config=mock_config)
-        _id, _ = asyncio.run(
-            authn.import_resource(_id=mapping["id"])
-        )
+        _id, _ = asyncio.run(authn.import_resource(_id=mapping["id"]))
         assert _id == mapping["id"]
 
     def test_import_resource_id_fetches_correct_mapping(self):
@@ -85,14 +82,20 @@ class TestAuthnMappingsIDFileSupport:
         mock_client.get.return_value = {"data": mapping}
         mock_config.source_client = mock_client
         authn = AuthNMappings(config=mock_config)
-        _id, result = asyncio.run(
-            authn.import_resource(_id=mapping_id)
-        )
+        _id, result = asyncio.run(authn.import_resource(_id=mapping_id))
         assert _id == mapping_id
         assert result == mapping
         mock_client.get.assert_called_once()
         call_path = mock_client.get.call_args[0][0]
         assert mapping_id in call_path, (
-            f"import_resource must fetch from a path containing the UUID; "
-            f"got path: {call_path!r}"
+            f"import_resource must fetch from a path containing the UUID; " f"got path: {call_path!r}"
         )
+
+    def test_import_resource_id_api_error_propagates(self):
+        """import_resource(uuid) propagates HTTP errors from the upstream GET."""
+        mock_config = MagicMock()
+        mock_config.source_client = AsyncMock()
+        mock_config.source_client.get.side_effect = Exception("HTTP 404")
+        authn = AuthNMappings(config=mock_config)
+        with pytest.raises(Exception, match="404"):
+            asyncio.run(authn.import_resource(_id="nonexistent-uuid"))

--- a/tests/unit/test_authn_mappings_id_file.py
+++ b/tests/unit/test_authn_mappings_id_file.py
@@ -3,7 +3,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019 Datadog, Inc.
 
-"""Tests for adding authn_mappings to _ID_FILE_SUPPORTED_TYPES (PR 6)."""
+"""Tests for authn_mappings support in _ID_FILE_SUPPORTED_TYPES."""
 
 import asyncio
 from unittest.mock import AsyncMock, MagicMock
@@ -13,13 +13,13 @@ from datadog_sync.model.authn_mappings import AuthNMappings
 
 
 class TestAuthnMappingsIDFileSupport:
-    """Tests for adding authn_mappings to _ID_FILE_SUPPORTED_TYPES (PR 6)."""
+    """Tests for authn_mappings support in _ID_FILE_SUPPORTED_TYPES."""
 
     def test_authn_mappings_in_id_file_supported_types(self):
-        """After PR 6: 'authn_mappings' must be present in _ID_FILE_SUPPORTED_TYPES."""
+        """'authn_mappings' must be present in _ID_FILE_SUPPORTED_TYPES."""
         assert "authn_mappings" in _ID_FILE_SUPPORTED_TYPES, (
-            "authn_mappings must be in _ID_FILE_SUPPORTED_TYPES after PR 6. "
-            "If this fails, the PR 6 code change has not been applied."
+            "authn_mappings must be in _ID_FILE_SUPPORTED_TYPES. "
+            "If this fails, id-file type support for authn_mappings is missing."
         )
 
     def test_import_resource_id_uuid_lookup_independent_of_resource_type(self):

--- a/tests/unit/test_authn_mappings_id_file.py
+++ b/tests/unit/test_authn_mappings_id_file.py
@@ -1,0 +1,98 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+"""Tests for adding authn_mappings to _ID_FILE_SUPPORTED_TYPES (PR 6)."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from datadog_sync.utils.configuration import _ID_FILE_SUPPORTED_TYPES
+from datadog_sync.model.authn_mappings import AuthNMappings
+
+
+class TestAuthnMappingsIDFileSupport:
+    """Tests for adding authn_mappings to _ID_FILE_SUPPORTED_TYPES (PR 6)."""
+
+    def test_authn_mappings_in_id_file_supported_types(self):
+        """After PR 6: 'authn_mappings' must be present in _ID_FILE_SUPPORTED_TYPES."""
+        assert "authn_mappings" in _ID_FILE_SUPPORTED_TYPES, (
+            "authn_mappings must be in _ID_FILE_SUPPORTED_TYPES after PR 6. "
+            "If this fails, the PR 6 code change has not been applied."
+        )
+
+    def test_import_resource_id_uuid_lookup_independent_of_resource_type(self):
+        """import_resource(uuid) succeeds for a mapping with resource_type=role
+        AND for one with resource_type=team — confirms the 1-arg lookup does not
+        require the caller to know or pass the resource_type; UUID is sufficient."""
+        mock_config = MagicMock()
+        role_mapping = {
+            "type": "authn_mappings",
+            "id": "role-mapping-uuid",
+            "attributes": {"attribute_key": "name", "attribute_value": "alice"},
+            "relationships": {"role": {"data": {"type": "roles", "id": "role-123"}}, "team": {"data": None}},
+        }
+        team_mapping = {
+            "type": "authn_mappings",
+            "id": "team-mapping-uuid",
+            "attributes": {"attribute_key": "email", "attribute_value": "alice@example.com"},
+            "relationships": {"team": {"data": {"type": "teams", "id": "team-456"}}, "role": {"data": None}},
+        }
+        mock_client = AsyncMock()
+        mock_config.source_client = mock_client
+
+        for mapping in [role_mapping, team_mapping]:
+            mock_client.get.return_value = {"data": mapping}
+            authn = AuthNMappings(config=mock_config)
+            _id, result = asyncio.run(
+                authn.import_resource(_id=mapping["id"])
+            )
+            assert _id == mapping["id"], (
+                f"import_resource({mapping['id']!r}) must return the UUID as _id, "
+                f"regardless of resource_type in the mapping"
+            )
+            assert result == mapping
+
+    def test_import_resource_id_succeeds_for_valid_uuid(self):
+        """import_resource(mapping_uuid) (1-arg) completes without error for a well-formed UUID."""
+        mock_config = MagicMock()
+        mapping = {
+            "type": "authn_mappings",
+            "id": "423368a4-956a-11ef-b92a-da7ad0900005",
+            "attributes": {"attribute_key": "name", "attribute_value": "alice"},
+            "relationships": {"role": {"data": {"type": "roles", "id": "role-1"}}, "team": {"data": None}},
+        }
+        mock_config.source_client = AsyncMock()
+        mock_config.source_client.get.return_value = {"data": mapping}
+        authn = AuthNMappings(config=mock_config)
+        _id, _ = asyncio.run(
+            authn.import_resource(_id=mapping["id"])
+        )
+        assert _id == mapping["id"]
+
+    def test_import_resource_id_fetches_correct_mapping(self):
+        """import_resource(uuid) fetches the mapping at the expected API path and writes state."""
+        mock_config = MagicMock()
+        mapping_id = "test-mapping-uuid-123"
+        mapping = {
+            "type": "authn_mappings",
+            "id": mapping_id,
+            "attributes": {"attribute_key": "name", "attribute_value": "bob"},
+            "relationships": {"role": {"data": {"type": "roles", "id": "role-99"}}, "team": {"data": None}},
+        }
+        mock_client = AsyncMock()
+        mock_client.get.return_value = {"data": mapping}
+        mock_config.source_client = mock_client
+        authn = AuthNMappings(config=mock_config)
+        _id, result = asyncio.run(
+            authn.import_resource(_id=mapping_id)
+        )
+        assert _id == mapping_id
+        assert result == mapping
+        mock_client.get.assert_called_once()
+        call_path = mock_client.get.call_args[0][0]
+        assert mapping_id in call_path, (
+            f"import_resource must fetch from a path containing the UUID; "
+            f"got path: {call_path!r}"
+        )

--- a/tests/unit/test_custom_client_timeout.py
+++ b/tests/unit/test_custom_client_timeout.py
@@ -163,8 +163,7 @@ class TestVerbsUseClientTimeout:
             _, kw = verb_mock.call_args
             timeout = kw.get("timeout")
             assert not isinstance(timeout, int), (
-                f"{verb_mock} passed a bare int timeout={timeout!r}; "
-                "must use aiohttp.ClientTimeout"
+                f"{verb_mock} passed a bare int timeout={timeout!r}; " "must use aiohttp.ClientTimeout"
             )
 
 
@@ -204,9 +203,7 @@ class TestTimeoutPropagation:
         """Built-in TimeoutError must also propagate (covers Python 3.11 alias)."""
         client = _make_client(timeout=120)
         client.session = MagicMock()
-        client.session.get = MagicMock(
-            return_value=self._resp_that_raises_on_text(TimeoutError("timeout"))
-        )
+        client.session.get = MagicMock(return_value=self._resp_that_raises_on_text(TimeoutError("timeout")))
 
         with pytest.raises((asyncio.TimeoutError, TimeoutError)):
             asyncio.run(client.get("/api/v1/dashboards"))

--- a/tests/unit/test_get_resources_by_ids_experiment.py
+++ b/tests/unit/test_get_resources_by_ids_experiment.py
@@ -309,18 +309,18 @@ def test_cross_language_marker_uppercase_still_matches():
     assert _is_rate_limit_output_python_replica(log_line)
 
 
-# --- Test 14: --id-file allowlist rejects non-monitors types in v1 ---
+# --- Test 14: --id-file allowlist rejects unsupported types ---
 
 
-def test_id_file_allowlist_rejects_non_monitors_v1(tmp_path, monkeypatch):
-    """PR4 v1 supports monitors only. Other types in --id-file must error at config-build.
-    Future expansion (SLOs, etc.) requires explicit code-level allowlist update — NOT
-    a config-time widening — to force per-model verification."""
+def test_id_file_allowlist_rejects_unsupported_type(tmp_path, monkeypatch):
+    """Unsupported types in --id-file must error at config-build.
+    Future expansion (SLOs, etc.) requires explicit code-level allowlist update
+    rather than config-time widening to force per-model verification."""
     import json
     from datadog_sync.utils.configuration import _parse_id_file
     from unittest.mock import MagicMock
 
-    # Write a payload with a non-monitors type
+    # Write a payload with an unsupported type
     payload_path = tmp_path / "ids.json"
     payload_path.write_text(json.dumps({"dashboards": ["abc-def-ghi"]}))
 
@@ -335,7 +335,7 @@ def test_id_file_allowlist_rejects_non_monitors_v1(tmp_path, monkeypatch):
 
 
 def test_id_file_allowlist_accepts_monitors(tmp_path):
-    """Monitors are in the v1 allowlist."""
+    """Monitors are in the current allowlist."""
     import json
     from datadog_sync.utils.configuration import _parse_id_file
     from unittest.mock import MagicMock
@@ -428,7 +428,7 @@ def test_max_concurrent_reads_zero_rejected(tmp_path, monkeypatch):
 
 
 def test_id_file_without_resources_rejected(tmp_path):
-    """--id-file with no --resources means every non-monitors type goes via legacy
+    """--id-file with no --resources means every supported id-file type goes via legacy
     full-list path, defeating the wall-clock bound. Must error at config-build.
     """
     # Coverage in subprocess integration test (test_id_file_subprocess_experiment.py).

--- a/tests/unit/test_id_file_subprocess_experiment.py
+++ b/tests/unit/test_id_file_subprocess_experiment.py
@@ -387,7 +387,7 @@ def test_subprocess_stdin_payload_parsed(tmp_path):
 
 @pytest.mark.experiment_subprocess
 def test_subprocess_unsupported_type_in_id_file(tmp_path):
-    """--id-file with non-monitors type errors at config-build. PR4 v1 monitors-only."""
+    """--id-file with unsupported type errors at config-build."""
     payload = json.dumps({"dashboards": ["abc-def-ghi"]})
     source_dir = tmp_path / "source"
     # Use any URL — the subprocess shouldn't even reach the network.
@@ -409,7 +409,7 @@ def test_subprocess_unsupported_type_in_id_file(tmp_path):
 
 @pytest.mark.experiment_subprocess
 def test_subprocess_id_file_without_resources_errors(tmp_path):
-    """--id-file with no --resources would import every non-monitors type
+    """--id-file with no --resources would import every supported id-file type
     via legacy full-list path. Must error at config-build."""
     payload = json.dumps({"monitors": ["100"]})
     source_dir = tmp_path / "source"

--- a/tests/unit/test_logs_pipelines.py
+++ b/tests/unit/test_logs_pipelines.py
@@ -82,10 +82,7 @@ def test_subdomain_path_used_when_no_override(mock_config):
         asyncio.run(lp.create_resource("src-nginx", resource))
 
     mock_config.destination_client.post_unauthenticated.assert_not_awaited()
-    intake_calls = [
-        c for c in mock_config.destination_client.post.call_args_list
-        if c[0][0] == lp.logs_intake_path
-    ]
+    intake_calls = [c for c in mock_config.destination_client.post.call_args_list if c[0][0] == lp.logs_intake_path]
     assert len(intake_calls) == 1
     assert intake_calls[0][1]["subdomain"] == "http-intake.logs"
 
@@ -110,9 +107,7 @@ def test_custom_pipeline_uses_base_post_regardless_of_override(mock_config):
     asyncio.run(lp.create_resource("src-custom", custom_resource))
 
     mock_config.destination_client.post_unauthenticated.assert_not_awaited()
-    mock_config.destination_client.post.assert_awaited_once_with(
-        lp.resource_config.base_path, custom_resource
-    )
+    mock_config.destination_client.post.assert_awaited_once_with(lp.resource_config.base_path, custom_resource)
 
 
 # ── G/G 1: pipeline already exists → no intake POST ──────────────────────────
@@ -176,10 +171,7 @@ def test_subdomain_construction_api_root(mock_config):
     with patch("datadog_sync.model.logs_pipelines.sleep", new_callable=AsyncMock):
         asyncio.run(lp.create_resource("src-nginx", _make_integration_resource()))
 
-    intake_call = next(
-        c for c in mock_config.destination_client.post.call_args_list
-        if c[0][0] == lp.logs_intake_path
-    )
+    intake_call = next(c for c in mock_config.destination_client.post.call_args_list if c[0][0] == lp.logs_intake_path)
     assert intake_call[1]["subdomain"] == "http-intake.logs"
 
 
@@ -199,8 +191,5 @@ def test_subdomain_construction_api_dot_prefix(mock_config):
     with patch("datadog_sync.model.logs_pipelines.sleep", new_callable=AsyncMock):
         asyncio.run(lp.create_resource("src-nginx", _make_integration_resource()))
 
-    intake_call = next(
-        c for c in mock_config.destination_client.post.call_args_list
-        if c[0][0] == lp.logs_intake_path
-    )
+    intake_call = next(c for c in mock_config.destination_client.post.call_args_list if c[0][0] == lp.logs_intake_path)
     assert intake_call[1]["subdomain"] == "http-intake.logs.datadoghq.com"

--- a/tests/unit/test_roles.py
+++ b/tests/unit/test_roles.py
@@ -229,9 +229,7 @@ class TestRolesReconcilePersistedPermissions:
         roles.config.state.source = {"roles": {}}
         requested = {
             "attributes": {"name": "Custom Engineering Role"},
-            "relationships": {
-                "permissions": {"data": [{"id": "dest-uuid-read-logs", "type": "permissions"}]}
-            },
+            "relationships": {"permissions": {"data": [{"id": "dest-uuid-read-logs", "type": "permissions"}]}},
         }
         persisted = {
             "attributes": {"name": "Custom Engineering Role"},
@@ -323,9 +321,7 @@ class TestRolesReconcileBuiltinRolePermissions:
                 "id-1": {
                     "id": "id-1",
                     "attributes": {"name": "Custom Engineering Role"},
-                    "relationships": {
-                        "permissions": {"data": [{"id": "read_logs", "type": "permissions"}]}
-                    },
+                    "relationships": {"permissions": {"data": [{"id": "read_logs", "type": "permissions"}]}},
                 }
             }
         }
@@ -340,8 +336,7 @@ class TestRolesReconcileBuiltinRolePermissions:
         # Both unchanged
         assert [p["id"] for p in working["relationships"]["permissions"]["data"]] == ["dest-uuid-read-logs"]
         assert [
-            p["id"]
-            for p in roles.config.state.source["roles"]["id-1"]["relationships"]["permissions"]["data"]
+            p["id"] for p in roles.config.state.source["roles"]["id-1"]["relationships"]["permissions"]["data"]
         ] == ["read_logs"]
 
     def test_noop_when_destination_grants_everything(self):
@@ -380,9 +375,7 @@ class TestRolesReconcileBuiltinRolePermissions:
                 "id-1": {
                     "id": "id-1",
                     "attributes": {"name": "Datadog Admin Role"},
-                    "relationships": {
-                        "permissions": {"data": [{"id": "read_logs", "type": "permissions"}]}
-                    },
+                    "relationships": {"permissions": {"data": [{"id": "read_logs", "type": "permissions"}]}},
                 }
             }
         }

--- a/tests/unit/test_team_memberships_id_file.py
+++ b/tests/unit/test_team_memberships_id_file.py
@@ -13,6 +13,7 @@ import pytest
 
 from datadog_sync.model.team_memberships import TeamMemberships
 from datadog_sync.utils.configuration import _ID_FILE_SUPPORTED_TYPES
+from datadog_sync.utils.resource_utils import CustomClientHTTPError
 
 
 class _MockState:
@@ -23,6 +24,12 @@ class _MockState:
 
     def set_source(self, resource_type, _id, resource):
         self.source[resource_type][_id] = resource
+
+
+class _FakeHTTPResponse:
+    def __init__(self, status, message="error"):
+        self.status = status
+        self.message = message
 
 
 def _make_member(team_id, user_id):
@@ -43,8 +50,7 @@ def _make_team_memberships(team_id, user_ids):
     config.state = _MockState()
 
     members = [_make_member(team_id, uid) for uid in user_ids]
-    config.source_client.paginated_request = MagicMock(return_value=AsyncMock(return_value=members))
-    config.source_client.get = MagicMock()
+    config.source_client.get = AsyncMock(return_value={"data": members})
 
     tm = TeamMemberships(config=config)
     return tm, config, members
@@ -84,14 +90,16 @@ class TestTeamMembershipsIDFileSupport:
     def test_get_resources_by_ids_cross_team_memberships_keep_both_rows(self):
         config = MagicMock()
         config.state = _MockState()
-        config.source_client = AsyncMock()
-        config.source_client.paginated_request = MagicMock(
-            side_effect=[
-                AsyncMock(return_value=[_make_member("team-A", "shared-user")]),
-                AsyncMock(return_value=[_make_member("team-B", "shared-user")]),
-            ]
-        )
-        config.source_client.get = MagicMock()
+
+        async def _get(path, **kwargs):
+            if "/team/team-A/memberships" in path:
+                return {"data": [_make_member("team-A", "shared-user")]}
+            if "/team/team-B/memberships" in path:
+                return {"data": [_make_member("team-B", "shared-user")]}
+            return {"data": []}
+
+        config.source_client = MagicMock()
+        config.source_client.get = AsyncMock(side_effect=_get)
 
         tm = TeamMemberships(config=config)
         resources, missing, errored = asyncio.run(
@@ -109,14 +117,16 @@ class TestTeamMembershipsIDFileSupport:
         }
         assert keys == {("team-A", "shared-user"), ("team-B", "shared-user")}
 
-    def test_get_resources_by_ids_api_error_is_classified_as_permanent(self):
+    def test_get_resources_by_ids_http_429_is_classified_as_transient(self):
         config = MagicMock()
-        config.source_client = AsyncMock()
+        config.source_client = MagicMock()
         config.state = _MockState()
-        config.source_client.paginated_request = MagicMock(
-            return_value=AsyncMock(side_effect=Exception("membership API 500"))
+        config.source_client.get = AsyncMock(
+            side_effect=CustomClientHTTPError(
+                _FakeHTTPResponse(status=429, message="Too Many Requests"),
+                message="rate limited",
+            )
         )
-        config.source_client.get = MagicMock()
 
         tm = TeamMemberships(config=config)
         resources, missing, errored = asyncio.run(
@@ -127,8 +137,28 @@ class TestTeamMembershipsIDFileSupport:
         assert missing == []
         assert len(errored) == 1
         assert errored[0][0] == "team-xyz"
-        assert errored[0][1] == "permanent"
-        assert "membership API 500" in errored[0][2]
+        assert errored[0][1] == "transient"
+        assert errored[0][2] == "HTTP 429"
+
+    def test_get_resources_by_ids_http_404_is_classified_as_missing(self):
+        config = MagicMock()
+        config.source_client = MagicMock()
+        config.state = _MockState()
+        config.source_client.get = AsyncMock(
+            side_effect=CustomClientHTTPError(
+                _FakeHTTPResponse(status=404, message="Not Found"),
+                message="team not found",
+            )
+        )
+
+        tm = TeamMemberships(config=config)
+        resources, missing, errored = asyncio.run(
+            tm.get_resources_by_ids(config.source_client, ["team-xyz"], max_concurrent_reads=10)
+        )
+
+        assert resources == []
+        assert missing == ["team-xyz"]
+        assert errored == []
 
     def test_import_resource_resource_arg_path_unaffected(self):
         config = MagicMock()

--- a/tests/unit/test_team_memberships_id_file.py
+++ b/tests/unit/test_team_memberships_id_file.py
@@ -1,0 +1,207 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+"""PR 7 TDD tests: team_memberships fan-out + _ID_FILE_SUPPORTED_TYPES."""
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from collections import defaultdict
+
+from datadog_sync.utils.configuration import _ID_FILE_SUPPORTED_TYPES
+from datadog_sync.model.team_memberships import TeamMemberships
+from datadog_sync.utils.resource_utils import SkipResource
+
+
+class _MockState:
+    """Minimal state mock that supports set_source, get_source_keys, delete_source."""
+    def __init__(self):
+        self.source = defaultdict(dict)
+
+    def set_source(self, resource_type, _id, resource):
+        self.source[resource_type][_id] = resource
+
+    def get_source_keys(self, resource_type):
+        return list(self.source[resource_type].keys())
+
+    def delete_source(self, resource_type, _id):
+        self.source[resource_type].pop(_id, None)
+
+
+def _make_member(team_id, user_id):
+    return {
+        "type": "team_memberships",
+        "id": f"{team_id}:{user_id}",
+        "attributes": {"role": "member"},
+        "relationships": {
+            "team": {"data": {"type": "team", "id": team_id}},
+            "user": {"data": {"type": "users", "id": user_id}},
+        },
+    }
+
+
+def _make_team_memberships(team_id, user_ids):
+    config = MagicMock()
+    config.source_client = MagicMock()
+    config.state = _MockState()
+
+    members = [_make_member(team_id, uid) for uid in user_ids]
+    # paginated_request(fn) returns an async callable that returns the member list
+    config.source_client.paginated_request = MagicMock(return_value=AsyncMock(return_value=members))
+    config.source_client.get = MagicMock()
+
+    tm = TeamMemberships(config=config)
+    return tm, config, members
+
+
+class TestTeamMembershipsIDFileSupport:
+
+    def test_team_memberships_in_id_file_supported_types(self):
+        assert "team_memberships" in _ID_FILE_SUPPORTED_TYPES
+
+    def test_import_resource_id_fan_out_produces_n_rows(self):
+        tm, config, _ = _make_team_memberships("team-abc", ["user-1", "user-2", "user-3"])
+        asyncio.run(
+            tm.import_resource(_id="team-abc")
+        )
+        assert len(config.state.source["team_memberships"]) == 3
+
+    def test_import_resource_id_composite_key_format(self):
+        tm, config, _ = _make_team_memberships("team-abc", ["user-1", "user-2"])
+        asyncio.run(tm.import_resource(_id="team-abc"))
+        keys = set(config.state.source["team_memberships"].keys())
+        assert "team-abc:user-1" in keys
+        assert "team-abc:user-2" in keys
+        for k in keys:
+            assert ":" in k, f"keys must be composite team_id:user_id, got {k!r}"
+
+    def test_import_resource_id_empty_team_writes_nothing(self):
+        tm, config, _ = _make_team_memberships("team-empty", [])
+        with pytest.raises(SkipResource):
+            asyncio.run(tm.import_resource(_id="team-empty"))
+        all_keys = list(config.state.source["team_memberships"].keys())
+        assert len(all_keys) == 0, (
+            "empty team must write no state rows at all (no bare team_id key, "
+            f"no composite keys); got: {all_keys}"
+        )
+
+    def test_import_resource_resource_arg_path_unaffected(self):
+        """2-arg import_resource path must remain unchanged (used by get_resources())."""
+        config = MagicMock()
+        config.state = _MockState()
+        tm = TeamMemberships(config=config)
+        existing_resource = _make_member("team-x", "user-y")
+        _id, result = asyncio.run(
+            tm.import_resource(_id="team-x:user-y", resource=existing_resource)
+        )
+        assert _id == "team-x:user-y"
+        assert result == existing_resource
+
+    def test_get_resources_unaffected(self):
+        """get_resources() is not called by import_resource; verify it still exists."""
+        config = MagicMock()
+        tm = TeamMemberships(config=config)
+        assert hasattr(tm, "get_resources"), "get_resources() must still exist after PR 7"
+
+    def test_import_resource_id_api_error_propagates(self):
+        config = MagicMock()
+        config.source_client = AsyncMock()
+        config.state = _MockState()
+        config.source_client.paginated_request = MagicMock(
+            return_value=AsyncMock(side_effect=Exception("membership API 500"))
+        )
+        config.source_client.get = MagicMock()
+        tm = TeamMemberships(config=config)
+        with pytest.raises(Exception, match="membership API 500"):
+            asyncio.run(tm.import_resource(_id="team-xyz"))
+        assert len(config.state.source["team_memberships"]) == 0
+
+    def test_import_resource_id_idempotent(self):
+        tm, config, _ = _make_team_memberships("team-abc", ["user-1", "user-2"])
+        asyncio.run(tm.import_resource(_id="team-abc"))
+        asyncio.run(tm.import_resource(_id="team-abc"))
+        keys = [k for k in config.state.source["team_memberships"].keys()
+                if k.startswith("team-abc:user-")]
+        assert len(keys) == 2, "two calls with same members must yield exactly 2 unique rows"
+
+    def test_import_resource_id_cross_team_user_both_rows_written(self):
+        config = MagicMock()
+        config.state = _MockState()
+
+        def make_members_for(team_id):
+            return [_make_member(team_id, "shared-user")]
+
+        config.source_client = AsyncMock()
+        config.source_client.paginated_request = MagicMock(
+            side_effect=[
+                AsyncMock(return_value=make_members_for("team-A")),
+                AsyncMock(return_value=make_members_for("team-B")),
+            ]
+        )
+        config.source_client.get = MagicMock()
+        tm = TeamMemberships(config=config)
+        asyncio.run(tm.import_resource(_id="team-A"))
+        asyncio.run(tm.import_resource(_id="team-B"))
+
+        keys = set(config.state.source["team_memberships"].keys())
+        assert "team-A:shared-user" in keys
+        assert "team-B:shared-user" in keys
+
+    def test_import_resource_id_member_removed_between_calls(self):
+        """Second import with fewer members removes stale rows from first import."""
+        config = MagicMock()
+        config.state = _MockState()
+        config.source_client = AsyncMock()
+
+        first_members = [_make_member("team-x", "user-1"), _make_member("team-x", "user-2")]
+        second_members = [_make_member("team-x", "user-1")]  # user-2 removed
+
+        config.source_client.paginated_request = MagicMock(
+            side_effect=[
+                AsyncMock(return_value=first_members),
+                AsyncMock(return_value=second_members),
+            ]
+        )
+        config.source_client.get = MagicMock()
+        tm = TeamMemberships(config=config)
+        asyncio.run(tm.import_resource(_id="team-x"))
+        asyncio.run(tm.import_resource(_id="team-x"))
+
+        composite_keys = [k for k in config.state.source["team_memberships"].keys()
+                          if k.startswith("team-x:user-")]
+        assert "team-x:user-1" in composite_keys
+        assert "team-x:user-2" not in composite_keys, (
+            "user-2 was removed between imports; stale row must be deleted"
+        )
+
+    def test_state_writer_overwrites_not_appends_for_team(self):
+        """Calling _import_team_memberships_by_team_id twice with different member sets
+        must result in ONLY the second call's rows — pins the overwrite-not-append invariant."""
+        config = MagicMock()
+        config.state = _MockState()
+        config.source_client = AsyncMock()
+
+        first_members = [_make_member("team-A", "user-1"), _make_member("team-A", "user-2")]
+        second_members = [_make_member("team-A", "user-1"), _make_member("team-A", "user-3")]
+
+        config.source_client.paginated_request = MagicMock(
+            side_effect=[
+                AsyncMock(return_value=first_members),
+                AsyncMock(return_value=second_members),
+            ]
+        )
+        config.source_client.get = MagicMock()
+        tm = TeamMemberships(config=config)
+        asyncio.run(tm._import_team_memberships_by_team_id("team-A"))
+        asyncio.run(tm._import_team_memberships_by_team_id("team-A"))
+
+        composite_keys = {k for k in config.state.source["team_memberships"].keys()
+                          if k.startswith("team-A:user-")}
+        # Must contain ONLY second call's rows
+        assert composite_keys == {"team-A:user-1", "team-A:user-3"}, (
+            f"After second call, state must contain ONLY second call's rows. "
+            f"Got: {composite_keys}. "
+            "If user-2 is present, stale-row removal is broken."
+        )

--- a/tests/unit/test_team_memberships_id_file.py
+++ b/tests/unit/test_team_memberships_id_file.py
@@ -115,6 +115,74 @@ class TestTeamMembershipsIDFileSupport:
         assert errored == []
         assert config.source_client.get.await_count == 1
 
+    def test_get_resources_by_ids_partial_page_then_429_discards_partial_members(self):
+        config = MagicMock()
+        config.source_client = MagicMock()
+        config.state = _MockState()
+
+        team_id = "team-partial"
+        first_page_members = [_make_member(team_id, f"user-{i}") for i in range(100)]
+
+        async def _get(path, **kwargs):
+            page_number = kwargs.get("params", {}).get("page[number]", 0)
+            if page_number == 0:
+                return {
+                    "data": first_page_members,
+                    "meta": {"pagination": {"total": 200}},
+                }
+            raise CustomClientHTTPError(
+                _FakeHTTPResponse(status=429, message="Too Many Requests"),
+                message="rate limited",
+            )
+
+        config.source_client.get = AsyncMock(side_effect=_get)
+        tm = TeamMemberships(config=config)
+        resources, missing, errored = asyncio.run(
+            tm.get_resources_by_ids(config.source_client, [team_id], max_concurrent_reads=10)
+        )
+
+        assert resources == []
+        assert missing == []
+        assert len(errored) == 1
+        assert errored[0][0] == team_id
+        assert errored[0][1] == "transient"
+        assert errored[0][2] == "HTTP 429"
+
+    def test_get_resources_partial_page_then_429_logs_warning_and_keeps_partial(self):
+        config = MagicMock()
+        config.source_client = MagicMock()
+        config.state = _MockState()
+        config.logger = MagicMock()
+
+        team_id = "team-partial"
+        first_page_members = [_make_member(team_id, f"user-{i}") for i in range(100)]
+
+        config.source_client.paginated_request = MagicMock(return_value=AsyncMock(return_value=[{"id": team_id}]))
+
+        async def _get(path, **kwargs):
+            page_number = kwargs.get("params", {}).get("page[number]", 0)
+            if page_number == 0:
+                return {
+                    "data": first_page_members,
+                    "meta": {"pagination": {"total": 200}},
+                }
+            raise CustomClientHTTPError(
+                _FakeHTTPResponse(status=429, message="Too Many Requests"),
+                message="rate limited",
+            )
+
+        config.source_client.get = AsyncMock(side_effect=_get)
+        tm = TeamMemberships(config=config)
+        resources = asyncio.run(tm.get_resources(config.source_client))
+
+        assert len(resources) == 100
+        assert {r["id"] for r in resources} == {m["id"] for m in first_page_members}
+        config.logger.warning.assert_called_once()
+        warning_msg = config.logger.warning.call_args[0][0]
+        assert team_id in warning_msg
+        assert "transient" in warning_msg
+        assert "HTTP 429" in warning_msg
+
     def test_get_resources_by_ids_cross_team_memberships_keep_both_rows(self):
         config = MagicMock()
         config.state = _MockState()

--- a/tests/unit/test_team_memberships_id_file.py
+++ b/tests/unit/test_team_memberships_id_file.py
@@ -3,37 +3,32 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019 Datadog, Inc.
 
-"""Tests for team_memberships fan-out + _ID_FILE_SUPPORTED_TYPES."""
+"""Tests for team_memberships id-file fan-out + _ID_FILE_SUPPORTED_TYPES."""
 
 import asyncio
-import pytest
-from unittest.mock import AsyncMock, MagicMock
 from collections import defaultdict
+from unittest.mock import AsyncMock, MagicMock
 
-from datadog_sync.utils.configuration import _ID_FILE_SUPPORTED_TYPES
+import pytest
+
 from datadog_sync.model.team_memberships import TeamMemberships
-from datadog_sync.utils.resource_utils import SkipResource
+from datadog_sync.utils.configuration import _ID_FILE_SUPPORTED_TYPES
 
 
 class _MockState:
-    """Minimal state mock that supports set_source, get_source_keys, delete_source."""
+    """Minimal state mock used to assert fetch-path side effects."""
+
     def __init__(self):
         self.source = defaultdict(dict)
 
     def set_source(self, resource_type, _id, resource):
         self.source[resource_type][_id] = resource
 
-    def get_source_keys(self, resource_type):
-        return list(self.source[resource_type].keys())
-
-    def delete_source(self, resource_type, _id):
-        self.source[resource_type].pop(_id, None)
-
 
 def _make_member(team_id, user_id):
     return {
         "type": "team_memberships",
-        "id": f"{team_id}:{user_id}",
+        "id": f"TeamMembership-{team_id}-{user_id}",
         "attributes": {"role": "member"},
         "relationships": {
             "team": {"data": {"type": "team", "id": team_id}},
@@ -48,8 +43,9 @@ def _make_team_memberships(team_id, user_ids):
     config.state = _MockState()
 
     members = [_make_member(team_id, uid) for uid in user_ids]
-    # paginated_request(fn) returns an async callable that returns the member list
-    config.source_client.paginated_request = MagicMock(return_value=AsyncMock(return_value=members))
+    config.source_client.paginated_request = MagicMock(
+        return_value=AsyncMock(return_value=members)
+    )
     config.source_client.get = MagicMock()
 
     tm = TeamMemberships(config=config)
@@ -57,55 +53,79 @@ def _make_team_memberships(team_id, user_ids):
 
 
 class TestTeamMembershipsIDFileSupport:
-
     def test_team_memberships_in_id_file_supported_types(self):
         assert "team_memberships" in _ID_FILE_SUPPORTED_TYPES
 
-    def test_import_resource_id_fan_out_produces_n_rows(self):
-        tm, config, _ = _make_team_memberships("team-abc", ["user-1", "user-2", "user-3"])
-        asyncio.run(
-            tm.import_resource(_id="team-abc")
+    def test_get_resources_by_ids_team_id_fans_out_all_memberships(self):
+        tm, config, _ = _make_team_memberships(
+            "team-abc", ["user-1", "user-2", "user-3"]
         )
-        assert len(config.state.source["team_memberships"]) == 3
+        resources, missing, errored = asyncio.run(
+            tm.get_resources_by_ids(
+                config.source_client, ["team-abc"], max_concurrent_reads=10
+            )
+        )
+        assert len(resources) == 3
+        assert missing == []
+        assert errored == []
+        assert {r["relationships"]["team"]["data"]["id"] for r in resources} == {
+            "team-abc"
+        }
 
-    def test_import_resource_id_composite_key_format(self):
+    def test_get_resources_by_ids_is_side_effect_free_for_source_state(self):
         tm, config, _ = _make_team_memberships("team-abc", ["user-1", "user-2"])
-        asyncio.run(tm.import_resource(_id="team-abc"))
-        keys = set(config.state.source["team_memberships"].keys())
-        assert "team-abc:user-1" in keys
-        assert "team-abc:user-2" in keys
-        for k in keys:
-            assert ":" in k, f"keys must be composite team_id:user_id, got {k!r}"
-
-    def test_import_resource_id_empty_team_writes_nothing(self):
-        tm, config, _ = _make_team_memberships("team-empty", [])
-        with pytest.raises(SkipResource):
-            asyncio.run(tm.import_resource(_id="team-empty"))
-        all_keys = list(config.state.source["team_memberships"].keys())
-        assert len(all_keys) == 0, (
-            "empty team must write no state rows at all (no bare team_id key, "
-            f"no composite keys); got: {all_keys}"
+        asyncio.run(
+            tm.get_resources_by_ids(
+                config.source_client, ["team-abc"], max_concurrent_reads=10
+            )
         )
+        assert config.state.source["team_memberships"] == {}
 
-    def test_import_resource_resource_arg_path_unaffected(self):
-        """2-arg import_resource path must remain unchanged (used by get_resources())."""
+    def test_get_resources_by_ids_empty_team_is_reported_as_skipped(self):
+        tm, config, _ = _make_team_memberships("team-empty", [])
+        resources, missing, errored = asyncio.run(
+            tm.get_resources_by_ids(
+                config.source_client, ["team-empty"], max_concurrent_reads=10
+            )
+        )
+        assert resources == []
+        assert missing == []
+        assert len(errored) == 1
+        assert errored[0][0] == "team-empty"
+        assert errored[0][1] == "skipped"
+        assert "no members" in errored[0][2]
+
+    def test_get_resources_by_ids_cross_team_memberships_keep_both_rows(self):
         config = MagicMock()
         config.state = _MockState()
-        tm = TeamMemberships(config=config)
-        existing_resource = _make_member("team-x", "user-y")
-        _id, result = asyncio.run(
-            tm.import_resource(_id="team-x:user-y", resource=existing_resource)
+        config.source_client = AsyncMock()
+        config.source_client.paginated_request = MagicMock(
+            side_effect=[
+                AsyncMock(return_value=[_make_member("team-A", "shared-user")]),
+                AsyncMock(return_value=[_make_member("team-B", "shared-user")]),
+            ]
         )
-        assert _id == "team-x:user-y"
-        assert result == existing_resource
+        config.source_client.get = MagicMock()
 
-    def test_get_resources_unaffected(self):
-        """get_resources() is not called by import_resource; verify it still exists."""
-        config = MagicMock()
         tm = TeamMemberships(config=config)
-        assert hasattr(tm, "get_resources"), "get_resources() must still exist"
+        resources, missing, errored = asyncio.run(
+            tm.get_resources_by_ids(
+                config.source_client, ["team-A", "team-B"], max_concurrent_reads=10
+            )
+        )
 
-    def test_import_resource_id_api_error_propagates(self):
+        assert missing == []
+        assert errored == []
+        keys = {
+            (
+                r["relationships"]["team"]["data"]["id"],
+                r["relationships"]["user"]["data"]["id"],
+            )
+            for r in resources
+        }
+        assert keys == {("team-A", "shared-user"), ("team-B", "shared-user")}
+
+    def test_get_resources_by_ids_api_error_is_classified_as_permanent(self):
         config = MagicMock()
         config.source_client = AsyncMock()
         config.state = _MockState()
@@ -113,95 +133,37 @@ class TestTeamMembershipsIDFileSupport:
             return_value=AsyncMock(side_effect=Exception("membership API 500"))
         )
         config.source_client.get = MagicMock()
+
         tm = TeamMemberships(config=config)
-        with pytest.raises(Exception, match="membership API 500"):
-            asyncio.run(tm.import_resource(_id="team-xyz"))
-        assert len(config.state.source["team_memberships"]) == 0
+        resources, missing, errored = asyncio.run(
+            tm.get_resources_by_ids(
+                config.source_client, ["team-xyz"], max_concurrent_reads=10
+            )
+        )
 
-    def test_import_resource_id_idempotent(self):
-        tm, config, _ = _make_team_memberships("team-abc", ["user-1", "user-2"])
-        asyncio.run(tm.import_resource(_id="team-abc"))
-        asyncio.run(tm.import_resource(_id="team-abc"))
-        keys = [k for k in config.state.source["team_memberships"].keys()
-                if k.startswith("team-abc:user-")]
-        assert len(keys) == 2, "two calls with same members must yield exactly 2 unique rows"
+        assert resources == []
+        assert missing == []
+        assert len(errored) == 1
+        assert errored[0][0] == "team-xyz"
+        assert errored[0][1] == "permanent"
+        assert "membership API 500" in errored[0][2]
 
-    def test_import_resource_id_cross_team_user_both_rows_written(self):
+    def test_import_resource_resource_arg_path_unaffected(self):
         config = MagicMock()
         config.state = _MockState()
-
-        def make_members_for(team_id):
-            return [_make_member(team_id, "shared-user")]
-
-        config.source_client = AsyncMock()
-        config.source_client.paginated_request = MagicMock(
-            side_effect=[
-                AsyncMock(return_value=make_members_for("team-A")),
-                AsyncMock(return_value=make_members_for("team-B")),
-            ]
-        )
-        config.source_client.get = MagicMock()
         tm = TeamMemberships(config=config)
-        asyncio.run(tm.import_resource(_id="team-A"))
-        asyncio.run(tm.import_resource(_id="team-B"))
 
-        keys = set(config.state.source["team_memberships"].keys())
-        assert "team-A:shared-user" in keys
-        assert "team-B:shared-user" in keys
+        existing_resource = _make_member("team-x", "user-y")
+        _id, result = asyncio.run(
+            tm.import_resource(_id=existing_resource["id"], resource=existing_resource)
+        )
 
-    def test_import_resource_id_member_removed_between_calls(self):
-        """Second import with fewer members removes stale rows from first import."""
+        assert _id == existing_resource["id"]
+        assert result == existing_resource
+
+    def test_import_resource_id_only_path_is_rejected(self):
         config = MagicMock()
-        config.state = _MockState()
-        config.source_client = AsyncMock()
-
-        first_members = [_make_member("team-x", "user-1"), _make_member("team-x", "user-2")]
-        second_members = [_make_member("team-x", "user-1")]  # user-2 removed
-
-        config.source_client.paginated_request = MagicMock(
-            side_effect=[
-                AsyncMock(return_value=first_members),
-                AsyncMock(return_value=second_members),
-            ]
-        )
-        config.source_client.get = MagicMock()
         tm = TeamMemberships(config=config)
-        asyncio.run(tm.import_resource(_id="team-x"))
-        asyncio.run(tm.import_resource(_id="team-x"))
 
-        composite_keys = [k for k in config.state.source["team_memberships"].keys()
-                          if k.startswith("team-x:user-")]
-        assert "team-x:user-1" in composite_keys
-        assert "team-x:user-2" not in composite_keys, (
-            "user-2 was removed between imports; stale row must be deleted"
-        )
-
-    def test_state_writer_overwrites_not_appends_for_team(self):
-        """Calling _import_team_memberships_by_team_id twice with different member sets
-        must result in ONLY the second call's rows — pins the overwrite-not-append invariant."""
-        config = MagicMock()
-        config.state = _MockState()
-        config.source_client = AsyncMock()
-
-        first_members = [_make_member("team-A", "user-1"), _make_member("team-A", "user-2")]
-        second_members = [_make_member("team-A", "user-1"), _make_member("team-A", "user-3")]
-
-        config.source_client.paginated_request = MagicMock(
-            side_effect=[
-                AsyncMock(return_value=first_members),
-                AsyncMock(return_value=second_members),
-            ]
-        )
-        config.source_client.get = MagicMock()
-        tm = TeamMemberships(config=config)
-        asyncio.run(tm._import_team_memberships_by_team_id("team-A"))
-        asyncio.run(tm._import_team_memberships_by_team_id("team-A"))
-
-        composite_keys = {k for k in config.state.source["team_memberships"].keys()
-                          if k.startswith("team-A:user-")}
-        # Must contain ONLY second call's rows
-        assert composite_keys == {"team-A:user-1", "team-A:user-3"}, (
-            f"After second call, state must contain ONLY second call's rows. "
-            f"Got: {composite_keys}. "
-            "If user-2 is present, stale-row removal is broken."
-        )
+        with pytest.raises(ValueError, match="direct ID import is not supported"):
+            asyncio.run(tm.import_resource(_id="team-abc"))

--- a/tests/unit/test_team_memberships_id_file.py
+++ b/tests/unit/test_team_memberships_id_file.py
@@ -3,7 +3,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019 Datadog, Inc.
 
-"""PR 7 TDD tests: team_memberships fan-out + _ID_FILE_SUPPORTED_TYPES."""
+"""Tests for team_memberships fan-out + _ID_FILE_SUPPORTED_TYPES."""
 
 import asyncio
 import pytest
@@ -103,7 +103,7 @@ class TestTeamMembershipsIDFileSupport:
         """get_resources() is not called by import_resource; verify it still exists."""
         config = MagicMock()
         tm = TeamMemberships(config=config)
-        assert hasattr(tm, "get_resources"), "get_resources() must still exist after PR 7"
+        assert hasattr(tm, "get_resources"), "get_resources() must still exist"
 
     def test_import_resource_id_api_error_propagates(self):
         config = MagicMock()

--- a/tests/unit/test_team_memberships_id_file.py
+++ b/tests/unit/test_team_memberships_id_file.py
@@ -17,6 +17,7 @@ from datadog_sync.utils.resource_utils import SkipResource
 
 class _MockState:
     """Minimal state mock that supports set_source, get_source_keys, delete_source."""
+
     def __init__(self):
         self.source = defaultdict(dict)
 
@@ -63,9 +64,7 @@ class TestTeamMembershipsIDFileSupport:
 
     def test_import_resource_id_fan_out_produces_n_rows(self):
         tm, config, _ = _make_team_memberships("team-abc", ["user-1", "user-2", "user-3"])
-        asyncio.run(
-            tm.import_resource(_id="team-abc")
-        )
+        asyncio.run(tm.import_resource(_id="team-abc"))
         assert len(config.state.source["team_memberships"]) == 3
 
     def test_import_resource_id_composite_key_format(self):
@@ -83,8 +82,7 @@ class TestTeamMembershipsIDFileSupport:
             asyncio.run(tm.import_resource(_id="team-empty"))
         all_keys = list(config.state.source["team_memberships"].keys())
         assert len(all_keys) == 0, (
-            "empty team must write no state rows at all (no bare team_id key, "
-            f"no composite keys); got: {all_keys}"
+            "empty team must write no state rows at all (no bare team_id key, " f"no composite keys); got: {all_keys}"
         )
 
     def test_import_resource_resource_arg_path_unaffected(self):
@@ -93,9 +91,7 @@ class TestTeamMembershipsIDFileSupport:
         config.state = _MockState()
         tm = TeamMemberships(config=config)
         existing_resource = _make_member("team-x", "user-y")
-        _id, result = asyncio.run(
-            tm.import_resource(_id="team-x:user-y", resource=existing_resource)
-        )
+        _id, result = asyncio.run(tm.import_resource(_id="team-x:user-y", resource=existing_resource))
         assert _id == "team-x:user-y"
         assert result == existing_resource
 
@@ -122,8 +118,7 @@ class TestTeamMembershipsIDFileSupport:
         tm, config, _ = _make_team_memberships("team-abc", ["user-1", "user-2"])
         asyncio.run(tm.import_resource(_id="team-abc"))
         asyncio.run(tm.import_resource(_id="team-abc"))
-        keys = [k for k in config.state.source["team_memberships"].keys()
-                if k.startswith("team-abc:user-")]
+        keys = [k for k in config.state.source["team_memberships"].keys() if k.startswith("team-abc:user-")]
         assert len(keys) == 2, "two calls with same members must yield exactly 2 unique rows"
 
     def test_import_resource_id_cross_team_user_both_rows_written(self):
@@ -169,12 +164,9 @@ class TestTeamMembershipsIDFileSupport:
         asyncio.run(tm.import_resource(_id="team-x"))
         asyncio.run(tm.import_resource(_id="team-x"))
 
-        composite_keys = [k for k in config.state.source["team_memberships"].keys()
-                          if k.startswith("team-x:user-")]
+        composite_keys = [k for k in config.state.source["team_memberships"].keys() if k.startswith("team-x:user-")]
         assert "team-x:user-1" in composite_keys
-        assert "team-x:user-2" not in composite_keys, (
-            "user-2 was removed between imports; stale row must be deleted"
-        )
+        assert "team-x:user-2" not in composite_keys, "user-2 was removed between imports; stale row must be deleted"
 
     def test_state_writer_overwrites_not_appends_for_team(self):
         """Calling _import_team_memberships_by_team_id twice with different member sets
@@ -197,8 +189,7 @@ class TestTeamMembershipsIDFileSupport:
         asyncio.run(tm._import_team_memberships_by_team_id("team-A"))
         asyncio.run(tm._import_team_memberships_by_team_id("team-A"))
 
-        composite_keys = {k for k in config.state.source["team_memberships"].keys()
-                          if k.startswith("team-A:user-")}
+        composite_keys = {k for k in config.state.source["team_memberships"].keys() if k.startswith("team-A:user-")}
         # Must contain ONLY second call's rows
         assert composite_keys == {"team-A:user-1", "team-A:user-3"}, (
             f"After second call, state must contain ONLY second call's rows. "

--- a/tests/unit/test_team_memberships_id_file.py
+++ b/tests/unit/test_team_memberships_id_file.py
@@ -75,17 +75,45 @@ class TestTeamMembershipsIDFileSupport:
         asyncio.run(tm.get_resources_by_ids(config.source_client, ["team-abc"], max_concurrent_reads=10))
         assert config.state.source["team_memberships"] == {}
 
-    def test_get_resources_by_ids_empty_team_is_reported_as_skipped(self):
+    def test_get_resources_by_ids_empty_team_is_successful_noop(self):
         tm, config, _ = _make_team_memberships("team-empty", [])
         resources, missing, errored = asyncio.run(
             tm.get_resources_by_ids(config.source_client, ["team-empty"], max_concurrent_reads=10)
         )
         assert resources == []
         assert missing == []
-        assert len(errored) == 1
-        assert errored[0][0] == "team-empty"
-        assert errored[0][1] == "skipped"
-        assert "no members" in errored[0][2]
+        assert errored == []
+
+    def test_get_resources_by_ids_exact_page_size_total_does_not_call_next_page(self):
+        config = MagicMock()
+        config.source_client = MagicMock()
+        config.state = _MockState()
+
+        team_id = "team-exact-100"
+        first_page_members = [_make_member(team_id, f"user-{i}") for i in range(100)]
+
+        async def _get(path, **kwargs):
+            page_number = kwargs.get("params", {}).get("page[number]", 0)
+            if page_number == 0:
+                return {
+                    "data": first_page_members,
+                    "meta": {"pagination": {"total": 100}},
+                }
+            raise CustomClientHTTPError(
+                _FakeHTTPResponse(status=429, message="Too Many Requests"),
+                message="rate limited",
+            )
+
+        config.source_client.get = AsyncMock(side_effect=_get)
+        tm = TeamMemberships(config=config)
+        resources, missing, errored = asyncio.run(
+            tm.get_resources_by_ids(config.source_client, [team_id], max_concurrent_reads=10)
+        )
+
+        assert len(resources) == 100
+        assert missing == []
+        assert errored == []
+        assert config.source_client.get.await_count == 1
 
     def test_get_resources_by_ids_cross_team_memberships_keep_both_rows(self):
         config = MagicMock()


### PR DESCRIPTION
## What
- add `authn_mappings` and `team_memberships` to `_ID_FILE_SUPPORTED_TYPES`
- implement `team_memberships` id-file fan-out in `get_resources_by_ids(...)` (`team_id` -> N membership resources)
- keep the id-file fetch phase side-effect free for `team_memberships` (no source-state mutation during fetch)
- reject direct `team_memberships.import_resource(_id=...)` usage; fan-out is handled by `get_resources_by_ids(...)`
- remove now-unused source-state helper methods that were added for fetch-time mutation
- include focused unit tests for both resource types
- use `asyncio.run(...)` in new tests for Python 3.12 compatibility

## Why
- ease batching these resources
- preserve second-pass import and filter semantics for id-file runs

## Validation
- `pytest tests/unit/test_team_memberships_id_file.py tests/unit/test_authn_mappings_id_file.py tests/unit/test_get_resources_by_ids_experiment.py::test_id_file_allowlist_rejects_non_monitors_v1 tests/unit/test_get_resources_by_ids_experiment.py::test_id_file_allowlist_accepts_monitors`
