### PR TITLE
Update doc for synthetics-private-locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ When running againts multiple destination organizations, a seperate working dire
 | slo_corrections                        | Sync Datadog SLO corrections.                                        |
 | spans_metrics                          | Sync Datadog spans metrics.                                          |
 | synthetics_global_variables            | Sync Datadog synthetic global variables.                             |
+| synthetics_private_locations           | Sync Datadog Synthetics Private Locations. See [DDR guide](docs/synthetics-private-locations.md). |
 | synthetics_tests                       | Sync Datadog synthetic tests.                                        |
 | teams                                  | Sync Datadog teams (excluding permissions).                          |
 | team_memberships                       | Sync Datadog team memberships.                                       |
@@ -297,6 +298,7 @@ See [Supported resources](#supported-resources) section below for potential reso
 | slo_corrections                        | service_level_objectives                                         |
 | spans_metrics                          | -                                                                |
 | synthetics_global_variables            | synthetics_tests                                                 |
+| synthetics_private_locations           | -                                                                |
 | synthetics_tests                       | synthetics_global_variables, roles                               |
 | teams                                  | -                                                                |
 | team_memberships                       | teams, users                                                     |

--- a/docs/synthetics-private-locations.md
+++ b/docs/synthetics-private-locations.md
@@ -9,7 +9,6 @@ that test traffic continues flowing when the destination region takes over (fail
 - [Overview](#overview)
 - [Replicating PLs with `datadog-sync-cli`](#replicating-pls-with-datadog-sync-cli)
   - [What gets synced](#what-gets-synced)
-  - [The `--datadog-host-override` flag](#the---datadog-host-override-flag)
 - [How replicated PLs work after sync](#how-replicated-pls-work-after-sync)
 - [Configuring `datadogHostOverride` on your PL workers](#configuring-datadoghostoverride-on-your-pl-workers)
   - [Option A: env var (Kubernetes / Helm chart)](#option-a-env-var-kubernetes--helm-chart)
@@ -63,54 +62,31 @@ datadog-sync-cli import \
 
 # Replicate them into the destination org
 datadog-sync-cli sync \
-  --resources synthetics_private_locations \
-  --datadog-host-override <your-failover-cname>.synthetics.datadoghq.com
+  --resources synthetics_private_locations
 ```
-
-### The `--datadog-host-override` flag
-
-When you replicate a PL into the destination org, the tool needs to know which intake
-hostname the destination-side PL should report to. You pass this via the
-`--datadog-host-override` flag (or `DD_DATADOG_HOST_OVERRIDE` env var).
-
-The value should be the **CNAME** that your DNS controls — the one whose target you flip
-when failing over from one region to another. Example:
-
-```bash
---datadog-host-override <your-failover-cname>.synthetics.datadoghq.com
-```
-
-That CNAME gets stored as `datadogHostOverride` in the destination PL's config, which the
-worker then picks up.
-
-If you don't pass the flag, the destination PL gets created without a `datadogHostOverride`,
-which means the worker will fall back to the standard region intake for the secondary org.
-That's usually **not** what you want for a failover setup — pass the flag.
 
 ## How replicated PLs work after sync
 
-After replication:
-
-- Both orgs have a PL with the same internal identifier (the same `pl:<slug>` name).
-- Both orgs share encryption keys, so tests scheduled in either region can be decrypted
-  and executed by the same worker.
-- Tests in each org can reference the PL by name. When the failover happens, the worker
-  starts polling the secondary region and continues running tests with no test-config
-  changes.
+After replication, both orgs have a PL with the same internal identifier (the same
+`pl:<slug>` name) and shared encryption keys. However, the PL worker can only report to
+**one datacenter at a time** — whichever datacenter the `datadogHostOverride` CNAME
+currently resolves to. Only that datacenter's org will show the PL as healthy and receive
+test results.
 
 The customer-side work to enable this is:
 
 1. **Run `datadog-sync-cli` to replicate the PL.** (Covered above.)
-2. **Set `datadogHostOverride` on your PL worker(s)** to the same CNAME you passed to the
-   sync tool. The next section explains the three ways to do this.
+2. **Set `datadogHostOverride` on your PL worker(s)** to a CNAME whose DNS target you
+   control. The next section explains the three ways to do this.
 3. **Control the CNAME's DNS target** so it points to your primary region in steady state
    and gets flipped to the secondary region during failover. The flip is transparent to
-   the worker — the next polling cycle picks up the new target automatically.
+   the worker — the next polling cycle picks up the new target automatically, and from
+   that point on tests are pulled from and results pushed to the secondary region only.
 
 ## Configuring `datadogHostOverride` on your PL workers
 
 `datadogHostOverride` tells the PL worker which intake hostname to send results and poll
-for tests. It must match the CNAME you configured at replication time.
+for tests.
 
 There are three equivalent ways to set it. Pick whichever fits your deployment.
 
@@ -190,9 +166,10 @@ After running the sync and starting your worker with `datadogHostOverride` set:
 
 1. **Confirm the PL appears in both orgs.** Check the Synthetics → Settings → Private
    Locations page in each org. The PL should be listed with the same name in both.
-2. **Confirm the worker reports.** The PL should show as healthy in both orgs once the
-   worker starts polling. If it only reports in one, double-check that the CNAME's current
-   DNS target is the region you expect.
-3. **Run a test.** Create a test in either org targeting the replicated PL, unpause it,
-   and confirm results appear. During steady state, results land in your primary region;
-   during failover, they land in the secondary region — without any test-config changes.
+2. **Confirm the worker reports to the active region.** Only the org whose datacenter the
+   `datadogHostOverride` CNAME currently resolves to will show the PL as healthy. The
+   other org's PL will appear offline until you flip the CNAME to point to it.
+3. **Run a test.** Create a test in the active org targeting the replicated PL, unpause
+   it, and confirm results appear. Results are pulled from and pushed to only the
+   datacenter the CNAME resolves to — flipping the CNAME switches where tests run and
+   results land, without any test-config changes.

--- a/docs/synthetics-private-locations.md
+++ b/docs/synthetics-private-locations.md
@@ -67,8 +67,8 @@ datadog-sync-cli sync \
 
 ## How replicated PLs work after sync
 
-After replication, both orgs have a PL with the same internal identifier (the same
-`pl:<slug>` name) and shared encryption keys. However, the PL worker can only report to
+After replication, both orgs have a PL with the same display name, tags, and shared
+encryption keys (but different internal identifiers). However, the PL worker can only report to
 **one datacenter at a time** — whichever datacenter the `datadogHostOverride` CNAME
 currently resolves to. Only that datacenter's org will show the PL as healthy and receive
 test results.

--- a/docs/synthetics-private-locations.md
+++ b/docs/synthetics-private-locations.md
@@ -76,12 +76,8 @@ test results.
 The customer-side work to enable this is:
 
 1. **Run `datadog-sync-cli` to replicate the PL.** (Covered above.)
-2. **Set `datadogHostOverride` on your PL worker(s)** to a CNAME whose DNS target you
-   control. The next section explains the three ways to do this.
-3. **Control the CNAME's DNS target** so it points to your primary region in steady state
-   and gets flipped to the secondary region during failover. The flip is transparent to
-   the worker — the next polling cycle picks up the new target automatically, and from
-   that point on tests are pulled from and results pushed to the secondary region only.
+2. **Set `datadogHostOverride` on your PL worker(s)** to the failover CNAME. The next
+   section explains the three ways to do this.
 
 ## Configuring `datadogHostOverride` on your PL workers
 

--- a/docs/synthetics-private-locations.md
+++ b/docs/synthetics-private-locations.md
@@ -1,0 +1,198 @@
+# Synthetics Private Locations with datadog-sync-cli
+
+This guide describes how to replicate Synthetics Private Locations (PLs) from one Datadog
+organization to another using `datadog-sync-cli`, and how to configure your PL workers so
+that test traffic continues flowing when the destination region takes over (failover).
+
+## Table of contents
+
+- [Overview](#overview)
+- [Replicating PLs with `datadog-sync-cli`](#replicating-pls-with-datadog-sync-cli)
+  - [What gets synced](#what-gets-synced)
+  - [The `--datadog-host-override` flag](#the---datadog-host-override-flag)
+- [How replicated PLs work after sync](#how-replicated-pls-work-after-sync)
+- [Configuring `datadogHostOverride` on your PL workers](#configuring-datadoghostoverride-on-your-pl-workers)
+  - [Option A: env var (Kubernetes / Helm chart)](#option-a-env-var-kubernetes--helm-chart)
+  - [Option B: command-line argument (Docker)](#option-b-command-line-argument-docker)
+  - [Option C: JSON config file](#option-c-json-config-file)
+- [Verifying the setup](#verifying-the-setup)
+
+## Overview
+
+When you onboard Synthetics Private Locations to a disaster-recovery setup, the goal is to
+have the *same* PL identity reachable from two regions:
+
+- **Primary region** (your everyday org) where tests normally run.
+- **Secondary region** (your standby org) that takes over during a failover event.
+
+`datadog-sync-cli` replicates the PL definition (name, description, tags, encryption keys,
+DDR metadata) into the secondary org, so the secondary region recognizes the same PL when
+traffic gets switched over.
+
+The **PL worker itself** runs in your infrastructure and is the same binary regardless of
+which region is active. The only thing that changes between regions is the **intake
+hostname** the worker reports to. That hostname is set through the `datadogHostOverride`
+config option, which the customer points at a DNS CNAME that resolves to whichever region
+is currently serving traffic. The CNAME flip is what triggers the failover.
+
+## Replicating PLs with `datadog-sync-cli`
+
+### What gets synced
+
+When you run `import` then `sync` against your two orgs with `synthetics_private_locations`
+in scope, the tool:
+
+1. Reads each private location from the source org (`GET /api/v1/synthetics/private-locations/<id>?include_pl_info=true`).
+2. Creates a matching private location in the destination org via the DDR-aware
+   create endpoint. The destination PL is created with:
+   - The same display name, description, tags, and restricted-role metadata.
+   - A reference back to the source PL (stored as `ddr_metadata.disaster_recovery`).
+   - The source PL's test-encryption public key (so the secondary region can decrypt
+     tests that were originally encrypted by the primary region).
+3. Persists the destination PL in your local state file so subsequent syncs are idempotent.
+
+You do **not** need to manage encryption keys, auth tokens, or worker configuration by
+hand. Those are handled by the tool and by Datadog out-of-band.
+
+Example commands (running in your environment with the two orgs' credentials configured):
+
+```bash
+# Pull source PLs into local state
+datadog-sync-cli import \
+  --resources synthetics_private_locations
+
+# Replicate them into the destination org
+datadog-sync-cli sync \
+  --resources synthetics_private_locations \
+  --datadog-host-override <your-failover-cname>.synthetics.datadoghq.com
+```
+
+### The `--datadog-host-override` flag
+
+When you replicate a PL into the destination org, the tool needs to know which intake
+hostname the destination-side PL should report to. You pass this via the
+`--datadog-host-override` flag (or `DD_DATADOG_HOST_OVERRIDE` env var).
+
+The value should be the **CNAME** that your DNS controls — the one whose target you flip
+when failing over from one region to another. Example:
+
+```bash
+--datadog-host-override <your-failover-cname>.synthetics.datadoghq.com
+```
+
+That CNAME gets stored as `datadogHostOverride` in the destination PL's config, which the
+worker then picks up.
+
+If you don't pass the flag, the destination PL gets created without a `datadogHostOverride`,
+which means the worker will fall back to the standard region intake for the secondary org.
+That's usually **not** what you want for a failover setup — pass the flag.
+
+## How replicated PLs work after sync
+
+After replication:
+
+- Both orgs have a PL with the same internal identifier (the same `pl:<slug>` name).
+- Both orgs share encryption keys, so tests scheduled in either region can be decrypted
+  and executed by the same worker.
+- Tests in each org can reference the PL by name. When the failover happens, the worker
+  starts polling the secondary region and continues running tests with no test-config
+  changes.
+
+The customer-side work to enable this is:
+
+1. **Run `datadog-sync-cli` to replicate the PL.** (Covered above.)
+2. **Set `datadogHostOverride` on your PL worker(s)** to the same CNAME you passed to the
+   sync tool. The next section explains the three ways to do this.
+3. **Control the CNAME's DNS target** so it points to your primary region in steady state
+   and gets flipped to the secondary region during failover. The flip is transparent to
+   the worker — the next polling cycle picks up the new target automatically.
+
+## Configuring `datadogHostOverride` on your PL workers
+
+`datadogHostOverride` tells the PL worker which intake hostname to send results and poll
+for tests. It must match the CNAME you configured at replication time.
+
+There are three equivalent ways to set it. Pick whichever fits your deployment.
+
+### Option A: env var (Kubernetes / Helm chart)
+
+Recommended when you run PL workers via the official [synthetics-private-location Helm
+chart](https://github.com/DataDog/helm-charts/tree/main/charts/synthetics-private-location).
+
+Set the `DATADOG_HOST_OVERRIDE` environment variable through the chart's
+`environmentVariableOverride` block (or your standard env var injection mechanism):
+
+```yaml
+# values.yaml
+datadog:
+  apiKey: <your api key>
+  appKey: <your app key>
+
+environmentVariableOverride:
+  - name: DATADOG_HOST_OVERRIDE
+    value: <your-failover-cname>.synthetics.datadoghq.com
+```
+
+This sets the value once at the deployment level, and every PL container that the chart
+spawns inherits it.
+
+> Requires synthetics-worker version that supports the `DATADOG_HOST_OVERRIDE` env var
+> (see [synthetics-worker#10100](https://github.com/DataDog/synthetics-worker/pull/10100)).
+> Use that worker version or newer.
+
+### Option B: command-line argument (Docker)
+
+If you run the PL worker directly with `docker run`, pass `--datadogHostOverride` as a
+launch argument:
+
+```bash
+docker run --rm \
+  -v $(pwd)/worker-config.json:/etc/datadog/synthetics-check-runner.json \
+  datadog/synthetics-private-location-worker:latest \
+  --datadogHostOverride=<your-failover-cname>.synthetics.datadoghq.com
+```
+
+### Option C: JSON config file
+
+Add `datadogHostOverride` to your PL worker's JSON config file (the same file the worker
+already reads for API/app keys and other settings):
+
+```json
+{
+  "datadogHostOverride": "<your-failover-cname>.synthetics.datadoghq.com",
+  "datadogApiKey": "...",
+  "datadogAppKey": "..."
+}
+```
+
+Then point the worker at the file:
+
+```bash
+docker run --rm \
+  -v $(pwd)/worker-config.json:/etc/datadog/synthetics-check-runner.json \
+  datadog/synthetics-private-location-worker:latest
+```
+
+### Precedence
+
+If you set the value through more than one mechanism, the worker resolves in this order
+(highest precedence first):
+
+1. CLI argument (`--datadogHostOverride=...`)
+2. Environment variable (`DATADOG_HOST_OVERRIDE`)
+3. JSON config file (`datadogHostOverride` field)
+
+In practice, pick one mechanism and stick with it for clarity.
+
+## Verifying the setup
+
+After running the sync and starting your worker with `datadogHostOverride` set:
+
+1. **Confirm the PL appears in both orgs.** Check the Synthetics → Settings → Private
+   Locations page in each org. The PL should be listed with the same name in both.
+2. **Confirm the worker reports.** The PL should show as healthy in both orgs once the
+   worker starts polling. If it only reports in one, double-check that the CNAME's current
+   DNS target is the region you expect.
+3. **Run a test.** Create a test in either org targeting the replicated PL, unpause it,
+   and confirm results appear. During steady state, results land in your primary region;
+   during failover, they land in the secondary region — without any test-config changes.


### PR DESCRIPTION
### What does this PR do?

Adds documentation for using Synthetics Private Locations with the Disaster Recovery (DDR) setup.

### Description of the Change

Adds `docs/synthetics-private-locations.md`, a guide explaining how to replicate Synthetics Private Locations from a source to a destination org using `datadog-sync-cli`, and how to configure the PL worker's `datadogHostOverride` for failover. Updates the README to list `synthetics_private_locations` as a supported resource with a link to the new guide.