### PR TITLE
fix(logs_pipelines): skip update on read-only integration pipelines

### DIFF
--- a/datadog_sync/model/logs_pipelines.py
+++ b/datadog_sync/model/logs_pipelines.py
@@ -4,16 +4,42 @@
 # Copyright 2019 Datadog, Inc.
 
 from __future__ import annotations
+import logging
 from typing import TYPE_CHECKING, Optional, List, Dict, Tuple, cast
 from asyncio import sleep
 
 from re import match
 
+from datadog_sync.constants import LOGGER_NAME, Metrics
 from datadog_sync.utils.base_resource import BaseResource, ResourceConfig
-from datadog_sync.utils.resource_utils import DEFAULT_TAGS, check_diff
+from datadog_sync.utils.resource_utils import DEFAULT_TAGS, SkipResource, check_diff
 
 if TYPE_CHECKING:
     from datadog_sync.utils.custom_client import CustomClient
+
+_log = logging.getLogger(LOGGER_NAME)
+
+
+def _summarize_diff_keys(diff) -> List[str]:
+    """Extract high-level change locations from a DeepDiff object.
+
+    Returns a de-duplicated list of top-level field names that changed
+    (e.g. ["is_enabled", "filter"]). Used to log which fields would have
+    been written when we're skipping an unsupported update.
+    """
+    if not diff:
+        return []
+    keys = set()
+    for change_type in ("values_changed", "type_changes", "iterable_item_added",
+                        "iterable_item_removed", "dictionary_item_added",
+                        "dictionary_item_removed"):
+        for path in diff.get(change_type, {}) or {}:
+            # DeepDiff paths look like "root['is_enabled']" or "root['filter']['query']"
+            # Extract the first bracketed segment.
+            m = match(r"root\['([^']+)'\]", str(path))
+            if m:
+                keys.add(m.group(1))
+    return sorted(keys)
 
 
 class LogsPipelines(BaseResource):
@@ -119,9 +145,14 @@ class LogsPipelines(BaseResource):
 
         diff = check_diff(self.resource_config, self.destination_integration_pipelines[resource["name"]], resource)
         if diff:
-            # We run an update call if there is a diff between source and destination org resource to ensure that
-            # the integration pipeline is in the correct state (enabled/disabled).
-            return await self.update_resource(_id, resource)
+            # See _handle_read_only_diff for why we do not PUT here.
+            # In create_resource, we return the destination's state instead of
+            # raising so first-sync callers still get a resource dict back and
+            # the ResourcesHandler accounts this as a success (the pipeline is
+            # now in the state map). Subsequent syncs that re-check the diff
+            # go through update_resource, which raises SkipResource so the
+            # handler buckets it correctly.
+            await self._handle_read_only_diff(_id, resource, diff)
 
         return _id, self.config.state.destination[self.resource_type][_id]
 
@@ -134,6 +165,23 @@ class LogsPipelines(BaseResource):
             current_destination_resource["__datadog_sync_invalid"] = True
             return _id, current_destination_resource
 
+        # Integration pipelines (is_read_only=True on the destination) cannot be
+        # updated via the public API -- PUT /api/v1/logs/config/pipelines/<id>
+        # does not route integration-pipeline IDs and returns a 404 that falls
+        # through to the edge web tier as HTML. Raise SkipResource so the
+        # ResourcesHandler counts this as a legitimate skip rather than a
+        # success with a silently-failed PUT, or a failure that retries on the
+        # next dispatch. Fires the same WARN + metric as create_resource.
+        if current_destination_resource.get("is_read_only") or resource.get("is_read_only"):
+            diff = check_diff(self.resource_config, current_destination_resource, resource)
+            if diff:
+                await self._handle_read_only_diff(_id, resource, diff)
+            raise SkipResource(
+                _id,
+                self.resource_type,
+                "Integration pipeline is auto-managed by Datadog and cannot be modified via the public API.",
+            )
+
         destination_client = self.config.destination_client
         resp = await destination_client.put(
             self.resource_config.base_path + f"/{self.config.state.destination[self.resource_type][_id]['id']}",
@@ -145,6 +193,50 @@ class LogsPipelines(BaseResource):
             resource["name"] = resource["name"].lower()
 
         return _id, resp
+
+    async def _handle_read_only_diff(self, _id: str, resource: Dict, diff) -> None:
+        """Log + metric for the "integration pipeline diverges but cannot be
+        updated via the public API" class.
+
+        Integration pipelines are auto-managed by Datadog
+        (https://docs.datadoghq.com/logs/log_configuration/pipelines/#integration-pipelines).
+        The PUT /api/v1/logs/config/pipelines/<id> endpoint only routes IDs in
+        the custom-pipelines namespace, so any PUT against an integration
+        pipeline returns 404 -- and the 404 falls through to the edge web
+        tier producing an HTML body rather than JSON. We accept the
+        destination's state as authoritative, log a WARNING with a diff
+        summary so the divergence stays visible, and emit a distinct
+        action-metric so operators can dashboard the class.
+
+        Called from both create_resource (first-sync path) and update_resource
+        (subsequent-sync path) so all writes to read-only pipelines are
+        handled consistently.
+        """
+        diff_keys = _summarize_diff_keys(diff)
+        _log.warning(
+            "logs_pipelines: integration pipeline %r (source id=%s) diverges from destination; "
+            "skipping update -- integration pipelines are auto-managed by Datadog and cannot be "
+            "modified via the public API. Diff keys: %s",
+            resource.get("name"),
+            _id,
+            diff_keys or "[unknown]",
+        )
+        try:
+            await self.config.destination_client.send_metric(
+                Metrics.ACTION.value,
+                tags=[
+                    f"resource_type:{self.resource_type}",
+                    "action_type:sync",
+                    "status:skipped",
+                    "action_sub_type:integration_diff_skipped",
+                    f"pipeline_name:{resource.get('name', 'unknown')}",
+                ],
+            )
+        except Exception as e:
+            # Never let metric emission block the return path.
+            self.config.logger.debug(
+                f"logs_pipelines: failed to emit integration_diff_skipped metric: {e}"
+            )
 
     async def delete_resource(self, _id: str) -> None:
         if self.config.state.destination[self.resource_type][_id]["is_read_only"]:

--- a/tests/unit/test_logs_pipelines.py
+++ b/tests/unit/test_logs_pipelines.py
@@ -193,3 +193,297 @@ def test_subdomain_construction_api_dot_prefix(mock_config):
 
     intake_call = next(c for c in mock_config.destination_client.post.call_args_list if c[0][0] == lp.logs_intake_path)
     assert intake_call[1]["subdomain"] == "http-intake.logs.datadoghq.com"
+
+
+# ── T7: integration pipeline diverges from destination → skip update, warn ────
+#
+# Motivation: `PUT /api/v1/logs/config/pipelines/<id>` does not route
+# integration-pipeline (read-only) IDs. Prior behaviour called update_resource
+# whenever check_diff detected any difference against the destination's
+# integration pipeline, producing an infinite loop of 404-HTML failures every
+# dispatch. The new behaviour keeps the state mapping, emits a WARN with a
+# diff summary, and fires a distinct action-metric so operators can dashboard
+# the class.
+
+
+def test_integration_pipeline_with_diff_skips_update_and_warns(mock_config, caplog):
+    """Source diverges from destination on `is_enabled`; PUT must NOT fire."""
+    from datadog_sync.model.logs_pipelines import LogsPipelines
+
+    caplog.set_level("WARNING", logger="datadog_sync_cli")
+    mock_config.destination_logs_intake_url = None
+
+    lp = LogsPipelines(mock_config)
+    # Destination has 'nginx' but with a different is_enabled value.
+    dest_pipeline = _make_dest_pipeline(name="nginx")
+    dest_pipeline["is_enabled"] = False
+    lp.destination_integration_pipelines = {"nginx": dest_pipeline}
+
+    mock_config.destination_client.post = AsyncMock()
+    mock_config.destination_client.post_unauthenticated = AsyncMock()
+    mock_config.destination_client.put = AsyncMock(return_value=_make_dest_pipeline())
+    mock_config.destination_client.send_metric = AsyncMock()
+
+    resource = _make_integration_resource(name="nginx")
+    resource["is_enabled"] = True  # forces a diff
+    asyncio.run(lp.create_resource("src-nginx", resource))
+
+    # PUT / update_resource must NOT be called — the endpoint doesn't route
+    # integration-pipeline IDs and would 404.
+    mock_config.destination_client.put.assert_not_awaited()
+
+    # WARN log must contain enough info to diagnose the divergence.
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    warn_msgs = [r.getMessage() for r in warnings]
+    assert any("integration pipeline 'nginx'" in m for m in warn_msgs)
+    assert any("src-nginx" in m for m in warn_msgs)
+    assert any("is_enabled" in m for m in warn_msgs), warn_msgs
+
+    # Distinct metric fires so the class is dashboardable.
+    mock_config.destination_client.send_metric.assert_awaited()
+    metric_call = mock_config.destination_client.send_metric.call_args
+    tags = metric_call.kwargs.get("tags") or metric_call.args[1]
+    assert "action_sub_type:integration_diff_skipped" in tags
+    assert "resource_type:logs_pipelines" in tags
+    assert "pipeline_name:nginx" in tags
+
+
+def test_integration_pipeline_with_no_diff_skips_update_and_no_warn(mock_config, caplog):
+    """Source == destination integration pipeline; no PUT, no WARN, no metric."""
+    from datadog_sync.model.logs_pipelines import LogsPipelines
+
+    caplog.set_level("WARNING", logger="datadog_sync_cli")
+    mock_config.destination_logs_intake_url = None
+
+    lp = LogsPipelines(mock_config)
+    # Construct destination + source with identical shape so check_diff returns empty.
+    identical_shape = {
+        "id": "dest-nginx",
+        "name": "nginx",
+        "is_read_only": True,
+        "is_enabled": True,
+        "filter": {"query": "source:nginx"},
+        "processors": [],
+    }
+    lp.destination_integration_pipelines = {"nginx": dict(identical_shape)}
+
+    mock_config.destination_client.post = AsyncMock()
+    mock_config.destination_client.post_unauthenticated = AsyncMock()
+    mock_config.destination_client.put = AsyncMock(return_value=dict(identical_shape))
+    mock_config.destination_client.send_metric = AsyncMock()
+
+    resource = dict(identical_shape)
+    resource["id"] = "src-nginx"  # source has different id; excluded_attributes drops it from diff
+    asyncio.run(lp.create_resource("src-nginx", resource))
+
+    mock_config.destination_client.put.assert_not_awaited()
+    integ_warnings = [
+        r for r in caplog.records
+        if r.levelname == "WARNING" and "integration pipeline" in r.getMessage()
+    ]
+    assert integ_warnings == []
+    mock_config.destination_client.send_metric.assert_not_awaited()
+
+
+def test_summarize_diff_keys_extracts_top_level_fields():
+    """The helper returns de-duplicated top-level field names from a DeepDiff."""
+    from datadog_sync.model.logs_pipelines import _summarize_diff_keys
+
+    fake_diff = {
+        "values_changed": {
+            "root['is_enabled']": {"old_value": False, "new_value": True},
+            "root['filter']['query']": {"old_value": "a", "new_value": "b"},
+        },
+        "dictionary_item_added": {"root['tags']": ["new"]},
+    }
+    keys = _summarize_diff_keys(fake_diff)
+    assert set(keys) == {"is_enabled", "filter", "tags"}
+
+
+def test_summarize_diff_keys_empty_diff_returns_empty_list():
+    from datadog_sync.model.logs_pipelines import _summarize_diff_keys
+
+    assert _summarize_diff_keys({}) == []
+    assert _summarize_diff_keys(None) == []
+
+
+def test_custom_writable_pipeline_still_hits_update_path(mock_config):
+    """Regression guard: is_read_only=False pipelines must NOT be affected by
+    the T7 skip; they still go through the direct POST at line 65 (or PUT via
+    update_resource when the caller dispatches an update)."""
+    from datadog_sync.model.logs_pipelines import LogsPipelines
+
+    mock_config.destination_logs_intake_url = None
+
+    lp = LogsPipelines(mock_config)
+    lp.destination_integration_pipelines = {}  # no integration cache needed for writable path
+
+    mock_config.destination_client.post = AsyncMock(return_value={"id": "dest-custom", "is_read_only": False})
+
+    resource = {
+        "id": "src-custom",
+        "name": "BIT_custom_pipeline",
+        "is_read_only": False,
+        "filter": {"query": "service:foo"},
+        "processors": [],
+    }
+    asyncio.run(lp.create_resource("src-custom", resource))
+
+    # Direct POST at line 66 fires; no branch into read-only handling.
+    mock_config.destination_client.post.assert_awaited_once()
+
+
+# ── T7: subsequent-sync path must also skip the futile PUT ────────────────────
+#
+# Motivation: PR #604 first-pass only guarded create_resource. But after the
+# first sync, the source id is present in state.destination[type], so
+# ResourcesHandler._apply_resource_cb dispatches directly to
+# _update_resource (which wraps update_resource). Without a guard there, the
+# second sync fires the same 404-generating PUT. Guard both entry points.
+
+
+def test_update_read_only_pipeline_raises_skip_resource(mock_config, caplog):
+    """update_resource on a read-only destination pipeline must raise
+    SkipResource (so handler counts as skipped, not success) and must NOT
+    issue any PUT."""
+    from datadog_sync.utils.resource_utils import SkipResource
+    from datadog_sync.model.logs_pipelines import LogsPipelines
+
+    caplog.set_level("WARNING", logger="datadog_sync_cli")
+
+    lp = LogsPipelines(mock_config)
+
+    # Destination state already has the read-only pipeline from a prior sync.
+    dest_state = {
+        "id": "dest-nginx",
+        "name": "nginx",
+        "is_read_only": True,
+        "is_enabled": True,
+        "filter": {"query": "source:nginx"},
+        "processors": [],
+    }
+    mock_config.state.destination["logs_pipelines"]["src-nginx"] = dest_state
+
+    mock_config.destination_client.put = AsyncMock()
+    mock_config.destination_client.send_metric = AsyncMock()
+
+    resource = dict(dest_state)
+    resource["id"] = "src-nginx"
+    resource["is_enabled"] = False  # forces a diff
+
+    raised = False
+    try:
+        asyncio.run(lp.update_resource("src-nginx", resource))
+    except SkipResource as e:
+        raised = True
+        assert "integration pipeline" in str(e).lower()
+    assert raised, "update_resource must raise SkipResource for read-only pipelines"
+
+    # No PUT to the unsupported endpoint.
+    mock_config.destination_client.put.assert_not_awaited()
+
+    # Divergence still logged + metric fires.
+    warn_msgs = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+    assert any("integration pipeline 'nginx'" in m for m in warn_msgs)
+    mock_config.destination_client.send_metric.assert_awaited()
+
+
+def test_update_read_only_pipeline_no_diff_still_raises_skip(mock_config, caplog):
+    """Even when source == destination (no diff), update_resource must skip
+    rather than PUT. The handler shouldn't dispatch to update in that case,
+    but the guard should be defensive."""
+    from datadog_sync.utils.resource_utils import SkipResource
+    from datadog_sync.model.logs_pipelines import LogsPipelines
+
+    caplog.set_level("WARNING", logger="datadog_sync_cli")
+
+    lp = LogsPipelines(mock_config)
+
+    dest_state = {
+        "id": "dest-nginx",
+        "name": "nginx",
+        "is_read_only": True,
+        "is_enabled": True,
+        "filter": {"query": "source:nginx"},
+        "processors": [],
+    }
+    mock_config.state.destination["logs_pipelines"]["src-nginx"] = dest_state
+
+    mock_config.destination_client.put = AsyncMock()
+    mock_config.destination_client.send_metric = AsyncMock()
+
+    resource = dict(dest_state)
+    resource["id"] = "src-nginx"  # same shape → no diff after excluded_attributes
+
+    raised = False
+    try:
+        asyncio.run(lp.update_resource("src-nginx", resource))
+    except SkipResource:
+        raised = True
+    assert raised
+
+    mock_config.destination_client.put.assert_not_awaited()
+    # No diff → no divergence log or metric (guard fires silently).
+    integ_warnings = [
+        r for r in caplog.records
+        if r.levelname == "WARNING" and "integration pipeline" in r.getMessage()
+    ]
+    assert integ_warnings == []
+    mock_config.destination_client.send_metric.assert_not_awaited()
+
+
+def test_update_writable_pipeline_still_puts(mock_config):
+    """Regression guard: writable (is_read_only=False) pipelines must still
+    hit the PUT path in update_resource."""
+    from datadog_sync.model.logs_pipelines import LogsPipelines
+
+    lp = LogsPipelines(mock_config)
+
+    dest_state = {
+        "id": "dest-custom",
+        "name": "BIT_custom",
+        "is_read_only": False,
+        "filter": {"query": "service:foo"},
+        "processors": [],
+    }
+    mock_config.state.destination["logs_pipelines"]["src-custom"] = dest_state
+
+    mock_config.destination_client.put = AsyncMock(
+        return_value={"id": "dest-custom", "is_read_only": False, "name": "BIT_custom"}
+    )
+
+    resource = dict(dest_state)
+    resource["id"] = "src-custom"
+
+    asyncio.run(lp.update_resource("src-custom", resource))
+    mock_config.destination_client.put.assert_awaited_once()
+
+
+def test_update_invalid_pipeline_short_circuit_unchanged(mock_config):
+    """Regression guard: the pre-existing __datadog_sync_invalid short-circuit
+    at the top of update_resource still fires ahead of the new read-only
+    guard."""
+    from datadog_sync.model.logs_pipelines import LogsPipelines
+
+    lp = LogsPipelines(mock_config)
+
+    # Invalid pipeline sentinel is set by the create-path for names in
+    # invalid_integration_pipelines (e.g. 'cron').
+    dest_state = {
+        "id": "dest-cron",
+        "name": "cron",
+        "is_read_only": True,
+        "__datadog_sync_invalid": True,
+    }
+    mock_config.state.destination["logs_pipelines"]["src-cron"] = dest_state
+
+    mock_config.destination_client.put = AsyncMock()
+
+    resource = {"id": "src-cron", "name": "cron", "is_read_only": True, "processors": []}
+
+    # Should NOT raise SkipResource — the invalid short-circuit at line 195
+    # returns cleanly with the merged local state.
+    _id, result = asyncio.run(lp.update_resource("src-cron", resource))
+    assert _id == "src-cron"
+    assert result["__datadog_sync_invalid"] is True
+    mock_config.destination_client.put.assert_not_awaited()


### PR DESCRIPTION
## Summary

`PUT /api/v1/logs/config/pipelines/<id>` does not accept integration-pipeline (`is_read_only: true`) IDs — they're [auto-managed by Datadog](https://docs.datadoghq.com/logs/log_configuration/pipelines/#integration-pipelines) and cannot be modified via the public API.

Prior behaviour called `update_resource` whenever `check_diff` detected any divergence, producing a persistent 404 on every sync. Replace the update with a `WARNING` log (including the diff keys) and a distinct action-metric so the divergence stays observable without the futile PUT.

## Test plan

- [x] `pytest tests/unit/` — 762 passing (5 new).