### PR TITLE
[HAMR-392] feat(monitors): per-type concurrency cap, overload backoff, error logging

### DIFF
--- a/datadog_sync/model/monitors.py
+++ b/datadog_sync/model/monitors.py
@@ -315,7 +315,11 @@ def _log_monitor_http_error(_id: str, action: str, resource: Dict, err: CustomCl
     """
     if err.status_code < 400:
         return
+    # Formula / multi-query monitors carry `queries: [...]` instead of a single
+    # `query` string. Fall back so those types still log a meaningful payload.
     query = resource.get("query")
+    if query is None:
+        query = resource.get("queries")
     m_type = resource.get("type")
     _log.warning(
         "monitor %s failed status=%s id=%s type=%r query=%r",

--- a/datadog_sync/model/monitors.py
+++ b/datadog_sync/model/monitors.py
@@ -251,38 +251,53 @@ _MONITOR_LOG_QUERY_MAX_CHARS = 2000
 _MONITOR_APPLICATION_ID_RE = re.compile(r"@application\.id:[A-Za-z0-9\-]+")
 
 
-def _summarize_query_for_log(query: Optional[str]) -> Optional[str]:
+def _summarize_query_for_log(query) -> Optional[str]:
     """Truncate a monitor query for logging while preserving any
     ``@application.id:<uuid>`` fragment.
 
     The @application.id token is the load-bearing identifier for RUM alert
-    monitors (HAMR-392 T4): it maps the failure to a specific RUM app that
-    may or may not exist in the destination. A naive length-based truncation
-    can drop the token when the query has a long leading filter chain. When
-    present, the token is preserved inline and the rest of the query is
-    truncated around it.
+    monitors: it maps the failure to a specific RUM app that may or may not
+    exist in the destination. A naive length-based truncation can drop the
+    token when the query has a long leading filter chain. When present, the
+    token is preserved inline and the rest of the query is truncated around
+    it.
+
+    Accepts non-string inputs (formula/multi-query alerts can populate
+    ``queries: [...]`` instead of ``query``) and stringifies them before
+    truncation.
     """
     if query is None:
         return None
-    q = str(query)
+    q = query if isinstance(query, str) else repr(query)
     if len(q) <= _MONITOR_LOG_QUERY_MAX_CHARS:
         return q
     match = _MONITOR_APPLICATION_ID_RE.search(q)
     if match is None:
         return q[: _MONITOR_LOG_QUERY_MAX_CHARS - 3] + "..."
-    # Preserve the @application.id token by keeping a window around it. The
-    # window is anchored on the token; leading and trailing halves are
-    # ellipsized so the token is always visible.
-    token = match.group(0)
-    keep = _MONITOR_LOG_QUERY_MAX_CHARS - len(token) - len("...") - len("...")
+    # Preserve the @application.id token by keeping a window around it. Cap
+    # the token first so a maliciously-long or malformed value can't bypass
+    # the overall length bound (real Datadog app IDs are UUIDs, ~52 chars
+    # including the "@application.id:" prefix). Then build a fixed-length
+    # window from the ORIGINAL string on either side of the (capped) token
+    # position, so the total output length is bounded by
+    # _MONITOR_LOG_QUERY_MAX_CHARS + a small constant for ellipses.
+    _MAX_TOKEN = 96
+    raw_token = match.group(0)
+    capped_token = raw_token if len(raw_token) <= _MAX_TOKEN else raw_token[: _MAX_TOKEN - 3] + "..."
+    keep = _MONITOR_LOG_QUERY_MAX_CHARS - len(capped_token) - len("...") - len("...")
     if keep < 0:
-        return "..." + token + "..."
+        # Token alone (post-cap) is already at/above the bound. Return just
+        # the token bracketed — bounded because token is bounded above.
+        return "..." + capped_token + "..."
     half = keep // 2
-    start = max(0, match.start() - half)
-    end = min(len(q), match.end() + (keep - (match.start() - start)))
-    prefix = "..." if start > 0 else ""
-    suffix = "..." if end < len(q) else ""
-    return prefix + q[start:end] + suffix
+    before_start = max(0, match.start() - half)
+    before_slice = q[before_start : match.start()]
+    remaining = keep - len(before_slice)
+    after_end = min(len(q), match.end() + remaining)
+    after_slice = q[match.end() : after_end]
+    prefix = "..." if before_start > 0 else ""
+    suffix = "..." if after_end < len(q) else ""
+    return prefix + before_slice + capped_token + after_slice + suffix
 
 
 def _log_monitor_http_error(_id: str, action: str, resource: Dict, err: CustomClientHTTPError) -> None:

--- a/datadog_sync/model/monitors.py
+++ b/datadog_sync/model/monitors.py
@@ -4,12 +4,16 @@
 # Copyright 2019 Datadog, Inc.
 
 from __future__ import annotations
+import logging
 import re
 from typing import TYPE_CHECKING, Optional, List, Dict, Tuple, cast
 
+from datadog_sync.constants import LOGGER_NAME
 from datadog_sync.utils.base_resource import BaseResource, ResourceConfig, TaggingConfig
 from datadog_sync.utils.custom_client import PaginationConfig
 from datadog_sync.utils.resource_utils import CustomClientHTTPError, SkipResource
+
+_log = logging.getLogger(LOGGER_NAME)
 
 if TYPE_CHECKING:
     from datadog_sync.utils.custom_client import CustomClient
@@ -44,6 +48,19 @@ class Monitors(BaseResource):
         null_values={"draft_status": "published"},
         tagging_config=TaggingConfig(path="tags"),
         skip_resource_mapping=True,
+        # max_concurrent is left unset by default so wrappers (e.g. dd-source
+        # managed-sync) can plumb it through per-org via Vault config without
+        # requiring a sync-cli release cycle.
+        #
+        # Motivating case (HAMR-392): destination monitor-create edge/proxy
+        # timeout storms (HTTP 512 "Timeout") on Allstate scale when the
+        # global 32-way worker pool queues too many concurrent
+        # POST/PUT /api/v1/monitor requests. Server-side monitor-app returned
+        # 200/400 normally throughout -- 512 was emitted by the edge proxy on
+        # request-queue overflow, not by the monitor-app itself. Recommended
+        # starting value for that org: 8 (each monitor sync issues a
+        # GET-check-existence + POST/PUT, so 8 workers -> ~16 in-flight
+        # destination requests, a ~4x drop from the ~64 at --max-workers=32).
     )
     # Additional Monitors specific attributes
     pagination_config = PaginationConfig(
@@ -117,15 +134,20 @@ class Monitors(BaseResource):
                     existing_id = match.group(1)
                     existing = await destination_client.get(f"{self.resource_config.base_path}/{existing_id}")
                     return _id, existing
+            _log_monitor_http_error(_id, "create", resource, e)
             raise
         return _id, resp
 
     async def update_resource(self, _id: str, resource: Dict) -> Tuple[str, Dict]:
         destination_client = self.config.destination_client
-        resp = await destination_client.put(
-            self.resource_config.base_path + f"/{self.config.state.destination[self.resource_type][_id]['id']}",
-            resource,
-        )
+        try:
+            resp = await destination_client.put(
+                self.resource_config.base_path + f"/{self.config.state.destination[self.resource_type][_id]['id']}",
+                resource,
+            )
+        except CustomClientHTTPError as e:
+            _log_monitor_http_error(_id, "update", resource, e)
+            raise
 
         return _id, resp
 
@@ -223,3 +245,68 @@ class Monitors(BaseResource):
                 if type_map.get(_type) == resource_to_connect
             ]
         return super(Monitors, self).extract_source_ids(key, r_obj, resource_to_connect)
+
+
+_MONITOR_LOG_QUERY_MAX_CHARS = 2000
+_MONITOR_APPLICATION_ID_RE = re.compile(r"@application\.id:[A-Za-z0-9\-]+")
+
+
+def _summarize_query_for_log(query: Optional[str]) -> Optional[str]:
+    """Truncate a monitor query for logging while preserving any
+    ``@application.id:<uuid>`` fragment.
+
+    The @application.id token is the load-bearing identifier for RUM alert
+    monitors (HAMR-392 T4): it maps the failure to a specific RUM app that
+    may or may not exist in the destination. A naive length-based truncation
+    can drop the token when the query has a long leading filter chain. When
+    present, the token is preserved inline and the rest of the query is
+    truncated around it.
+    """
+    if query is None:
+        return None
+    q = str(query)
+    if len(q) <= _MONITOR_LOG_QUERY_MAX_CHARS:
+        return q
+    match = _MONITOR_APPLICATION_ID_RE.search(q)
+    if match is None:
+        return q[: _MONITOR_LOG_QUERY_MAX_CHARS - 3] + "..."
+    # Preserve the @application.id token by keeping a window around it. The
+    # window is anchored on the token; leading and trailing halves are
+    # ellipsized so the token is always visible.
+    token = match.group(0)
+    keep = _MONITOR_LOG_QUERY_MAX_CHARS - len(token) - len("...") - len("...")
+    if keep < 0:
+        return "..." + token + "..."
+    half = keep // 2
+    start = max(0, match.start() - half)
+    end = min(len(q), match.end() + (keep - (match.start() - start)))
+    prefix = "..." if start > 0 else ""
+    suffix = "..." if end < len(q) else ""
+    return prefix + q[start:end] + suffix
+
+
+def _log_monitor_http_error(_id: str, action: str, resource: Dict, err: CustomClientHTTPError) -> None:
+    """Emit the outbound monitor's identifying fields on any HTTP error so the
+    cause is diagnosable from logs alone.
+
+    Prior behaviour logged only the destination's response body (e.g. HAMR-392
+    "Invalid query: Check for invalid tags or facets in your query"), forcing
+    operators to reach into cloud-storage state to see which monitor query the
+    validator rejected. The status_code gate keeps error-log volume bounded to
+    the classes where the outbound payload is actually informative:
+      * 4xx (validation failures): the query is the direct cause.
+      * 512 / 502-504 (upstream/edge overload): the type + query length help
+        classify whether an expensive-validation class dominates the batch.
+    """
+    if err.status_code < 400:
+        return
+    query = resource.get("query")
+    m_type = resource.get("type")
+    _log.warning(
+        "monitor %s failed status=%s id=%s type=%r query=%r",
+        action,
+        err.status_code,
+        _id,
+        m_type,
+        _summarize_query_for_log(query),
+    )

--- a/datadog_sync/model/monitors.py
+++ b/datadog_sync/model/monitors.py
@@ -248,6 +248,7 @@ class Monitors(BaseResource):
 
 
 _MONITOR_LOG_QUERY_MAX_CHARS = 2000
+_MONITOR_LOG_REASON_MAX_CHARS = 200
 _MONITOR_APPLICATION_ID_RE = re.compile(r"@application\.id:[A-Za-z0-9\-]+")
 
 
@@ -307,11 +308,11 @@ def _log_monitor_http_error(_id: str, action: str, resource: Dict, err: CustomCl
     Prior behaviour logged only the destination's response body (e.g. HAMR-392
     "Invalid query: Check for invalid tags or facets in your query"), forcing
     operators to reach into cloud-storage state to see which monitor query the
-    validator rejected. The status_code gate keeps error-log volume bounded to
-    the classes where the outbound payload is actually informative:
-      * 4xx (validation failures): the query is the direct cause.
-      * 512 / 502-504 (upstream/edge overload): the type + query length help
-        classify whether an expensive-validation class dominates the batch.
+    validator rejected. The gate fires on any status_code >= 400 (both 4xx and
+    5xx): 4xx validation failures where the query is the direct cause, and 5xx
+    upstream/edge overload where the type + query help classify the batch. The
+    server's failure reason (from the exception message) is included, truncated
+    so a large/HTML/empty response body can neither bloat nor break the log.
     """
     if err.status_code < 400:
         return
@@ -321,11 +322,17 @@ def _log_monitor_http_error(_id: str, action: str, resource: Dict, err: CustomCl
     if query is None:
         query = resource.get("queries")
     m_type = resource.get("type")
+    try:
+        reason_text = str(err)
+    except Exception:  # never let logging diagnostics crash the sync path
+        reason_text = ""
+    reason = (reason_text or "")[:_MONITOR_LOG_REASON_MAX_CHARS]
     _log.warning(
-        "monitor %s failed status=%s id=%s type=%r query=%r",
+        "monitor %s failed status=%s id=%s type=%r query=%r reason=%r",
         action,
         err.status_code,
         _id,
         m_type,
         _summarize_query_for_log(query),
+        reason,
     )

--- a/datadog_sync/utils/base_resource.py
+++ b/datadog_sync/utils/base_resource.py
@@ -115,6 +115,12 @@ class ResourceConfig:
         # fresh loop each time). Always construct inside init_async() which
         # runs under the loop we're going to use.
         self.async_lock = Lock()
+        # Always clear async_semaphore first so a re-init with
+        # max_concurrent=None/0 disables the cap. Long-lived wrappers that
+        # reuse the same Configuration across orgs (setting a cap for one org
+        # then unsetting it for the next) would otherwise keep honoring a
+        # stale semaphore from the previous org.
+        self.async_semaphore = None
         if self.max_concurrent and self.max_concurrent > 0:
             self.async_semaphore = Semaphore(self.max_concurrent)
 

--- a/datadog_sync/utils/base_resource.py
+++ b/datadog_sync/utils/base_resource.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 import abc
 import asyncio
-from asyncio import Lock
+from asyncio import Lock, Semaphore
 from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Callable, ClassVar, Optional, Dict, List, Tuple, Union
@@ -92,12 +92,40 @@ class ResourceConfig:
     # made metadata-only filters force a per-id GET per item, a wall-clock
     # / rate-limit regression for the common filter-by-name use case.
     list_omitted_attr_prefixes: List[str] = field(default_factory=list)
+    # Optional per-resource-type concurrency cap. When set to a positive int N,
+    # limits _create_resource / _update_resource to at most N in-flight for this
+    # resource type, regardless of the global --max-workers value. Motivating
+    # case: the destination monitors API's edge/proxy layer times out
+    # (HTTP 512) when sync-cli's 32-way worker pool queues too many concurrent
+    # POST/PUT /api/v1/monitor requests. Setting max_concurrent=8 on the
+    # Monitors resource caps the pressure on that specific endpoint without
+    # slowing the other resource types.
+    #
+    # `concurrent=False` continues to serialize a resource type completely (via
+    # `async_lock`). `max_concurrent` is the semaphore-based, N>1 middle ground.
+    # When both are set, `concurrent=False` wins (serial behavior).
+    max_concurrent: Optional[int] = None
+    async_semaphore: Optional[Semaphore] = None
 
     async def init_async(self) -> None:
+        # Both Lock and Semaphore bind to the current running event loop on
+        # construction (Python 3.9). Instantiating them at dataclass
+        # __post_init__ time can pin them to a loop that's about to be
+        # replaced (e.g. tests that call asyncio.run per test-case get a
+        # fresh loop each time). Always construct inside init_async() which
+        # runs under the loop we're going to use.
         self.async_lock = Lock()
+        if self.max_concurrent and self.max_concurrent > 0:
+            self.async_semaphore = Semaphore(self.max_concurrent)
 
     def __post_init__(self) -> None:
         self.build_excluded_attributes()
+        # Note: async primitives (async_lock, async_semaphore) are constructed
+        # by init_async() so they bind to the correct running loop. Prior
+        # code constructed async_lock here when concurrent=False; keep that
+        # for backward compatibility with callers that acquire the lock
+        # without first calling init_async(). Semaphore has no such legacy
+        # path, so it's created only in init_async().
         if not self.concurrent:
             self.async_lock = Lock()
 

--- a/datadog_sync/utils/custom_client.py
+++ b/datadog_sync/utils/custom_client.py
@@ -15,10 +15,39 @@ from urllib.parse import urlparse
 import aiohttp
 import certifi
 
+from collections import Counter as _StdCounter
 from datadog_sync.constants import DDR_Status, LOGGER_NAME, Metrics
 from datadog_sync.utils.resource_utils import CustomClientHTTPError
 
 log = logging.getLogger(LOGGER_NAME)
+
+
+# HTTP statuses that signal upstream/edge overload rather than app-level failure.
+# For these, hammering with tight-cycle retries makes the situation worse (the
+# same request queue is still full). Use a longer, jittered exponential backoff
+# that respects the Retry-After header when present.
+_OVERLOAD_STATUSES = frozenset({502, 503, 504, 512})
+# Jittered exponential backoff schedule for _OVERLOAD_STATUSES, in seconds.
+# Index by retry_count. Falls off the end -> caller gives up. Matches the
+# observed proxy queue drain time on the destination monitor API during the
+# HAMR-392 storm (see PR body).
+_OVERLOAD_BACKOFF_SCHEDULE = (30, 60, 120)
+
+
+def _overload_sleep_duration(retry_count: int, retry_after_hdr: Optional[str]) -> int:
+    """Return the number of seconds to wait before retrying an _OVERLOAD_STATUSES
+    response. Honors Retry-After if present; otherwise falls back to
+    _OVERLOAD_BACKOFF_SCHEDULE indexed by retry_count.
+    """
+    if retry_after_hdr:
+        try:
+            # Retry-After per RFC 7231 can be seconds or an HTTP-date. We accept
+            # the seconds form only; treat non-integer values as unset.
+            return max(0, int(retry_after_hdr))
+        except (TypeError, ValueError):
+            pass
+    idx = min(retry_count, len(_OVERLOAD_BACKOFF_SCHEDULE) - 1)
+    return _OVERLOAD_BACKOFF_SCHEDULE[idx]
 
 
 def request_with_retry(func: Awaitable) -> Awaitable:
@@ -49,6 +78,34 @@ def request_with_retry(func: Awaitable) -> Awaitable:
                             log.warning(f"{e}. retry timeout has or will exceed timeout duration")
                             raise CustomClientHTTPError(e, message=err_text)
                         log.warning(f"{e}. retrying request after {sleep_duration}s")
+                        await asyncio.sleep(sleep_duration)
+                        retry_count += 1
+                        log.debug(f"retry count: {retry_count}")
+                        continue
+                    elif e.status in _OVERLOAD_STATUSES:
+                        # Edge/proxy timeouts and gateway overload: back off
+                        # substantially longer than the 5s * retry_count
+                        # baseline used for other 5xx. Honor Retry-After if the
+                        # server sent one; otherwise use the fixed schedule.
+                        # Increment the per-status counter so operators can
+                        # dashboard "is the fix working?" long-term via
+                        # client.overload_status_counter, rather than
+                        # log-grep.
+                        try:
+                            args[0].overload_status_counter[e.status] += 1
+                        except AttributeError:
+                            # Older CustomClient instances or test doubles.
+                            pass
+                        sleep_duration = _overload_sleep_duration(retry_count, e.headers.get("Retry-After"))
+                        if (sleep_duration + time.time()) > timeout:
+                            log.warning(
+                                f"{e}. overload backoff ({sleep_duration}s) exceeds retry timeout budget; giving up"
+                            )
+                            raise CustomClientHTTPError(e, message=err_text)
+                        if retry_count + 1 >= max_retries:
+                            log.warning("retry count has or will exceed retry maximum")
+                            raise CustomClientHTTPError(e, message=err_text)
+                        log.warning(f"{e}. upstream overloaded; backing off {sleep_duration}s before retry")
                         await asyncio.sleep(sleep_duration)
                         retry_count += 1
                         log.debug(f"retry count: {retry_count}")
@@ -90,6 +147,12 @@ class CustomClient:
         self.auth = auth
         self.send_metrics = send_metrics
         self.verify_ssl = verify_ssl
+        # Per-status counter of upstream-overload retries (see _OVERLOAD_STATUSES).
+        # Exposed so callers (or a follow-up drainer coroutine) can emit a
+        # metric like sync_cli.overload_status_encountered{status=512}. Kept as
+        # an in-memory counter rather than emitting a metric inline to avoid
+        # recursive-request risk during a proxy overload storm.
+        self.overload_status_counter: _StdCounter = _StdCounter()
 
         # Metrics only work with API keys, not JWT
         # If JWT is present, metrics are not available

--- a/datadog_sync/utils/custom_client.py
+++ b/datadog_sync/utils/custom_client.py
@@ -42,8 +42,10 @@ def _overload_sleep_duration(retry_count: int, retry_after_hdr: Optional[str]) -
     if retry_after_hdr:
         try:
             # Retry-After per RFC 7231 can be seconds or an HTTP-date. We accept
-            # the seconds form only; treat non-integer values as unset.
-            return max(0, int(retry_after_hdr))
+            # the seconds form only (integer or fractional); treat HTTP-date and
+            # other non-numeric values as unset. float() also handles integer
+            # strings, so this covers both common forms.
+            return max(0, int(float(retry_after_hdr)))
         except (TypeError, ValueError):
             pass
     idx = min(retry_count, len(_OVERLOAD_BACKOFF_SCHEDULE) - 1)
@@ -96,14 +98,20 @@ def request_with_retry(func: Awaitable) -> Awaitable:
                         except AttributeError:
                             # Older CustomClient instances or test doubles.
                             pass
+                        # Cap at the schedule length rather than max_retries.
+                        # This keeps every bucket in _OVERLOAD_BACKOFF_SCHEDULE
+                        # reachable: with a 3-element schedule and retry_count
+                        # starting at 0, we sleep schedule[0], schedule[1],
+                        # schedule[2] on successive retries before giving up
+                        # (subject to the retry_timeout total budget).
+                        if retry_count >= len(_OVERLOAD_BACKOFF_SCHEDULE):
+                            log.warning("retry count has exceeded overload backoff schedule length")
+                            raise CustomClientHTTPError(e, message=err_text)
                         sleep_duration = _overload_sleep_duration(retry_count, e.headers.get("Retry-After"))
                         if (sleep_duration + time.time()) > timeout:
                             log.warning(
                                 f"{e}. overload backoff ({sleep_duration}s) exceeds retry timeout budget; giving up"
                             )
-                            raise CustomClientHTTPError(e, message=err_text)
-                        if retry_count + 1 >= max_retries:
-                            log.warning("retry count has or will exceed retry maximum")
                             raise CustomClientHTTPError(e, message=err_text)
                         log.warning(f"{e}. upstream overloaded; backing off {sleep_duration}s before retry")
                         await asyncio.sleep(sleep_duration)

--- a/datadog_sync/utils/custom_client.py
+++ b/datadog_sync/utils/custom_client.py
@@ -3,7 +3,8 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019 Datadog, Inc.
 import asyncio
-from datetime import datetime
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 import ssl
 import time
 import logging
@@ -40,12 +41,23 @@ def _overload_sleep_duration(retry_count: int, retry_after_hdr: Optional[str]) -
     _OVERLOAD_BACKOFF_SCHEDULE indexed by retry_count.
     """
     if retry_after_hdr:
+        # Retry-After per RFC 7231 can be either a delta-seconds integer or an
+        # HTTP-date. Try numeric first (covers integer and fractional forms
+        # some servers send), then fall back to HTTP-date parsing.
         try:
-            # Retry-After per RFC 7231 can be seconds or an HTTP-date. We accept
-            # the seconds form only (integer or fractional); treat HTTP-date and
-            # other non-numeric values as unset. float() also handles integer
-            # strings, so this covers both common forms.
             return max(0, int(float(retry_after_hdr)))
+        except (TypeError, ValueError):
+            pass
+        try:
+            when = parsedate_to_datetime(retry_after_hdr)
+            if when is not None:
+                # parsedate_to_datetime returns naive on ambiguous input; treat
+                # naive as UTC per RFC 7231. Compute seconds-until-when,
+                # clamped to 0 (past dates -> no wait).
+                if when.tzinfo is None:
+                    when = when.replace(tzinfo=timezone.utc)
+                delta = (when - datetime.now(timezone.utc)).total_seconds()
+                return max(0, int(delta))
         except (TypeError, ValueError):
             pass
     idx = min(retry_count, len(_OVERLOAD_BACKOFF_SCHEDULE) - 1)

--- a/datadog_sync/utils/resources_handler.py
+++ b/datadog_sync/utils/resources_handler.py
@@ -323,6 +323,7 @@ class ResourcesHandler:
         resource_type, _id = q_item
         lock_acquired = False
         sem = None
+        sem_acquired = False
 
         try:
             r_class = self.config.resources[resource_type]
@@ -337,8 +338,13 @@ class ResourcesHandler:
                 # concurrent=False we already hold the full lock above. Using
                 # isinstance rather than a truthy None-check so MagicMock
                 # attributes in unit tests don't get treated as real semaphores.
+                # sem_acquired is set only after acquire returns, so a
+                # cancellation mid-await doesn't cause the finally to release
+                # a slot the caller never held (which would permanently
+                # inflate the effective concurrency limit).
                 sem = r_class.resource_config.async_semaphore
                 await sem.acquire()
+                sem_acquired = True
 
             # Run hooks
             await r_class._pre_resource_action_hook(_id, resource)
@@ -400,7 +406,9 @@ class ResourcesHandler:
             self.sorter.done(q_item)
             if lock_acquired:
                 r_class.resource_config.async_lock.release()
-            if sem is not None:
+            if sem_acquired:
+                # Only release if acquire() actually returned; guards against
+                # cancellation mid-await inflating the semaphore's slot count.
                 sem.release()
 
     async def diffs(self) -> None:

--- a/datadog_sync/utils/resources_handler.py
+++ b/datadog_sync/utils/resources_handler.py
@@ -8,6 +8,7 @@ import asyncio
 import logging
 import sys
 import time
+from asyncio import Semaphore
 from collections import defaultdict
 from copy import deepcopy
 from time import sleep
@@ -321,6 +322,7 @@ class ResourcesHandler:
     async def _apply_resource_cb(self, q_item: List) -> None:
         resource_type, _id = q_item
         lock_acquired = False
+        sem = None
 
         try:
             r_class = self.config.resources[resource_type]
@@ -329,6 +331,14 @@ class ResourcesHandler:
             if not r_class.resource_config.concurrent:
                 await r_class.resource_config.async_lock.acquire()
                 lock_acquired = True
+            elif isinstance(getattr(r_class.resource_config, "async_semaphore", None), Semaphore):
+                # Per-resource-type concurrency cap (see ResourceConfig.max_concurrent).
+                # Acquire the semaphore only for concurrent-safe types — if
+                # concurrent=False we already hold the full lock above. Using
+                # isinstance rather than a truthy None-check so MagicMock
+                # attributes in unit tests don't get treated as real semaphores.
+                sem = r_class.resource_config.async_semaphore
+                await sem.acquire()
 
             # Run hooks
             await r_class._pre_resource_action_hook(_id, resource)
@@ -390,6 +400,8 @@ class ResourcesHandler:
             self.sorter.done(q_item)
             if lock_acquired:
                 r_class.resource_config.async_lock.release()
+            if sem is not None:
+                sem.release()
 
     async def diffs(self) -> None:
         self._dependency_graph, _, _ = self.get_dependency_graph()

--- a/tests/unit/test_id_file_subprocess_experiment.py
+++ b/tests/unit/test_id_file_subprocess_experiment.py
@@ -265,6 +265,7 @@ def test_subprocess_threshold_breach_preserves_partial_state(tmp_path):
             str(source_dir),
             max_concurrent_reads=10,
             threshold=5,
+            extra_flags=["--http-client-retry-timeout=1"],
         )
         # Expect exit 1 due to threshold breach (6% > 5%)
         assert rc == 1, (
@@ -338,6 +339,7 @@ def test_subprocess_below_threshold_failures_exit_zero(tmp_path):
             str(source_dir),
             max_concurrent_reads=10,
             threshold=5,
+            extra_flags=["--http-client-retry-timeout=1"],
         )
         assert rc == 0, (
             f"expected exit 0 (3% < 5% threshold), got {rc}\n" f"STDERR:\n{stderr.decode(errors='replace')[:2000]}"

--- a/tests/unit/test_max_concurrent_semaphore.py
+++ b/tests/unit/test_max_concurrent_semaphore.py
@@ -54,7 +54,10 @@ def test_semaphore_limits_concurrent_acquisitions():
         # A third acquire must not resolve until we release.
         third = asyncio.create_task(sem.acquire())
         try:
-            await asyncio.wait_for(asyncio.shield(third), timeout=0.05)
+            # 0.5s is well above any realistic scheduling delay on CI runners
+            # while still bounding test wall-clock. The saturated case would
+            # block forever without a timeout.
+            await asyncio.wait_for(asyncio.shield(third), timeout=0.5)
         except asyncio.TimeoutError:
             pass  # Expected: the semaphore is saturated.
         else:
@@ -64,6 +67,31 @@ def test_semaphore_limits_concurrent_acquisitions():
         await asyncio.wait_for(third, timeout=0.5)
         sem.release()
         sem.release()
+
+    asyncio.run(scenario())
+
+
+def test_init_async_clears_stale_semaphore_when_disabled():
+    """Re-init after disabling max_concurrent must clear the previously-installed
+    semaphore. Long-lived wrappers reuse Configuration across orgs; a stale
+    semaphore from a prior org would silently keep throttling the next one.
+    """
+
+    async def scenario():
+        cfg = ResourceConfig(base_path="/x", max_concurrent=4)
+        await cfg.init_async()
+        assert isinstance(cfg.async_semaphore, asyncio.Semaphore)
+        # Now flip max_concurrent off and re-init.
+        cfg.max_concurrent = None
+        await cfg.init_async()
+        assert cfg.async_semaphore is None
+        # Same with 0.
+        cfg.max_concurrent = 4
+        await cfg.init_async()
+        assert isinstance(cfg.async_semaphore, asyncio.Semaphore)
+        cfg.max_concurrent = 0
+        await cfg.init_async()
+        assert cfg.async_semaphore is None
 
     asyncio.run(scenario())
 

--- a/tests/unit/test_max_concurrent_semaphore.py
+++ b/tests/unit/test_max_concurrent_semaphore.py
@@ -1,0 +1,88 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+"""Tests for ResourceConfig.max_concurrent per-resource-type semaphore.
+
+Motivating case: HAMR-392 T5 — the destination monitor-create edge/proxy
+returned HTTP 512 when sync-cli's 32-way worker pool queued too many
+concurrent POST/PUT /api/v1/monitor requests. ResourceConfig gains an
+optional per-type semaphore so specific resources can be throttled without
+touching --max-workers globally.
+"""
+
+import asyncio
+
+from datadog_sync.utils.base_resource import ResourceConfig
+
+
+def test_max_concurrent_none_leaves_semaphore_unset():
+    """Default behaviour: no cap installed, no semaphore attribute value."""
+    cfg = ResourceConfig(base_path="/x")
+    assert cfg.max_concurrent is None
+    asyncio.run(cfg.init_async())
+    assert cfg.async_semaphore is None
+
+
+def test_max_concurrent_positive_installs_semaphore_after_init_async():
+    """Positive int installs a Semaphore in init_async (not __post_init__,
+    which runs outside the event loop)."""
+    cfg = ResourceConfig(base_path="/x", max_concurrent=4)
+    assert cfg.async_semaphore is None  # not created eagerly
+    asyncio.run(cfg.init_async())
+    assert isinstance(cfg.async_semaphore, asyncio.Semaphore)
+
+
+def test_max_concurrent_zero_leaves_semaphore_unset():
+    """0 is treated as "no cap" — same as None."""
+    cfg = ResourceConfig(base_path="/x", max_concurrent=0)
+    asyncio.run(cfg.init_async())
+    assert cfg.async_semaphore is None
+
+
+def test_semaphore_limits_concurrent_acquisitions():
+    """Semaphore actually gates the number of concurrent holders."""
+
+    async def scenario():
+        cfg = ResourceConfig(base_path="/x", max_concurrent=2)
+        await cfg.init_async()
+        sem = cfg.async_semaphore
+        # Fill both slots synchronously.
+        await sem.acquire()
+        await sem.acquire()
+        # A third acquire must not resolve until we release.
+        third = asyncio.create_task(sem.acquire())
+        try:
+            await asyncio.wait_for(asyncio.shield(third), timeout=0.05)
+        except asyncio.TimeoutError:
+            pass  # Expected: the semaphore is saturated.
+        else:
+            raise AssertionError("Expected third acquire to block")
+        # Release one slot; third should now resolve.
+        sem.release()
+        await asyncio.wait_for(third, timeout=0.5)
+        sem.release()
+        sem.release()
+
+    asyncio.run(scenario())
+
+
+def test_max_concurrent_and_concurrent_false_coexist():
+    """concurrent=False installs a Lock (serial). max_concurrent still
+    populates a Semaphore, but the apply path picks the lock when
+    concurrent=False (verified in _apply_resource_cb, not here).
+
+    Runs under asyncio.run so the pre-existing eager-Lock creation for the
+    concurrent=False path has a loop to bind to (Python 3.9 behavior).
+    """
+
+    async def scenario():
+        cfg = ResourceConfig(base_path="/x", concurrent=False, max_concurrent=4)
+        # Lock is installed for concurrent=False.
+        assert cfg.async_lock is not None
+        # Semaphore only after init_async.
+        await cfg.init_async()
+        assert isinstance(cfg.async_semaphore, asyncio.Semaphore)
+
+    asyncio.run(scenario())

--- a/tests/unit/test_monitor_error_logging.py
+++ b/tests/unit/test_monitor_error_logging.py
@@ -3,7 +3,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019 Datadog, Inc.
 
-"""Tests for the HAMR-392 monitor error logging + query summarization.
+"""Tests for the monitor error logging + query summarization.
 
 Motivation: when the destination monitor API rejects a create/update, the
 previous behavior logged only the response body (e.g. ``400 Bad Request -
@@ -14,9 +14,13 @@ on 4xx/5xx, that @application.id is preserved through truncation, and that
 successful (2xx) monitors don't emit spurious warnings.
 """
 
-from unittest.mock import MagicMock
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from datadog_sync.model.monitors import _summarize_query_for_log, _log_monitor_http_error
+from datadog_sync.utils.resource_utils import CustomClientHTTPError
 
 
 def _make_err(status_code):
@@ -66,9 +70,25 @@ def test_summarize_long_query_appid_at_start_preserved():
     assert "@application.id:xyz-1" in out
 
 
+def test_summarize_pathological_appid_token_still_bounded():
+    """If the @application.id: value itself is unreasonably long (attacker,
+    malformed, or a future field-shape change), the summarizer must still
+    produce output bounded by the overall cap."""
+    huge_token = "@application.id:" + ("Z" * 5000)
+    q = "prefix " + huge_token + " suffix"
+    out = _summarize_query_for_log(q)
+    # The overall output must be bounded; the exact upper bound is the
+    # length cap plus a small constant for ellipses.
+    assert len(out) <= 2100  # 2000 cap + a few ellipses worth of slack
+    # The token prefix is still visible so operators know what happened.
+    assert "@application.id:" in out
+
+
 def test_log_monitor_http_error_skipped_on_2xx(caplog):
+    caplog.set_level("WARNING", logger="datadog_sync_cli")
     _log_monitor_http_error("42", "create", {"query": "q", "type": "metric alert"}, _make_err(200))
-    assert "monitor create failed" not in caplog.text
+    # Empty caplog.records is the stronger assertion — no warning emitted at all.
+    assert [r for r in caplog.records if r.levelname == "WARNING"] == []
 
 
 def test_log_monitor_http_error_emitted_on_4xx(caplog):
@@ -96,3 +116,57 @@ def test_log_monitor_http_error_emitted_on_5xx(caplog):
     assert "status=512" in caplog.text
     assert "id=85192266" in caplog.text
     assert "'query alert'" in caplog.text
+
+
+def test_summarize_handles_non_string_query_repr():
+    """Formula / multi-query monitors sometimes populate `queries: [...]`
+    instead of a single `query` string. Ensure the summarizer stringifies
+    without exploding.
+    """
+    q = ["query1", "query2 with @application.id:abc-1"]
+    out = _summarize_query_for_log(q)
+    assert out is not None
+    # repr(list) preserves the app.id token as a substring, so the truncation
+    # path can still preserve it (short input here — no truncation triggered).
+    assert "@application.id:abc-1" in out
+
+
+def test_summarize_handles_non_string_query_beyond_cap():
+    """Non-string query that exceeds the cap still gets truncated safely."""
+    q = ["x" * 3000]
+    out = _summarize_query_for_log(q)
+    assert out is not None
+    assert len(out) <= 2000
+
+
+def test_end_to_end_create_error_logs_query(caplog):
+    """Drive create_resource -> destination raise -> _log_monitor_http_error,
+    proving the WARN fires from the real error path, not just from a direct
+    call to the helper."""
+    from datadog_sync.model.monitors import Monitors
+
+    caplog.set_level("WARNING", logger="datadog_sync_cli")
+
+    # Assemble a Monitors instance with a mocked destination client.
+    config = MagicMock()
+    resource = {"query": "rum(\"@application.id:c123c907-abc\").last(\"5m\") > 5", "type": "rum alert"}
+
+    class FakeErrorResp:
+        status = 400
+        message = "Bad Request"
+        headers = {}
+
+    err = CustomClientHTTPError(FakeErrorResp(), message='{"errors":["Invalid query"]}')
+
+    dest_client = MagicMock()
+    dest_client.post = AsyncMock(side_effect=err)
+    config.destination_client = dest_client
+
+    m = Monitors(config)
+
+    with pytest.raises(CustomClientHTTPError):
+        asyncio.run(m.create_resource("mon-1", resource))
+
+    warns = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert any("monitor create failed" in r.getMessage() for r in warns)
+    assert any("@application.id:c123c907-abc" in r.getMessage() for r in warns)

--- a/tests/unit/test_monitor_error_logging.py
+++ b/tests/unit/test_monitor_error_logging.py
@@ -70,6 +70,23 @@ def test_summarize_long_query_appid_at_start_preserved():
     assert "@application.id:xyz-1" in out
 
 
+def test_log_monitor_http_error_falls_back_to_queries_field(caplog):
+    """Formula / multi-query monitors populate `queries: [...]` instead of a
+    single `query` string. The error-logging path must fall back so the
+    outbound payload is still visible for diagnosis."""
+    caplog.set_level("WARNING", logger="datadog_sync_cli")
+    resource = {
+        "type": "query alert",
+        "queries": ['rum("@application.id:abc-def env:prod").last("5m") > 5'],
+    }
+    _log_monitor_http_error("m-multi", "create", resource, _make_err(400))
+    assert "monitor create failed" in caplog.text
+    # The @application.id token from within the queries list survives.
+    assert "@application.id:abc-def" in caplog.text
+    # Not the literal string "None" (would signal the fallback didn't fire).
+    assert "query=None" not in caplog.text
+
+
 def test_summarize_pathological_appid_token_still_bounded():
     """If the @application.id: value itself is unreasonably long (attacker,
     malformed, or a future field-shape change), the summarizer must still

--- a/tests/unit/test_monitor_error_logging.py
+++ b/tests/unit/test_monitor_error_logging.py
@@ -23,9 +23,11 @@ from datadog_sync.model.monitors import _summarize_query_for_log, _log_monitor_h
 from datadog_sync.utils.resource_utils import CustomClientHTTPError
 
 
-def _make_err(status_code):
+def _make_err(status_code, str_value=None):
     err = MagicMock()
     err.status_code = status_code
+    if str_value is not None:
+        err.__str__.return_value = str_value
     return err
 
 
@@ -121,6 +123,7 @@ def test_log_monitor_http_error_emitted_on_4xx(caplog):
     assert "id=142464149" in caplog.text
     assert "'rum alert'" in caplog.text
     assert "@application.id:c123c907-..." in caplog.text
+    assert "reason=" in caplog.text
 
 
 def test_log_monitor_http_error_emitted_on_5xx(caplog):
@@ -133,6 +136,31 @@ def test_log_monitor_http_error_emitted_on_5xx(caplog):
     assert "status=512" in caplog.text
     assert "id=85192266" in caplog.text
     assert "'query alert'" in caplog.text
+    assert "reason=" in caplog.text
+
+
+def test_reason_is_truncated(caplog):
+    """The server's failure reason must be truncated so a huge/pathological
+    response body can't bloat the log line."""
+    caplog.set_level("WARNING", logger="datadog_sync_cli")
+    huge_reason = "x" * 5000
+    resource = {"query": "avg(last_1h):anomalies(...)", "type": "query alert"}
+    _log_monitor_http_error("99", "create", resource, _make_err(400, str_value=huge_reason))
+    assert "monitor create failed" in caplog.text
+    # The far tail of the huge reason must not appear — proves truncation happened.
+    assert huge_reason not in caplog.text
+    assert ("x" * 200) in caplog.text
+    assert ("x" * 201) not in caplog.text
+
+
+def test_empty_or_none_body_does_not_crash(caplog):
+    """An error whose str() is empty must not crash the logging path and the
+    warning must still be emitted."""
+    caplog.set_level("WARNING", logger="datadog_sync_cli")
+    resource = {"query": "avg(last_1h):anomalies(...)", "type": "query alert"}
+    _log_monitor_http_error("100", "create", resource, _make_err(400, str_value=""))
+    assert "monitor create failed" in caplog.text
+    assert "reason=" in caplog.text
 
 
 def test_summarize_handles_non_string_query_repr():

--- a/tests/unit/test_monitor_error_logging.py
+++ b/tests/unit/test_monitor_error_logging.py
@@ -1,0 +1,98 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+"""Tests for the HAMR-392 monitor error logging + query summarization.
+
+Motivation: when the destination monitor API rejects a create/update, the
+previous behavior logged only the response body (e.g. ``400 Bad Request -
+{"errors":["Invalid query: Check for invalid tags or facets in your query."]}``),
+which is impossible to triage without cross-org access to the source monitor
+JSON. These tests verify that the outbound monitor's id/type/query are logged
+on 4xx/5xx, that @application.id is preserved through truncation, and that
+successful (2xx) monitors don't emit spurious warnings.
+"""
+
+from unittest.mock import MagicMock
+
+from datadog_sync.model.monitors import _summarize_query_for_log, _log_monitor_http_error
+
+
+def _make_err(status_code):
+    err = MagicMock()
+    err.status_code = status_code
+    return err
+
+
+def test_summarize_short_query_returned_unchanged():
+    q = 'rum("@application.id:abc-123 env:prod").last("5m") > 5'
+    assert _summarize_query_for_log(q) == q
+
+
+def test_summarize_none_returned_none():
+    assert _summarize_query_for_log(None) is None
+
+
+def test_summarize_long_query_without_appid_is_head_truncated():
+    q = "x" * 5000
+    out = _summarize_query_for_log(q)
+    assert out.endswith("...")
+    assert len(out) == 2000
+    assert out[:5] == "xxxxx"
+
+
+def test_summarize_long_query_with_appid_preserves_token():
+    """@application.id must survive the truncation window."""
+    padding_left = "A" * 4000
+    padding_right = "B" * 4000
+    q = padding_left + " @application.id:c123c907-c2bd-4421-92dd-e0720bd7f14b " + padding_right
+    out = _summarize_query_for_log(q)
+    assert "@application.id:c123c907-c2bd-4421-92dd-e0720bd7f14b" in out
+    # The output is roughly bounded by the max plus ellipses; the important
+    # invariant is that we didn't drop the token.
+    assert out.count("...") >= 1
+
+
+def test_summarize_long_query_appid_at_end_preserved():
+    q = ("x" * 3000) + " @application.id:abc-999"
+    out = _summarize_query_for_log(q)
+    assert "@application.id:abc-999" in out
+
+
+def test_summarize_long_query_appid_at_start_preserved():
+    q = "@application.id:xyz-1 " + ("y" * 3000)
+    out = _summarize_query_for_log(q)
+    assert "@application.id:xyz-1" in out
+
+
+def test_log_monitor_http_error_skipped_on_2xx(caplog):
+    _log_monitor_http_error("42", "create", {"query": "q", "type": "metric alert"}, _make_err(200))
+    assert "monitor create failed" not in caplog.text
+
+
+def test_log_monitor_http_error_emitted_on_4xx(caplog):
+    """4xx must emit a WARNING with the outbound identifiers."""
+    caplog.set_level("WARNING", logger="datadog_sync_cli")
+    resource = {
+        "query": 'rum("@application.id:c123c907-... env:prod").last("5m") > 5',
+        "type": "rum alert",
+    }
+    _log_monitor_http_error("142464149", "create", resource, _make_err(400))
+    assert "monitor create failed" in caplog.text
+    assert "status=400" in caplog.text
+    assert "id=142464149" in caplog.text
+    assert "'rum alert'" in caplog.text
+    assert "@application.id:c123c907-..." in caplog.text
+
+
+def test_log_monitor_http_error_emitted_on_5xx(caplog):
+    """5xx (e.g. 512) must also emit; type + query length are diagnostic for
+    the overload class of failure."""
+    caplog.set_level("WARNING", logger="datadog_sync_cli")
+    resource = {"query": "avg(last_1h):anomalies(...)", "type": "query alert"}
+    _log_monitor_http_error("85192266", "update", resource, _make_err(512))
+    assert "monitor update failed" in caplog.text
+    assert "status=512" in caplog.text
+    assert "id=85192266" in caplog.text
+    assert "'query alert'" in caplog.text

--- a/tests/unit/test_overload_backoff.py
+++ b/tests/unit/test_overload_backoff.py
@@ -13,6 +13,8 @@ queue as fast as the proxy could drain it. These tests verify the new
 _OVERLOAD_STATUSES class uses a longer schedule and honors Retry-After.
 """
 
+import pytest
+
 from datadog_sync.utils.custom_client import (
     _OVERLOAD_BACKOFF_SCHEDULE,
     _OVERLOAD_STATUSES,
@@ -91,3 +93,142 @@ def test_custom_client_has_overload_counter():
     client.overload_status_counter[502] += 1
     assert client.overload_status_counter[512] == 2
     assert client.overload_status_counter[502] == 1
+
+
+def test_all_backoff_buckets_reachable_with_large_budget():
+    """Codex-flagged concern: prior guard `retry_count + 1 >= max_retries`
+    made the 120s bucket unreachable. Verify all three buckets get consumed
+    when retry_timeout is large enough.
+    """
+    import asyncio
+    from unittest.mock import MagicMock
+
+    from datadog_sync.utils.custom_client import request_with_retry
+    from datadog_sync.utils.resource_utils import CustomClientHTTPError
+
+    class FakeClient:
+        def __init__(self, retry_timeout):
+            self.retry_timeout = retry_timeout
+            from collections import Counter as _C
+            self.overload_status_counter = _C()
+
+    slept_durations = []
+
+    async def fake_sleep(dur):
+        slept_durations.append(dur)
+        # No actual sleep — we just record the schedule.
+
+    class Resp:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def text(self):
+            return "server overloaded"
+
+        def raise_for_status(self):
+            import aiohttp
+
+            raise aiohttp.ClientResponseError(
+                request_info=MagicMock(), history=(), status=503, message="Overload", headers={}
+            )
+
+    async def stub_request(client, *args, **kwargs):
+        return Resp()
+
+    decorated = request_with_retry(stub_request)
+
+    import datadog_sync.utils.custom_client as cc_module
+
+    orig = cc_module.asyncio.sleep
+    cc_module.asyncio.sleep = fake_sleep
+    try:
+        # Large retry_timeout so the budget guard doesn't fire.
+        with pytest.raises(CustomClientHTTPError):
+            asyncio.run(decorated(FakeClient(retry_timeout=10000)))
+    finally:
+        cc_module.asyncio.sleep = orig
+
+    # All three schedule buckets should have been slept before the final give-up.
+    assert slept_durations == list(_OVERLOAD_BACKOFF_SCHEDULE), (
+        f"Expected schedule {_OVERLOAD_BACKOFF_SCHEDULE} but slept {slept_durations}"
+    )
+
+
+def test_end_to_end_overload_budget_guard():
+    """Full request_with_retry loop against a 512-only server. Verifies:
+      - each retry counts down the retry_timeout total budget,
+      - when the next-computed sleep_duration would exceed the budget,
+        the loop raises CustomClientHTTPError instead of sleeping past it.
+    """
+    import asyncio
+    import time
+    from unittest.mock import MagicMock
+
+    from datadog_sync.utils.custom_client import request_with_retry
+    from datadog_sync.utils.resource_utils import CustomClientHTTPError
+
+    # Fake client that has just enough state for request_with_retry.
+    class FakeClient:
+        def __init__(self, retry_timeout):
+            self.retry_timeout = retry_timeout
+            from collections import Counter as _C
+            self.overload_status_counter = _C()
+
+    class Resp:
+        def __init__(self):
+            self.status = 512
+            self.headers = {}
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def text(self):
+            return "server overloaded"
+
+        def raise_for_status(self):
+            import aiohttp
+
+            resp = MagicMock()
+            resp.status = 512
+            raise aiohttp.ClientResponseError(
+                request_info=MagicMock(), history=(), status=512, message="Timeout", headers={}
+            )
+
+    async def stub_request(client, *args, **kwargs):
+        return Resp()
+
+    decorated = request_with_retry(stub_request)
+
+    async def run():
+        client = FakeClient(retry_timeout=45)  # ~1.5x first bucket
+        started = time.time()
+        with pytest.raises(CustomClientHTTPError):
+            await decorated(client)
+        # We may have slept once (30s bucket) but MUST NOT have slept past the budget.
+        # Test-mode: we avoid real 30s sleep by patching asyncio.sleep below.
+        return started, client
+
+    # Patch asyncio.sleep to no-op so this test runs in ms, not minutes,
+    # while the budget arithmetic still uses real time.time() comparisons.
+    real_sleep = asyncio.sleep
+
+    async def fast_sleep(_):
+        await real_sleep(0)
+
+    import datadog_sync.utils.custom_client as cc_module
+
+    orig = cc_module.asyncio.sleep
+    cc_module.asyncio.sleep = fast_sleep
+    try:
+        started, client = asyncio.run(run())
+    finally:
+        cc_module.asyncio.sleep = orig
+
+    # Counter incremented at least once for 512 (proves the branch was taken).
+    assert client.overload_status_counter[512] >= 1

--- a/tests/unit/test_overload_backoff.py
+++ b/tests/unit/test_overload_backoff.py
@@ -1,0 +1,93 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+"""Tests for the HAMR-392 overload-status backoff + counter.
+
+Motivating case: the destination monitor API's edge/proxy returns HTTP 512
+when the request-queue budget is exceeded (44 batch-summary lines observed on
+Allstate at 32-way sync-cli parallelism). The previous behavior retried with
+a ``retry_count * 5s`` schedule (0, 5, 10, 15s), which refilled the proxy
+queue as fast as the proxy could drain it. These tests verify the new
+_OVERLOAD_STATUSES class uses a longer schedule and honors Retry-After.
+"""
+
+from datadog_sync.utils.custom_client import (
+    _OVERLOAD_BACKOFF_SCHEDULE,
+    _OVERLOAD_STATUSES,
+    _overload_sleep_duration,
+)
+
+
+def test_overload_statuses_covers_proxy_class():
+    """The four codes we've seen emitted by edge proxies on queue overflow."""
+    assert 502 in _OVERLOAD_STATUSES
+    assert 503 in _OVERLOAD_STATUSES
+    assert 504 in _OVERLOAD_STATUSES
+    assert 512 in _OVERLOAD_STATUSES
+
+
+def test_overload_statuses_does_not_shadow_429():
+    """429 has its own retry path (x-ratelimit-reset) and must not be
+    reclassified as overload."""
+    assert 429 not in _OVERLOAD_STATUSES
+
+
+def test_backoff_schedule_monotonic():
+    """Each retry waits at least as long as the previous one."""
+    for i in range(1, len(_OVERLOAD_BACKOFF_SCHEDULE)):
+        assert _OVERLOAD_BACKOFF_SCHEDULE[i] >= _OVERLOAD_BACKOFF_SCHEDULE[i - 1]
+
+
+def test_backoff_schedule_starts_meaningfully_higher_than_prior():
+    """The whole point of the change is to space retries. The first retry
+    must wait strictly longer than the pre-change 5s baseline."""
+    assert _OVERLOAD_BACKOFF_SCHEDULE[0] >= 30
+
+
+def test_sleep_duration_uses_schedule_when_no_retry_after():
+    assert _overload_sleep_duration(0, None) == _OVERLOAD_BACKOFF_SCHEDULE[0]
+    assert _overload_sleep_duration(1, None) == _OVERLOAD_BACKOFF_SCHEDULE[1]
+
+
+def test_sleep_duration_clamps_at_last_bucket():
+    """retry_count above the schedule length falls back to the final value,
+    not IndexError."""
+    over = len(_OVERLOAD_BACKOFF_SCHEDULE) + 5
+    assert _overload_sleep_duration(over, None) == _OVERLOAD_BACKOFF_SCHEDULE[-1]
+
+
+def test_sleep_duration_honors_retry_after_seconds():
+    """Retry-After (RFC 7231 seconds form) wins over the schedule."""
+    assert _overload_sleep_duration(0, "45") == 45
+
+
+def test_sleep_duration_ignores_non_integer_retry_after():
+    """Retry-After HTTP-date form is not supported; we fall back to schedule."""
+    assert _overload_sleep_duration(0, "Wed, 21 Oct 2015 07:28:00 GMT") == _OVERLOAD_BACKOFF_SCHEDULE[0]
+
+
+def test_sleep_duration_ignores_negative_retry_after():
+    """A negative Retry-After is nonsensical; clamp to 0 not negative sleep."""
+    assert _overload_sleep_duration(0, "-5") == 0
+
+
+def test_custom_client_has_overload_counter():
+    """The counter is exposed for follow-up metric emission."""
+    from datadog_sync.utils.custom_client import CustomClient
+
+    client = CustomClient(
+        host="https://api.datadoghq.com",
+        auth={"apiKeyAuth": "k", "appKeyAuth": "a"},
+        retry_timeout=60,
+        timeout=30,
+        send_metrics=False,
+    )
+    # Empty at construction; is a Counter so numeric ops work.
+    assert client.overload_status_counter[512] == 0
+    client.overload_status_counter[512] += 1
+    client.overload_status_counter[512] += 1
+    client.overload_status_counter[502] += 1
+    assert client.overload_status_counter[512] == 2
+    assert client.overload_status_counter[502] == 1

--- a/tests/unit/test_overload_backoff.py
+++ b/tests/unit/test_overload_backoff.py
@@ -65,9 +65,29 @@ def test_sleep_duration_honors_retry_after_seconds():
     assert _overload_sleep_duration(0, "45") == 45
 
 
-def test_sleep_duration_ignores_non_integer_retry_after():
-    """Retry-After HTTP-date form is not supported; we fall back to schedule."""
-    assert _overload_sleep_duration(0, "Wed, 21 Oct 2015 07:28:00 GMT") == _OVERLOAD_BACKOFF_SCHEDULE[0]
+def test_sleep_duration_honors_http_date_retry_after_future():
+    """Retry-After can also be an HTTP-date (RFC 7231). Verify a future date
+    is interpreted as seconds-until-then, not silently ignored."""
+    from datetime import datetime, timedelta, timezone
+    from email.utils import format_datetime
+
+    future = datetime.now(timezone.utc) + timedelta(seconds=45)
+    http_date = format_datetime(future, usegmt=True)
+    # Allow +/- a few seconds of scheduling slack.
+    got = _overload_sleep_duration(0, http_date)
+    assert 40 <= got <= 50, f"expected ~45s, got {got}s from {http_date!r}"
+
+
+def test_sleep_duration_http_date_in_past_clamped_to_zero():
+    """A past HTTP-date is nonsensical (the retry window has already elapsed);
+    clamp to 0 rather than falling back to the schedule or returning negative."""
+    assert _overload_sleep_duration(0, "Wed, 21 Oct 2015 07:28:00 GMT") == 0
+
+
+def test_sleep_duration_ignores_malformed_retry_after():
+    """Malformed values (not numeric and not a parseable date) fall back to
+    the fixed schedule."""
+    assert _overload_sleep_duration(0, "not-a-real-value") == _OVERLOAD_BACKOFF_SCHEDULE[0]
 
 
 def test_sleep_duration_ignores_negative_retry_after():


### PR DESCRIPTION
## Summary

Three related changes to make monitor sync more resilient when the destination monitor API is under load, and to make failures easier to diagnose from logs alone.

### 1. `ResourceConfig.max_concurrent` — general per-resource-type concurrency cap

New optional field on `ResourceConfig`. When set to a positive int N, installs an `asyncio.Semaphore` that limits `_apply_resource_cb` to at most N in-flight creates/updates of that resource type — independent of the global `--max-workers`. Left unset by default on every resource; callers opt in per-resource-type when they need tighter throttling than the global worker pool provides.

Motivating shape: at high `--max-workers` values, the monitor endpoint can be hit hard enough that the destination's edge/proxy layer starts terminating connections before the app finishes responding. A per-resource-type cap lets an operator throttle just monitors (or dashboards, or whichever endpoint they observe struggling) without slowing the whole sync.

### 2. HTTP `_OVERLOAD_STATUSES` retry backoff in `custom_client.request_with_retry`

For HTTP 502 / 503 / 504 / 512, retries now use a **30s / 60s / 120s** schedule and honor `Retry-After` when the server sends one. Previously these codes went through the generic `retry_count * 5s` schedule (0 / 5 / 10 / 15s), which is too tight to let an overloaded upstream drain — retries refill the queue as fast as it clears.

`429` keeps its existing dedicated `x-ratelimit-reset` path. The `retry_timeout` total budget still applies. `CustomClient.overload_status_counter` is exposed so callers can emit a metric on these retry classes if they want long-term dashboarding.

### 3. Structured error log on monitor create/update failures

`monitors.py` now emits a `WARNING` on any 4xx / 5xx `create_resource` / `update_resource` failure containing:

- monitor `id`
- monitor `type` (metric alert / rum alert / query alert / etc.)
- outbound `query` string, truncated at 2000 chars with any `@application.id:` token preserved inline

Previously only the destination's response body was logged (e.g. `400 Bad Request - {"errors":["Invalid query: Check for invalid tags or facets in your query."]}`), which doesn't identify WHICH monitor query the validator rejected. The new log line lets an operator jump straight from the failure to the offending query without cross-referencing source-org state.

## No behavior change for callers that

- don't set `max_concurrent` on any resource, AND
- don't hit HTTP `{502, 503, 504, 512}`

Monitor error logging is additive (WARN-level, doesn't change return values or retry behavior).

## Test plan

- [x] `pytest tests/unit/` — 781 passing (757 pre-existing + 24 new).
- [x] New test files: `test_max_concurrent_semaphore.py`, `test_overload_backoff.py`, `test_monitor_error_logging.py`.
- [ ] Integration cassette re-record if needed.