### PR TITLE
Filter metrics_metadata by destination-existence

### DIFF
--- a/datadog_sync/model/metrics_metadata.py
+++ b/datadog_sync/model/metrics_metadata.py
@@ -2,11 +2,15 @@
 # under the 3-clause BSD style license (see LICENSE).
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019 Datadog, Inc.
+import logging
 from typing import Optional, List, Dict, Tuple
 
+from datadog_sync.constants import LOGGER_NAME
 from datadog_sync.utils.base_resource import BaseResource, ResourceConfig
 from datadog_sync.utils.custom_client import CustomClient
-from datadog_sync.utils.resource_utils import SkipResource
+from datadog_sync.utils.resource_utils import CustomClientHTTPError, SkipResource
+
+log = logging.getLogger(LOGGER_NAME)
 
 
 class MetricsMetadata(BaseResource):
@@ -49,6 +53,32 @@ class MetricsMetadata(BaseResource):
 
     async def update_resource(self, _id: str, resource: Dict) -> Tuple[str, Dict]:
         destination_client = self.config.destination_client
+
+        # metrics_metadata can only attach to a metric that already exists on
+        # destination. Legacy dogweb returns 400 {"errors":["error updating metric
+        # metadata"]} when the metric is missing; that failure adds ~25-30min of
+        # wall-clock per dispatch on DR replicas where large fractions of the
+        # source's custom metrics haven't yet been ingested to the destination.
+        # Probe existence first via GET /api/v1/metrics/{name} (same base_path
+        # sync-cli PUTs to below); skip on 404. Other errors from the probe
+        # propagate to the existing retry layer.
+        # NOTE: use the v1 path, not self.metrics_get_path (=/api/v2/metrics),
+        # because /api/v2/metrics/{name} is not a registered route in dd-source
+        # governance (only /api/v2/metrics list + subresources like /tags exist).
+        # The v1 handler returns 404 via GetResolvedMetricWithLegacyErrorHandling
+        # when the metric is not resolvable in the destination org.
+        try:
+            await destination_client.get(self.resource_config.base_path + f"/{_id}")
+        except CustomClientHTTPError as e:
+            if e.status_code == 404:
+                log.debug(f"[metrics_metadata - {_id}] skipping: metric not present on destination")
+                raise SkipResource(
+                    _id,
+                    self.resource_type,
+                    "Metric not present on destination; metadata cannot attach.",
+                )
+            raise
+
         resp = await destination_client.put(self.resource_config.base_path + f"/{_id}", resource)
 
         return _id, resp

--- a/tests/unit/test_metrics_metadata.py
+++ b/tests/unit/test_metrics_metadata.py
@@ -1,0 +1,100 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+"""Unit tests for metrics_metadata destination-existence filter (HAMR-392 Jul8-T20)."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from datadog_sync.model.metrics_metadata import MetricsMetadata
+from datadog_sync.utils.resource_utils import CustomClientHTTPError, SkipResource
+
+
+def _http_error(status, message="err"):
+    return CustomClientHTTPError(SimpleNamespace(status=status, message="err"), message=message)
+
+
+@pytest.fixture
+def metrics_metadata():
+    mock_config = MagicMock()
+    mock_config.state = MagicMock()
+    mock_config.destination_client = AsyncMock()
+    return MetricsMetadata(mock_config)
+
+
+def test_update_resource_dest_exists_calls_put(metrics_metadata):
+    """When destination GET returns 200, the PUT proceeds and metadata is updated."""
+    client = metrics_metadata.config.destination_client
+    client.get = AsyncMock(return_value={"data": {"id": "my.metric", "type": "metrics"}})
+    client.put = AsyncMock(return_value={"description": "updated"})
+
+    resource = {"description": "updated", "unit": "byte"}
+    _id, resp = asyncio.run(metrics_metadata.update_resource("my.metric", resource))
+
+    assert _id == "my.metric"
+    assert resp == {"description": "updated"}
+    client.get.assert_awaited_once_with("/api/v1/metrics/my.metric")
+    client.put.assert_awaited_once_with("/api/v1/metrics/my.metric", resource)
+
+
+def test_update_resource_dest_missing_raises_skip(metrics_metadata):
+    """When destination GET returns 404, PUT is skipped and SkipResource is raised."""
+    client = metrics_metadata.config.destination_client
+    client.get = AsyncMock(side_effect=_http_error(404))
+    client.put = AsyncMock()
+
+    with pytest.raises(SkipResource) as exc_info:
+        asyncio.run(metrics_metadata.update_resource("missing.metric", {"description": "x"}))
+
+    assert "missing.metric" in str(exc_info.value)
+    assert "not present on destination" in str(exc_info.value)
+    client.put.assert_not_awaited()
+
+
+def test_update_resource_get_500_propagates(metrics_metadata):
+    """When destination GET returns 500, the error propagates (retry layer handles it)."""
+    client = metrics_metadata.config.destination_client
+    client.get = AsyncMock(side_effect=_http_error(500, "Internal Server Error"))
+    client.put = AsyncMock()
+
+    with pytest.raises(CustomClientHTTPError) as exc_info:
+        asyncio.run(metrics_metadata.update_resource("some.metric", {"description": "x"}))
+
+    assert exc_info.value.status_code == 500
+    client.put.assert_not_awaited()
+
+
+def test_update_resource_get_403_propagates(metrics_metadata):
+    """When destination GET returns 403 (permission), the error propagates unchanged."""
+    client = metrics_metadata.config.destination_client
+    client.get = AsyncMock(side_effect=_http_error(403, "Forbidden"))
+    client.put = AsyncMock()
+
+    with pytest.raises(CustomClientHTTPError) as exc_info:
+        asyncio.run(metrics_metadata.update_resource("some.metric", {"description": "x"}))
+
+    assert exc_info.value.status_code == 403
+    client.put.assert_not_awaited()
+
+
+def test_create_resource_delegates_to_update(metrics_metadata):
+    """create_resource remains a thin wrapper around update_resource (behaviour unchanged)."""
+    client = metrics_metadata.config.destination_client
+    client.get = AsyncMock(return_value={"data": {"id": "my.metric"}})
+    client.put = AsyncMock(return_value={"description": "created"})
+
+    _id, resp = asyncio.run(metrics_metadata.create_resource("my.metric", {"description": "created"}))
+
+    assert _id == "my.metric"
+    assert resp == {"description": "created"}
+    client.get.assert_awaited_once()
+    client.put.assert_awaited_once()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Skip `metrics_metadata` PUT when the metric doesn't exist on destination. The legacy dogweb handler returns 400 `{"errors":["error updating metric metadata"]}` for missing metrics, wasting ~700 API calls / 25-30min per DR dispatch.

## Change

Before PUT, `GET /api/v1/metrics/{name}` (same base_path):

| GET result | Action |
|---|---|
| 200 | Proceed to PUT (existing behavior) |
| 404 | Raise `SkipResource` (logged at DEBUG); PUT skipped |
| Other | Propagate to existing retry layer |

5 unit tests cover 200/404/500/403 + `create_resource` delegation. Mirrors the `host_tags.py` 404-skip pattern.

## Notes

- Uses `/api/v1/metrics/{name}` — the v2 bare-name route isn't registered in dd-source governance (only v2 list + subresources).
- No CLI opt-out flag added; 404-skip strictly reduces failure noise vs. current behavior.
- Unblocks restoring `metrics_metadata` to Vault allowlist (Jul8-T19 dropped it temporarily).

Ref: HAMR-392 Jul8-T20. Root cause at `team-compass HAMR-392/T-metrics-metadata/STATUS.md@d22a7ce222`.