### PR TITLE
fix(roles): surface source ids on sync failure + paginated-list truncation

### DIFF
--- a/datadog_sync/model/roles.py
+++ b/datadog_sync/model/roles.py
@@ -147,10 +147,28 @@ class Roles(BaseResource):
                                 retry_count += 1
                                 continue  # Retry with the updated resource
 
-                    # If we couldn't handle the error, re-raise it
+                    # If we couldn't handle the error, log the specific
+                    # source id + name so downstream resource types can
+                    # correlate cascade failures via the apply-summary,
+                    # then re-raise.
+                    self.config.logger.error(
+                        "role sync failed for source id=%s name=%r status=%s: %s",
+                        _id,
+                        role_name,
+                        getattr(e, "status_code", "?"),
+                        e,
+                    )
                     raise
 
-            # If we exhausted retries, raise an error
+            # If we exhausted the permission-retry budget, raise an error.
+            # max_retries is a cap on distinct permission-removals (1 + len
+            # of allow_partial_permissions_roles), not an attempt count.
+            self.config.logger.error(
+                "role sync exhausted permission-retry budget (%d) for source id=%s name=%r",
+                max_retries,
+                _id,
+                role_name,
+            )
             raise Exception(f"Exceeded maximum retries ({max_retries}) while creating role '{role_name}'")
 
         # role already exists at the destination
@@ -227,10 +245,26 @@ class Roles(BaseResource):
                             retry_count += 1
                             continue  # Retry with the updated resource
 
-                # If we couldn't handle the error, re-raise it
+                # If we couldn't handle the error, log the specific source
+                # id + name so downstream cascade tracking is possible, then
+                # re-raise.
+                self.config.logger.error(
+                    "role update failed for source id=%s name=%r status=%s: %s",
+                    _id,
+                    role_name,
+                    getattr(e, "status_code", "?"),
+                    e,
+                )
                 raise
 
-        # If we exhausted retries, raise an error
+        # If we exhausted the permission-retry budget, raise an error.
+        # max_retries is a cap on distinct permission-removals, not attempts.
+        self.config.logger.error(
+            "role update exhausted permission-retry budget (%d) for source id=%s name=%r",
+            max_retries,
+            _id,
+            role_name,
+        )
         raise Exception(f"Exceeded maximum retries ({max_retries}) while updating role '{role_name}'")
 
     async def delete_resource(self, _id: str) -> None:

--- a/datadog_sync/utils/custom_client.py
+++ b/datadog_sync/utils/custom_client.py
@@ -367,10 +367,22 @@ class CustomClient:
                             page_number = pagination_config.page_number_func(idx, page_size, page_number)
                         remaining = 1  # after this error we need to keep processing
                     else:
+                        # Non-5xx failure mid-pagination (e.g. 403 Forbidden
+                        # on a specific page). The `break` silently truncates
+                        # the resource list to what we've collected so far;
+                        # downstream sync workers cannot tell the difference
+                        # between "source has N resources" and "source has
+                        # N+K resources but we couldn't read K". Elevate the
+                        # log to make the truncation explicit so operators
+                        # can correlate downstream cascade failures with a
+                        # specific partial-list event.
                         log.error(
-                            f"Error during paginated request for {args[0]} "
-                            f"{pagination_config.page_number_param}: {page_number} "
-                            f"{pagination_config.page_size_param}: {page_size} - {err}"
+                            f"Paginated request TRUNCATED for {args[0]} at "
+                            f"{pagination_config.page_number_param}={page_number} "
+                            f"{pagination_config.page_size_param}={page_size} "
+                            f"after collecting {len(resources)} resource(s). "
+                            f"Downstream syncs may show missing-dependency cascades. "
+                            f"Error: {err}"
                         )
                         break
 

--- a/datadog_sync/utils/resources_handler.py
+++ b/datadog_sync/utils/resources_handler.py
@@ -40,6 +40,45 @@ if TYPE_CHECKING:
 
 _timing_log = logging.getLogger(LOGGER_NAME)
 
+# Cap ids per summary log line so downstream log shippers (syslog: 8KB,
+# journald default: 48KB, Datadog agent: 256KB) don't silently truncate.
+# 50 UUIDs * ~40 chars = ~2KB, well under every common cap.
+_SUMMARY_ID_CHUNK = 50
+
+
+def _emit_apply_summary(logger, counter) -> None:
+    """Emit per-resource-type summary of failed / missing-deps source ids.
+
+    Chunks ids into groups of _SUMMARY_ID_CHUNK per WARN line so no single
+    line exceeds common log-shipper truncation thresholds. Preserves list-
+    insertion order (chronological failure order) rather than sorting —
+    operators debugging a cascade usually want to see WHICH failure happened
+    first, not lexicographic order.
+    """
+    def _chunked_emit(rt: str, action_desc: str, ids: List[str]) -> None:
+        total = len(ids)
+        for start in range(0, total, _SUMMARY_ID_CHUNK):
+            chunk = ids[start:start + _SUMMARY_ID_CHUNK]
+            end = min(start + _SUMMARY_ID_CHUNK, total)
+            logger.warning(
+                "sync summary: %s %s [%d-%d of %d]: %s",
+                rt,
+                action_desc,
+                start + 1,
+                end,
+                total,
+                ", ".join(chunk),
+            )
+
+    for rt in sorted(counter.failed_ids_by_type.keys()):
+        ids = counter.failed_ids_by_type[rt]
+        if ids:
+            _chunked_emit(rt, "failed source ids", ids)
+    for rt in sorted(counter.skipped_missing_deps_by_type.keys()):
+        ids = counter.skipped_missing_deps_by_type[rt]
+        if ids:
+            _chunked_emit(rt, "skipped for missing dependencies", ids)
+
 
 def _list_time_filter_passes(r_class, config, resource) -> bool:
     """Run the user's --filter at LIST-time, deferring list-unsafe filters.
@@ -317,7 +356,27 @@ class ResourcesHandler:
         self.worker.counter.filtered = filtered_count
         self.config.logger.info(f"finished syncing resource items: {self.worker.counter}.")
 
+        # Persist state BEFORE emitting the summary logs. If the logger backend
+        # rejects a large payload (e.g. syslog handler with an ~8KB line cap
+        # truncating a batch of 600 UUIDs) or any handler in the chain raises,
+        # we must not lose the on-disk state that downstream sync-cli
+        # invocations depend on. Any exception from the summary loops is
+        # caught below so state persistence stays unconditional.
         self.config.state.dump_state()
+
+        # Per-resource-type summary of failed / missing-deps ids. Emitted so
+        # subsequent sync-cli invocations (a separate process per resource
+        # type in the managed-sync wrapper) can correlate cascade failures
+        # back to specific source ids. Ids are chunked at
+        # _SUMMARY_ID_CHUNK per log line to keep individual lines well below
+        # common log-shipper truncation thresholds (~8-16KB) while remaining
+        # greppable via "sync summary:" plus an id substring.
+        try:
+            _emit_apply_summary(self.config.logger, self.worker.counter)
+        except Exception as e:
+            self.config.logger.warning(
+                "sync summary emission failed: %s. State was already persisted.", e
+            )
 
     async def _apply_resource_cb(self, q_item: List) -> None:
         resource_type, _id = q_item
@@ -388,14 +447,25 @@ class ResourcesHandler:
                 resource_type=resource_type,
                 _id=_id,
             )
-            self.worker.counter.increment_skipped()
+            # Track this source id in the counter's missing-deps bucket so
+            # apply_resources can emit a targeted per-type summary. Downstream
+            # sync-cli invocations for other resource types (each is a
+            # separate process reading state from disk) can correlate the
+            # cascade by matching failed source ids against the previous
+            # process's summary log.
+            self.worker.counter.increment_skipped(
+                resource_type=resource_type, _id=_id, missing_deps=True
+            )
             _reason, _fc = self._sanitize_reason(e)
             self._emit(resource_type, _id, "sync", "skipped", reason=_reason, failure_class=_fc)
             await r_class._send_action_metrics(
                 Command.SYNC.value, _id, Status.SKIPPED.value, tags=["reason:connection_error"]
             )
         except Exception as e:
-            self.worker.counter.increment_failure()
+            # Track the source id in the counter's failed-ids bucket so
+            # apply_resources can emit a targeted per-type summary at the
+            # end of the run.
+            self.worker.counter.increment_failure(resource_type=resource_type, _id=_id)
             _reason, _fc = self._sanitize_reason(e)
             self._emit(resource_type, _id, "sync", "failure", reason=_reason, failure_class=_fc)
             # format_exc_for_log guards against empty-str() exceptions producing blank log bodies.
@@ -609,6 +679,12 @@ class ResourcesHandler:
                     self.config.source_client, ids, max_concurrent_reads=mcr
                 )
             except Exception as e:
+                # Whole-type discovery failure (get_resources_by_ids raised
+                # before yielding per-id results). No specific source id in
+                # scope, so this can't populate failed_ids_by_type — the
+                # aggregate `failure` count still ticks. Downstream cascade
+                # analysis for this class needs the top-of-log error line
+                # emitted below.
                 self.worker.counter.increment_failure()
                 _reason, _fc = self._sanitize_reason(e)
                 self._emit(resource_type, "", "import", "failure", reason=_reason, failure_class=_fc)
@@ -624,14 +700,24 @@ class ResourcesHandler:
                     "skipped",
                     reason="resource not found in source (deleted between enumeration and fetch)",
                 )
-                self.worker.counter.increment_skipped()
+                # Missing-in-source ids are exactly the class of skipped
+                # resource whose id downstream sync-cli invocations need to
+                # correlate — a monitor that references this id will later
+                # fail its connect_resources.
+                self.worker.counter.increment_skipped(
+                    resource_type=resource_type, _id=mid, missing_deps=True
+                )
             for eid, cls, reason in errored:
                 if cls == "skipped":
                     self._emit(resource_type, eid, "import", "skipped", reason=reason)
-                    self.worker.counter.increment_skipped()
+                    self.worker.counter.increment_skipped(
+                        resource_type=resource_type, _id=eid, missing_deps=True
+                    )
                 else:
                     self._emit(resource_type, eid, "import", "failure", reason=reason)
-                    self.worker.counter.increment_failure()
+                    self.worker.counter.increment_failure(
+                        resource_type=resource_type, _id=eid
+                    )
 
             # Threshold check — emit a log line containing the literal "rate limit"
             # substring so downstream consumers that scan subprocess output for a
@@ -657,10 +743,14 @@ class ResourcesHandler:
             self.worker.counter.increment_success()
             tmp_storage[resource_type] = get_resp
         except (asyncio.TimeoutError, TimeoutError):
+            # Whole-type list failure (legacy path). No per-id available;
+            # aggregate `failure` count ticks. Cascade analysis: search
+            # "TimeoutError while getting resources" for the type.
             self.worker.counter.increment_failure()
             self._emit(resource_type, "", "import", "failure", reason="TimeoutError", failure_class="http_timeout")
             self.config.logger.error(f"TimeoutError while getting resources {resource_type}")
         except Exception as e:
+            # Whole-type list failure (legacy path). Same reasoning as above.
             self.worker.counter.increment_failure()
             _reason, _fc = self._sanitize_reason(e)
             self._emit(resource_type, "", "import", "failure", reason=_reason, failure_class=_fc)
@@ -703,6 +793,9 @@ class ResourcesHandler:
             _reason, _fc = self._sanitize_reason(e)
             self._emit(resource_type, _id, "import", "filtered", reason=_reason, failure_class=_fc)
         except SkipResource as e:
+            # User-intent skip (filter/status/etc.) — NOT a missing-dependency
+            # class. Deliberately not tracked in skipped_missing_deps_by_type;
+            # a downstream cascade would not want to grep these ids.
             self.worker.counter.increment_skipped()
             _reason, _fc = self._sanitize_reason(e)
             self._emit(resource_type, _id, "import", "skipped", reason=_reason, failure_class=_fc)
@@ -710,7 +803,7 @@ class ResourcesHandler:
             self.config.logger.info(f"skipping resource: {str(e)}", resource_type=resource_type, _id=_id)
             self.config.logger.debug(str(e))
         except Exception as e:
-            self.worker.counter.increment_failure()
+            self.worker.counter.increment_failure(resource_type=resource_type, _id=_id)
             _reason, _fc = self._sanitize_reason(e)
             self._emit(resource_type, _id, "import", "failure", reason=_reason, failure_class=_fc)
             await r_class._send_action_metrics(Command.IMPORT.value, _id, Status.FAILURE.value)
@@ -1022,6 +1115,8 @@ class ResourcesHandler:
             self._emit(resource_type, _id, "delete", "success")
             await r_class._send_action_metrics("delete", _id, Status.SUCCESS.value)
         except SkipResource as e:
+            # Deliberate skip (built-in role, invalid pipeline, etc.) — not a
+            # cascade signal. Numeric-only accounting.
             self.worker.counter.increment_skipped()
             _reason, _fc = self._sanitize_reason(e)
             self._emit(resource_type, _id, "delete", "skipped", reason=_reason, failure_class=_fc)
@@ -1029,7 +1124,7 @@ class ResourcesHandler:
             self.config.logger.info(f"skipping resource: {str(e)}", resource_type=resource_type, _id=_id)
             self.config.logger.info(f"skip deleting resource: {str(e)}", resource_type=resource_type, _id=_id)
         except Exception as e:
-            self.worker.counter.increment_failure()
+            self.worker.counter.increment_failure(resource_type=resource_type, _id=_id)
             _reason, _fc = self._sanitize_reason(e)
             self._emit(resource_type, _id, "delete", "failure", reason=_reason, failure_class=_fc)
             await r_class._send_action_metrics("delete", _id, Status.FAILURE.value)

--- a/datadog_sync/utils/workers.py
+++ b/datadog_sync/utils/workers.py
@@ -6,9 +6,10 @@
 from __future__ import annotations
 from asyncio import AbstractEventLoop, Future, Queue, QueueEmpty, Task, gather, get_event_loop, sleep
 
-from dataclasses import dataclass
+from collections import defaultdict
+from dataclasses import dataclass, field
 from traceback import format_exc
-from typing import Awaitable, Callable, List, Optional
+from typing import Awaitable, Callable, Dict, List, Optional
 
 from tqdm.asyncio import tqdm
 from tqdm.contrib.logging import logging_redirect_tqdm
@@ -110,6 +111,14 @@ class Counter:
     failure: int = 0
     skipped: int = 0
     filtered: int = 0
+    # Per-resource-type source IDs that failed or were skipped. Populated by
+    # _apply_resource_cb. Used to emit a targeted end-of-apply summary so
+    # subsequent sync-cli invocations (a separate process for a different
+    # resource type) can correlate cascade failures back to specific source
+    # IDs — e.g. "monitors sync couldn't remap roles X, Y, Z" is only
+    # actionable if the roles-sync run logged that X, Y, Z failed.
+    failed_ids_by_type: Dict[str, List[str]] = field(default_factory=lambda: defaultdict(list))
+    skipped_missing_deps_by_type: Dict[str, List[str]] = field(default_factory=lambda: defaultdict(list))
 
     def __str__(self):
         return (
@@ -118,15 +127,25 @@ class Counter:
 
     def reset_counter(self) -> None:
         self.successes = self.failure = self.skipped = self.filtered = 0
+        self.failed_ids_by_type = defaultdict(list)
+        self.skipped_missing_deps_by_type = defaultdict(list)
 
     def increment_success(self) -> None:
         self.successes += 1
 
-    def increment_failure(self) -> None:
+    def increment_failure(self, resource_type: Optional[str] = None, _id: Optional[str] = None) -> None:
         self.failure += 1
+        # Explicit `is not None` (not truthy) so numeric-0 ids and empty-string
+        # ids still get tracked — future resource types may use them, and
+        # dropping them silently would under-report the summary.
+        if resource_type is not None and _id is not None:
+            self.failed_ids_by_type[resource_type].append(str(_id))
 
-    def increment_skipped(self) -> None:
+    def increment_skipped(self, resource_type: Optional[str] = None, _id: Optional[str] = None,
+                          missing_deps: bool = False) -> None:
         self.skipped += 1
+        if missing_deps and resource_type is not None and _id is not None:
+            self.skipped_missing_deps_by_type[resource_type].append(str(_id))
 
     def increment_filtered(self) -> None:
         self.filtered += 1

--- a/tests/unit/test_apply_summary_handler.py
+++ b/tests/unit/test_apply_summary_handler.py
@@ -1,0 +1,148 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+"""Handler-level regression test for the per-resource-type sync summary emission.
+
+Motivation (Codex review of PR #614): the Counter unit tests in
+test_apply_summary_ids.py verify the data-structure, but a regression
+that removed or changed the actual summary emission in
+resources_handler.py would still pass. This file drives
+_emit_apply_summary against a populated Counter and asserts the log
+output shape + chunking + insertion-order preservation.
+"""
+
+from unittest.mock import MagicMock
+
+from datadog_sync.utils.resources_handler import _emit_apply_summary, _SUMMARY_ID_CHUNK
+from datadog_sync.utils.workers import Counter
+
+
+def _make_logger():
+    return MagicMock()
+
+
+def _rendered_warnings(logger):
+    out = []
+    for call in logger.warning.call_args_list:
+        args = call.args
+        if not args:
+            continue
+        try:
+            out.append(args[0] % args[1:])
+        except Exception:
+            out.append(str(args))
+    return out
+
+
+def test_summary_emits_failed_ids_by_type():
+    counter = Counter()
+    counter.increment_failure(resource_type="roles", _id="uuid-abc")
+    counter.increment_failure(resource_type="roles", _id="uuid-def")
+    counter.increment_failure(resource_type="monitors", _id="mon-1")
+
+    logger = _make_logger()
+    _emit_apply_summary(logger, counter)
+
+    joined = "\n".join(_rendered_warnings(logger))
+    assert "roles" in joined
+    assert "monitors" in joined
+    assert "uuid-abc" in joined
+    assert "uuid-def" in joined
+    assert "mon-1" in joined
+    assert "failed source ids" in joined
+
+
+def test_summary_emits_skipped_missing_deps_by_type():
+    counter = Counter()
+    counter.increment_skipped(resource_type="dashboards", _id="dsh-1", missing_deps=True)
+    counter.increment_skipped(resource_type="dashboards", _id="dsh-2", missing_deps=True)
+
+    logger = _make_logger()
+    _emit_apply_summary(logger, counter)
+
+    joined = "\n".join(_rendered_warnings(logger))
+    assert "dashboards" in joined
+    assert "dsh-1" in joined
+    assert "dsh-2" in joined
+    assert "skipped for missing dependencies" in joined
+
+
+def test_summary_silent_when_no_failures():
+    counter = Counter()
+    logger = _make_logger()
+    _emit_apply_summary(logger, counter)
+    assert logger.warning.call_count == 0
+
+
+def test_summary_chunks_large_id_lists():
+    counter = Counter()
+    for i in range(130):
+        counter.increment_failure(resource_type="monitors", _id=f"mon-{i:03d}")
+
+    logger = _make_logger()
+    _emit_apply_summary(logger, counter)
+
+    lines = _rendered_warnings(logger)
+    monitor_lines = [line for line in lines if "monitors" in line]
+    assert len(monitor_lines) == 3, f"expected 3 chunks, got {len(monitor_lines)}: {monitor_lines}"
+
+    assert "[1-50 of 130]" in monitor_lines[0]
+    assert "[51-100 of 130]" in monitor_lines[1]
+    assert "[101-130 of 130]" in monitor_lines[2]
+
+    joined = "\n".join(monitor_lines)
+    for i in range(130):
+        assert f"mon-{i:03d}" in joined, f"id mon-{i:03d} missing"
+
+
+def test_summary_preserves_insertion_order_not_sorted():
+    counter = Counter()
+    counter.increment_failure(resource_type="roles", _id="zzz-last")
+    counter.increment_failure(resource_type="roles", _id="aaa-first")
+    counter.increment_failure(resource_type="roles", _id="mmm-middle")
+
+    logger = _make_logger()
+    _emit_apply_summary(logger, counter)
+
+    joined = "\n".join(_rendered_warnings(logger))
+    assert joined.index("zzz-last") < joined.index("aaa-first")
+    assert joined.index("aaa-first") < joined.index("mmm-middle")
+
+
+def test_summary_uses_join_not_repr_for_greppability():
+    counter = Counter()
+    counter.increment_failure(resource_type="roles", _id="uuid-searchable")
+
+    logger = _make_logger()
+    _emit_apply_summary(logger, counter)
+
+    joined = "\n".join(_rendered_warnings(logger))
+    assert "uuid-searchable" in joined
+    assert "sync summary" in joined
+
+
+def test_chunk_constant_is_reasonable():
+    assert 20 <= _SUMMARY_ID_CHUNK <= 200
+
+
+def test_summary_emission_exception_does_not_propagate_to_dump_state():
+    """Regression guard for MAJOR#1: if the logger backend raises during
+    summary emission, _emit_apply_summary should not swallow it — that's
+    the caller's job. But the caller (apply_resources) wraps this call in
+    try/except so state persistence is guaranteed. Test that
+    _emit_apply_summary itself propagates so we can distinguish 'summary
+    failed' from 'nothing to summarize'."""
+    import pytest
+
+    counter = Counter()
+    counter.increment_failure(resource_type="roles", _id="x")
+
+    class BadLogger:
+        def warning(self, *args, **kwargs):
+            raise RuntimeError("log backend down")
+
+    # Bad logger propagates. apply_resources' outer try/except catches.
+    with pytest.raises(RuntimeError):
+        _emit_apply_summary(BadLogger(), counter)

--- a/tests/unit/test_apply_summary_ids.py
+++ b/tests/unit/test_apply_summary_ids.py
@@ -1,0 +1,81 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+"""Tests for the counter's per-resource-type failure / missing-deps id tracking.
+
+Motivation: managed-sync runs sync-cli once per resource type as separate
+processes. When a downstream type (e.g. monitors) fails to remap a role
+UUID from an earlier roles-sync process, an operator has to correlate the
+cascade back to the specific source ids that failed in the earlier process.
+Previously only aggregate counts were logged. These tests verify that the
+counter records the specific source ids by resource type and that
+apply_resources emits a targeted per-type summary.
+"""
+
+from datadog_sync.utils.workers import Counter
+
+
+def test_counter_defaults_have_empty_id_maps():
+    c = Counter()
+    assert c.failed_ids_by_type == {}
+    assert c.skipped_missing_deps_by_type == {}
+
+
+def test_increment_failure_records_source_id_by_type():
+    c = Counter()
+    c.increment_failure(resource_type="roles", _id="uuid-a")
+    c.increment_failure(resource_type="roles", _id="uuid-b")
+    c.increment_failure(resource_type="monitors", _id="mon-1")
+    assert c.failure == 3
+    assert c.failed_ids_by_type["roles"] == ["uuid-a", "uuid-b"]
+    assert c.failed_ids_by_type["monitors"] == ["mon-1"]
+
+
+def test_increment_failure_still_counts_without_ids():
+    """Backwards compat: legacy callers passing no args still increment the
+    numeric counter (they just don't populate the id map)."""
+    c = Counter()
+    c.increment_failure()
+    c.increment_failure()
+    assert c.failure == 2
+    assert c.failed_ids_by_type == {}
+
+
+def test_increment_skipped_records_missing_deps_only_when_flagged():
+    c = Counter()
+    # Regular skip: numeric only, no id tracked.
+    c.increment_skipped(resource_type="monitors", _id="mon-2")
+    # Missing-deps skip: id tracked so downstream cascade correlation works.
+    c.increment_skipped(resource_type="monitors", _id="mon-3", missing_deps=True)
+    c.increment_skipped(resource_type="dashboards", _id="dsh-1", missing_deps=True)
+    assert c.skipped == 3
+    assert c.skipped_missing_deps_by_type["monitors"] == ["mon-3"]
+    assert c.skipped_missing_deps_by_type["dashboards"] == ["dsh-1"]
+
+
+def test_increment_skipped_still_counts_without_ids():
+    c = Counter()
+    c.increment_skipped()
+    c.increment_skipped()
+    assert c.skipped == 2
+    assert c.skipped_missing_deps_by_type == {}
+
+
+def test_reset_clears_id_maps():
+    c = Counter()
+    c.increment_failure(resource_type="roles", _id="uuid-a")
+    c.increment_skipped(resource_type="monitors", _id="mon-1", missing_deps=True)
+    c.reset_counter()
+    assert c.failure == 0
+    assert c.skipped == 0
+    assert c.failed_ids_by_type == {}
+    assert c.skipped_missing_deps_by_type == {}
+
+
+def test_string_representation_unchanged():
+    """The __str__ format is consumed by logs downstream; keep it stable so
+    log-based dashboards don't break."""
+    c = Counter(successes=10, failure=2, skipped=1, filtered=3)
+    assert str(c) == "Successes: 10, Failures: 2, Skipped: 1, Filtered: 3"

--- a/tests/unit/test_paginated_truncation_logging.py
+++ b/tests/unit/test_paginated_truncation_logging.py
@@ -1,0 +1,104 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+"""Tests for the paginated_request truncation warning.
+
+Motivation: when the source API returns a non-5xx error (e.g. 403 Forbidden)
+mid-pagination, paginated_request silently break()s and returns the partial
+list. Downstream syncs cannot distinguish "source has N resources" from
+"source has N+K resources but K couldn't be read". The error log must
+therefore say TRUNCATED explicitly so operators correlating a cascade of
+missing-dependency failures downstream can find the truncation event.
+"""
+
+import asyncio
+import logging
+
+from datadog_sync.utils.custom_client import CustomClient, PaginationConfig
+from datadog_sync.utils.resource_utils import CustomClientHTTPError
+
+
+class _FakeResp:
+    """Minimal aiohttp.ClientResponseError-shaped object for
+    CustomClientHTTPError.__init__ (which reads response.status +
+    response.message)."""
+    def __init__(self, status):
+        self.status = status
+        self.message = "Forbidden"
+
+
+def _make_client():
+    return CustomClient(
+        host="https://api.datadoghq.com",
+        auth={"apiKeyAuth": "k", "appKeyAuth": "a"},
+        retry_timeout=60,
+        timeout=30,
+        send_metrics=False,
+    )
+
+
+def test_paginated_request_truncation_error_says_truncated(caplog):
+    """A 403 mid-pagination must log with 'TRUNCATED' explicitly."""
+    caplog.set_level(logging.ERROR, logger="datadog_sync_cli")
+
+    async def scenario():
+        client = _make_client()
+
+        # First page: returns 2 rows successfully.
+        # Second page: raises 403.
+        page = 0
+
+        async def flaky_get(path, **kwargs):
+            nonlocal page
+            page += 1
+            if page == 1:
+                # Return two rows so remaining_func is triggered.
+                return {"data": [{"id": "a"}, {"id": "b"}], "meta": {"page": {"total_count": 10}}}
+            raise CustomClientHTTPError(_FakeResp(403), message="Forbidden")
+
+        cfg = PaginationConfig(page_size=2)
+        wrapped = client.paginated_request(flaky_get)
+        resources = await wrapped("/api/v2/roles", pagination_config=cfg)
+        # Truncation returns the partial page collected before the 403.
+        assert len(resources) == 2
+
+    asyncio.run(scenario())
+
+    err_messages = [r.getMessage() for r in caplog.records if r.levelname == "ERROR"]
+    joined = " | ".join(err_messages)
+    assert "TRUNCATED" in joined, f"Expected 'TRUNCATED' in error log, got: {joined!r}"
+    assert "/api/v2/roles" in joined
+    # The message should also flag downstream cascade so an operator scanning
+    # missing-dependency errors can search for this event by keyword.
+    assert "cascade" in joined.lower() or "missing" in joined.lower()
+
+
+def test_paginated_request_500_still_isolates_not_truncates(caplog):
+    """5xx errors trigger the isolation-by-halving path, NOT the truncation
+    break. Regression guard: the truncation log change must not fire for
+    5xx isolation errors, which are recoverable."""
+    caplog.set_level(logging.WARNING, logger="datadog_sync_cli")
+
+    async def scenario():
+        client = _make_client()
+        calls = {"n": 0}
+
+        async def flaky_get(path, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise CustomClientHTTPError(_FakeResp(500), message="server error")
+            # Second call at reduced page_size succeeds with empty page.
+            return {"data": [], "meta": {"page": {"total_count": 0}}}
+
+        cfg = PaginationConfig(page_size=2)
+        wrapped = client.paginated_request(flaky_get)
+        # Should not raise; isolation kicks in.
+        await wrapped("/api/v2/logs/config/pipelines", pagination_config=cfg)
+
+    asyncio.run(scenario())
+
+    joined = " | ".join(r.getMessage() for r in caplog.records)
+    # The isolation warning should fire, but NOT the truncation ERROR.
+    assert "TRUNCATED" not in joined

--- a/tests/unit/test_roles_failure_logging.py
+++ b/tests/unit/test_roles_failure_logging.py
@@ -1,0 +1,109 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+"""Tests for the role create/update ERROR-level logging on unhandled failures.
+
+Motivation: managed-sync runs sync-cli once per resource type in separate
+processes. When a role fails to sync, downstream types (monitors, dashboards,
+users, etc.) that reference that role can't be told which source id
+disappeared. Before this change, sync-cli's roles module re-raised the
+HTTP error without logging the source id + role name, so cascade failures
+downstream could not be correlated back to the specific role that failed.
+
+These tests verify that role create + update failures log the source id
+and role name at ERROR level before re-raising.
+"""
+
+import asyncio
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from datadog_sync.model.roles import Roles
+from datadog_sync.utils.resource_utils import CustomClientHTTPError
+
+
+class _FakeResp:
+    def __init__(self, status):
+        self.status = status
+        self.message = "Bad Request"
+
+
+def _make_roles():
+    mock_config = MagicMock()
+    mock_config.state = MagicMock()
+    mock_config.allow_partial_permissions_roles = []
+    return Roles(mock_config)
+
+
+def _get_error_log_calls(mock_logger):
+    """Return concatenated messages from all logger.error() calls on the mock.
+    The roles module uses ``self.config.logger.error(fmt, *args)``; MagicMock
+    records the call args, so we render them back like %-formatting would."""
+    calls = mock_logger.error.call_args_list
+    rendered = []
+    for call in calls:
+        args = call.args
+        if not args:
+            continue
+        fmt = args[0]
+        try:
+            rendered.append(fmt % args[1:])
+        except Exception:
+            rendered.append(str(args))
+    return " | ".join(rendered)
+
+
+def test_create_resource_logs_source_id_on_error():
+    """When create_resource re-raises a non-retryable error, the source id
+    and role name must appear in an ERROR log so downstream cascade
+    correlation is possible."""
+    roles = _make_roles()
+    roles._existing_resources_map = {}  # role is NOT already on destination -> POST path
+
+    err = CustomClientHTTPError(_FakeResp(400), message='{"detail":"boom"}')
+    roles.config.destination_client = MagicMock()
+    roles.config.destination_client.post = AsyncMock(side_effect=err)
+
+    resource = {
+        "id": "role-uuid-abc-123",
+        "attributes": {"name": "MyCustomRole"},
+        "relationships": {"permissions": {"data": []}},
+    }
+
+    with pytest.raises(CustomClientHTTPError):
+        asyncio.run(roles.create_resource("role-uuid-abc-123", resource))
+
+    joined = _get_error_log_calls(roles.config.logger)
+    assert "role-uuid-abc-123" in joined, f"expected source id in ERROR log; got: {joined!r}"
+    assert "MyCustomRole" in joined
+    assert "role sync failed" in joined
+
+
+def test_update_resource_logs_source_id_on_error():
+    """update_resource must also log source id + name at ERROR before
+    re-raising."""
+    roles = _make_roles()
+    # State has the destination role mapped from the source id; update takes
+    # the "found in destination" path.
+    roles.config.state.destination = {"roles": {"role-uuid-def-456": {"id": "dest-id"}}}
+
+    err = CustomClientHTTPError(_FakeResp(400), message='{"detail":"nope"}')
+    roles.config.destination_client = MagicMock()
+    roles.config.destination_client.patch = AsyncMock(side_effect=err)
+
+    resource = {
+        "id": "role-uuid-def-456",
+        "attributes": {"name": "AnotherCustomRole"},
+        "relationships": {"permissions": {"data": []}},
+    }
+
+    with pytest.raises(CustomClientHTTPError):
+        asyncio.run(roles.update_resource("role-uuid-def-456", resource))
+
+    joined = _get_error_log_calls(roles.config.logger)
+    assert "role-uuid-def-456" in joined, f"expected source id in ERROR log; got: {joined!r}"
+    assert "AnotherCustomRole" in joined
+    assert "role update failed" in joined


### PR DESCRIPTION
## Summary

Three linked observability fixes so operators can correlate cross-process cascade failures when sync-cli is invoked once per resource type as separate processes:

1. **`Roles.create_resource` / `update_resource`** — log source id + role name at `ERROR` before re-raising on unhandled failure. Previously the module logged nothing before propagating the HTTP error, so a downstream resource type that later couldn't remap the role UUID had no way to see which specific role failed to sync.

2. **`Counter`** — track failed and missing-dependency source ids by resource type. `apply_resources` emits a per-type summary at end so a subsequent sync-cli invocation can find the exact ids to search for in cascade logs. Ids are chunked at 50 per line to stay under common log-shipper truncation caps. Backwards-compatible: existing callers that pass no ids still increment the numeric counter as before.

3. **`paginated_request`** — elevate the non-5xx mid-pagination failure log to say `TRUNCATED` explicitly and mention downstream cascade risk. A 403 Forbidden on one page previously produced a benign-looking `Error during paginated request ...` line and silently truncated the returned resource list; downstream syncs saw a partial source list without knowing why.

## Motivation

When sync-cli is orchestrated as one process per resource type (each reading state from a shared store), a failure in an earlier process can cascade into "missing connections" errors in later processes referencing ids that never appeared in any prior log. These three changes make that failure mode debuggable from logs alone.

## No behavior change for callers that

- don't hit an unhandled error in `Roles.create/update` (2xx and handled 4xx paths unchanged)
- don't experience non-5xx mid-pagination failures
- don't consume the new counter attributes

## Test plan

- `pytest tests/unit/` — 829 passing (19 new across 4 new test files).
- New coverage includes:
  - Counter data-structure semantics (backwards-compat guards).
  - Handler-level summary emission: chunking, insertion-order preservation, silence-on-clean-run, exception propagation.
  - `paginated_request` truncation log wording (403 path) + regression guard for 5xx isolation path.
  - Roles create/update ERROR logging on source id + role name.