### PR TITLE
fix(restriction_policies): drop stale principals instead of skipping the whole policy (2/4)

### DIFF
--- a/datadog_sync/model/dashboards.py
+++ b/datadog_sync/model/dashboards.py
@@ -4,11 +4,18 @@
 # Copyright 2019 Datadog, Inc.
 
 from __future__ import annotations
+from collections import defaultdict
 from copy import deepcopy
 from typing import TYPE_CHECKING, Optional, List, Dict, Tuple, cast
 
-from datadog_sync.utils.base_resource import BaseResource, ResourceConfig
-from datadog_sync.utils.resource_utils import CustomClientHTTPError, SkipResource, check_diff, prep_resource
+from datadog_sync.utils.base_resource import BaseResource, ResourceConfig, ResourceConnectionResult
+from datadog_sync.utils.resource_utils import (
+    CustomClientHTTPError,
+    SkipResource,
+    check_diff,
+    find_attr,
+    prep_resource,
+)
 
 if TYPE_CHECKING:
     from datadog_sync.utils.custom_client import CustomClient
@@ -170,6 +177,37 @@ class Dashboards(BaseResource):
         destination_client = self.config.destination_client
         await destination_client.delete(
             self.resource_config.base_path + f"/{self.config.state.destination[self.resource_type][_id]['id']}"
+        )
+
+    def connect_resources(self, _id: str, resource: Dict) -> ResourceConnectionResult:
+        """Drop-aware override.
+
+        Widget connections (monitor alert_ids, powerpacks, slos) keep the generic
+        find_attr/connect_id path. The flat `restricted_roles` list goes through the shared
+        drop-aware filter so a permanently-stale role can be dropped (under
+        --drop-unresolvable-principals) while an emptied list still hard-fails as an
+        access-elevation guard.
+        """
+        if not self.resource_config.resource_connections:
+            return ResourceConnectionResult()
+
+        failed_connections_dict = defaultdict(list)
+        for resource_to_connect, attrs in self.resource_config.resource_connections.items():
+            for attr_connection in attrs:
+                if attr_connection == "restricted_roles":
+                    continue  # handled by the drop-aware filter below
+                c = find_attr(attr_connection, resource_to_connect, resource, self.connect_id)
+                if c:
+                    failed_connections_dict[resource_to_connect].extend(c)
+
+        role_failed, roles_risk = self._filter_stale_flat_roles(_id, resource, "restricted_roles")
+        if role_failed:
+            failed_connections_dict["roles"].extend(role_failed)
+
+        return ResourceConnectionResult(
+            empty_binding_escalation=self._raise_connection_error_if_any(
+                _id, failed_connections_dict, roles_risk
+            )
         )
 
     def connect_id(self, key: str, r_obj: Dict, resource_to_connect: str) -> Optional[List[str]]:

--- a/datadog_sync/model/monitors.py
+++ b/datadog_sync/model/monitors.py
@@ -4,14 +4,15 @@
 # Copyright 2019 Datadog, Inc.
 
 from __future__ import annotations
+from collections import defaultdict
 import logging
 import re
 from typing import TYPE_CHECKING, Optional, List, Dict, Tuple, cast
 
 from datadog_sync.constants import LOGGER_NAME
-from datadog_sync.utils.base_resource import BaseResource, ResourceConfig, TaggingConfig
+from datadog_sync.utils.base_resource import BaseResource, ResourceConfig, ResourceConnectionResult, TaggingConfig
 from datadog_sync.utils.custom_client import PaginationConfig
-from datadog_sync.utils.resource_utils import CustomClientHTTPError, SkipResource
+from datadog_sync.utils.resource_utils import CustomClientHTTPError, SkipResource, find_attr
 
 _log = logging.getLogger(LOGGER_NAME)
 
@@ -238,6 +239,49 @@ class Monitors(BaseResource):
             params={"force": "true"},
         )
 
+    def connect_resources(self, _id: str, resource: Dict) -> ResourceConnectionResult:
+        """Drop-aware override.
+
+        query / composite-monitor / slo-alert connections keep the generic
+        find_attr/connect_id path. The two access-control shapes -- the flat
+        `restricted_roles` list and the `restriction_policy.bindings.principals` composites
+        -- go through the shared drop-aware filters so permanently-stale references can be
+        dropped (under --drop-unresolvable-principals) while an emptied binding/list still
+        hard-fails as an access-elevation guard.
+        """
+        if not self.resource_config.resource_connections:
+            return ResourceConnectionResult()
+
+        failed_connections_dict = defaultdict(list)
+        for resource_to_connect, attrs in self.resource_config.resource_connections.items():
+            for attr_connection in attrs:
+                if attr_connection in ("restricted_roles", "restriction_policy.bindings.principals"):
+                    continue  # handled by the drop-aware filters below
+                c = find_attr(attr_connection, resource_to_connect, resource, self.connect_id)
+                if c:
+                    failed_connections_dict[resource_to_connect].extend(c)
+
+        empty_risk = False
+        restriction_policy = resource.get("restriction_policy")
+        if restriction_policy:
+            principal_failed, binding_risk = self._filter_stale_binding_principals(
+                _id, restriction_policy.get("bindings")
+            )
+            for rt, ids in principal_failed.items():
+                failed_connections_dict[rt].extend(ids)
+            empty_risk = empty_risk or binding_risk
+
+        role_failed, roles_risk = self._filter_stale_flat_roles(_id, resource, "restricted_roles")
+        if role_failed:
+            failed_connections_dict["roles"].extend(role_failed)
+        empty_risk = empty_risk or roles_risk
+
+        return ResourceConnectionResult(
+            empty_binding_escalation=self._raise_connection_error_if_any(
+                _id, failed_connections_dict, empty_risk
+            )
+        )
+
     def connect_id(self, key: str, r_obj: Dict, resource_to_connect: str) -> Optional[List[str]]:
         monitors = self.config.state.destination[resource_to_connect]
 
@@ -308,6 +352,9 @@ class Monitors(BaseResource):
 
     def extract_source_ids(self, key: str, r_obj: Dict, resource_to_connect: str) -> Optional[List[str]]:
         # Mirror of connect_id -- keep in sync when connect_id changes.
+        # Intentionally UNAFFECTED by --drop-unresolvable-principals: must keep returning
+        # every referenced id (including ones connect_resources will later drop) so
+        # --minimize-reads lazy-loading can look them up in source to make the drop decision.
         if key == "query" and r_obj.get("type") == "composite" and resource_to_connect != "service_level_objectives":
             return re.findall("[0-9]+", r_obj[key])
         elif key == "query" and resource_to_connect == "service_level_objectives" and r_obj.get("type") == "slo alert":

--- a/datadog_sync/model/restriction_policies.py
+++ b/datadog_sync/model/restriction_policies.py
@@ -4,10 +4,15 @@
 # Copyright 2019 Datadog, Inc.
 
 from __future__ import annotations
+from collections import defaultdict
 from typing import TYPE_CHECKING, Optional, List, Dict, Tuple
 
-from datadog_sync.utils.base_resource import BaseResource, ResourceConfig
-from datadog_sync.utils.resource_utils import CustomClientHTTPError, SkipResource
+from datadog_sync.utils.base_resource import BaseResource, ResourceConfig, ResourceConnectionResult
+from datadog_sync.utils.resource_utils import (
+    CustomClientHTTPError,
+    SkipResource,
+    find_attr,
+)
 
 if TYPE_CHECKING:
     from datadog_sync.utils.custom_client import CustomClient
@@ -147,6 +152,38 @@ class RestrictionPolicies(BaseResource):
             self.resource_config.base_path + f"/{self.config.state.destination[self.resource_type][_id]['id']}"
         )
 
+    def connect_resources(self, _id: str, resource: Dict) -> ResourceConnectionResult:
+        """Drop-aware override.
+
+        The "id" connections (dashboards/slos/notebooks) keep the generic
+        find_attr/connect_id hard-fail path. The bindings' composite principals go through
+        the shared per-binding filter so that principals permanently absent from source can
+        be dropped (under --drop-unresolvable-principals) instead of failing the whole
+        policy, while an emptied binding still hard-fails as an access-elevation guard.
+        """
+        if not self.resource_config.resource_connections:
+            return ResourceConnectionResult()
+
+        failed_connections_dict = defaultdict(list)
+        for resource_to_connect, attrs in self.resource_config.resource_connections.items():
+            for attr_connection in attrs:
+                if attr_connection == "attributes.bindings.principals":
+                    continue  # handled per-binding below
+                c = find_attr(attr_connection, resource_to_connect, resource, self.connect_id)
+                if c:
+                    failed_connections_dict[resource_to_connect].extend(c)
+
+        bindings = (resource.get("attributes") or {}).get("bindings")
+        principal_failed, empty_binding_risk = self._filter_stale_binding_principals(_id, bindings)
+        for rt, ids in principal_failed.items():
+            failed_connections_dict[rt].extend(ids)
+
+        return ResourceConnectionResult(
+            empty_binding_escalation=self._raise_connection_error_if_any(
+                _id, failed_connections_dict, empty_binding_risk
+            )
+        )
+
     def connect_id(self, key: str, r_obj: Dict, resource_to_connect: str) -> Optional[List[str]]:
         dashboards = self.config.state.destination["dashboards"]
         slos = self.config.state.destination["service_level_objectives"]
@@ -198,6 +235,11 @@ class RestrictionPolicies(BaseResource):
 
     def extract_source_ids(self, key: str, r_obj: Dict, resource_to_connect: str) -> Optional[List[str]]:
         # Mirror of connect_id -- keep in sync when connect_id changes.
+        # Intentionally UNAFFECTED by --drop-unresolvable-principals: this must keep
+        # returning every referenced id (including ones connect_resources will later drop),
+        # because --minimize-reads lazy-loading relies on it to decide WHICH principals to
+        # look up in source in order to make the drop decision. Do NOT "fix" this to match
+        # connect_resources' filtering.
         if key == "id":
             _type, _id = r_obj[key].split(":", 1)
             type_map = {"dashboard": "dashboards", "slo": "service_level_objectives", "notebook": "notebooks"}

--- a/datadog_sync/model/synthetics_private_locations.py
+++ b/datadog_sync/model/synthetics_private_locations.py
@@ -6,11 +6,12 @@
 from __future__ import annotations
 import json
 import re
+from collections import defaultdict
 
 from typing import TYPE_CHECKING, List, Dict, Optional, Tuple
 
-from datadog_sync.utils.base_resource import BaseResource, ResourceConfig, TaggingConfig
-from datadog_sync.utils.resource_utils import SkipResource
+from datadog_sync.utils.base_resource import BaseResource, ResourceConfig, ResourceConnectionResult, TaggingConfig
+from datadog_sync.utils.resource_utils import SkipResource, find_attr
 
 if TYPE_CHECKING:
     from datadog_sync.utils.custom_client import CustomClient
@@ -100,6 +101,35 @@ class SyntheticsPrivateLocations(BaseResource):
         destination_client = self.config.destination_client
         await destination_client.delete(
             self.resource_config.base_path + f"/{self.config.state.destination[self.resource_type][_id]['id']}"
+        )
+
+    def connect_resources(self, _id: str, resource: Dict) -> ResourceConnectionResult:
+        """Drop-aware override for the flat `metadata.restricted_roles` list.
+
+        A permanently-stale role can be dropped (under --drop-unresolvable-principals) while
+        an emptied list still hard-fails as an access-elevation guard. Any future
+        non-restricted_roles connection keeps the generic find_attr/connect_id path.
+        """
+        if not self.resource_config.resource_connections:
+            return ResourceConnectionResult()
+
+        failed_connections_dict = defaultdict(list)
+        for resource_to_connect, attrs in self.resource_config.resource_connections.items():
+            for attr_connection in attrs:
+                if attr_connection == "metadata.restricted_roles":
+                    continue  # handled by the drop-aware filter below
+                c = find_attr(attr_connection, resource_to_connect, resource, self.connect_id)
+                if c:
+                    failed_connections_dict[resource_to_connect].extend(c)
+
+        role_failed, roles_risk = self._filter_stale_flat_roles(_id, resource.get("metadata"), "restricted_roles")
+        if role_failed:
+            failed_connections_dict["roles"].extend(role_failed)
+
+        return ResourceConnectionResult(
+            empty_binding_escalation=self._raise_connection_error_if_any(
+                _id, failed_connections_dict, roles_risk
+            )
         )
 
     def connect_id(self, key: str, r_obj: Dict, resource_to_connect: str) -> Optional[List[str]]:

--- a/datadog_sync/model/synthetics_tests.py
+++ b/datadog_sync/model/synthetics_tests.py
@@ -9,11 +9,13 @@ import aiohttp
 import certifi
 import json
 import ssl
+from collections import defaultdict
 from copy import deepcopy
 from typing import TYPE_CHECKING, Optional, List, Dict, Tuple, cast
 from yarl import URL
 
-from datadog_sync.utils.base_resource import BaseResource, ResourceConfig, TaggingConfig
+from datadog_sync.utils.base_resource import BaseResource, ResourceConfig, ResourceConnectionResult, TaggingConfig
+from datadog_sync.utils.resource_utils import find_attr
 from datadog_sync.model.synthetics_mobile_applications_versions import SyntheticsMobileApplicationsVersions
 
 if TYPE_CHECKING:
@@ -422,6 +424,49 @@ class SyntheticsTests(BaseResource):
         dest_resource = self.config.state.destination[self.resource_type][_id]
         await self._delete_test(destination_client, dest_resource.get("type"), dest_resource["public_id"])
 
+    def connect_resources(self, _id: str, resource: Dict) -> ResourceConnectionResult:
+        """Drop-aware override.
+
+        All non-access-control connections (private locations, subtests, global variables,
+        rum/mobile apps) keep the generic find_attr/connect_id path. The flat
+        `options.restricted_roles` list and the `restriction_policy.bindings.principals`
+        composites go through the shared drop-aware filters so permanently-stale references
+        can be dropped (under --drop-unresolvable-principals) while an emptied binding/list
+        still hard-fails as an access-elevation guard.
+        """
+        if not self.resource_config.resource_connections:
+            return ResourceConnectionResult()
+
+        failed_connections_dict = defaultdict(list)
+        for resource_to_connect, attrs in self.resource_config.resource_connections.items():
+            for attr_connection in attrs:
+                if attr_connection in ("options.restricted_roles", "restriction_policy.bindings.principals"):
+                    continue  # handled by the drop-aware filters below
+                c = find_attr(attr_connection, resource_to_connect, resource, self.connect_id)
+                if c:
+                    failed_connections_dict[resource_to_connect].extend(c)
+
+        empty_risk = False
+        restriction_policy = resource.get("restriction_policy")
+        if restriction_policy:
+            principal_failed, binding_risk = self._filter_stale_binding_principals(
+                _id, restriction_policy.get("bindings")
+            )
+            for rt, ids in principal_failed.items():
+                failed_connections_dict[rt].extend(ids)
+            empty_risk = empty_risk or binding_risk
+
+        role_failed, roles_risk = self._filter_stale_flat_roles(_id, resource.get("options"), "restricted_roles")
+        if role_failed:
+            failed_connections_dict["roles"].extend(role_failed)
+        empty_risk = empty_risk or roles_risk
+
+        return ResourceConnectionResult(
+            empty_binding_escalation=self._raise_connection_error_if_any(
+                _id, failed_connections_dict, empty_risk
+            )
+        )
+
     def connect_id(self, key: str, r_obj: Dict, resource_to_connect: str) -> Optional[List[str]]:
         failed_connections: List[str] = []
         if resource_to_connect == "synthetics_private_locations":
@@ -504,6 +549,9 @@ class SyntheticsTests(BaseResource):
 
     def extract_source_ids(self, key: str, r_obj: Dict, resource_to_connect: str) -> Optional[List[str]]:
         # Mirror of connect_id -- keep in sync when connect_id changes.
+        # Intentionally UNAFFECTED by --drop-unresolvable-principals: must keep returning
+        # every referenced id (including ones connect_resources will later drop) so
+        # --minimize-reads lazy-loading can look them up in source to make the drop decision.
         # Only synthetics_private_locations and mobile application versions need special handling.
         # rum_applications, synthetics_tests (subtests), synthetics_global_variables, roles, and
         # synthetics_mobile_applications (applicationId key) all use plain IDs at the leaf —

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -12,12 +12,14 @@ clone-on-update fallback.
 """
 
 import asyncio
+from collections import defaultdict
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from datadog_sync.model.dashboards import Dashboards
-from datadog_sync.utils.resource_utils import CustomClientHTTPError, SkipResource
+from datadog_sync.utils.resource_utils import CustomClientHTTPError, ResourceConnectionError, SkipResource
+from datadog_sync.utils.workers import Counter
 
 
 def _read_only_error() -> CustomClientHTTPError:
@@ -285,3 +287,65 @@ class TestDashboardsReadOnlyConflict:
         with pytest.raises(CustomClientHTTPError):
             asyncio.run(dashboards.update_resource("abc-123", {"title": "src"}))
         dashboards.config.destination_client.post.assert_not_awaited()
+
+
+class TestDashboardsConnectResourcesDrop:
+    """connect_resources drop/keep/hard-fail for dashboards' flat `restricted_roles`."""
+
+    def _make_dashboard(self, drop=False, skip_failed=False):
+        config = MagicMock()
+        config.state = MagicMock()
+        config.state.source = defaultdict(dict)
+        config.state.destination = defaultdict(dict)
+        config.state.ensure_resource_loaded = MagicMock()
+        config.drop_unresolvable_principals = drop
+        config.skip_failed_resource_connections = skip_failed
+        config.counter = Counter()
+        config.logger = MagicMock()
+        return Dashboards(config)
+
+    def _seed_valid_role(self, d, src="role-good", dst="role-good-dst"):
+        d.config.state.destination["roles"][src] = {"id": dst}
+
+    def test_flag_off_stale_role_hard_fails(self):
+        d = self._make_dashboard(drop=False)
+        resource = {"id": "abc-def-ghi", "restricted_roles": ["role-gone"]}
+        with pytest.raises(ResourceConnectionError):
+            d.connect_resources("abc-def-ghi", resource)
+        assert resource["restricted_roles"] == ["role-gone"]  # not dropped when flag off
+
+    def test_flag_on_drops_stale_keeps_valid(self):
+        d = self._make_dashboard(drop=True)
+        self._seed_valid_role(d)
+        resource = {"id": "abc-def-ghi", "restricted_roles": ["role-good", "role-gone"]}
+        d.connect_resources("abc-def-ghi", resource)  # no raise
+        assert resource["restricted_roles"] == ["role-good-dst"]
+        assert d.config.counter.stale_principals_dropped_by_type["dashboards"] == ["abc-def-ghi"]
+
+    def test_flag_on_all_stale_empty_list_raises_risk(self):
+        d = self._make_dashboard(drop=True)
+        resource = {"id": "abc-def-ghi", "restricted_roles": ["role-gone"]}
+        with pytest.raises(ResourceConnectionError) as exc_info:
+            d.connect_resources("abc-def-ghi", resource)
+        assert exc_info.value.empty_binding_risk is True
+        assert resource["restricted_roles"] == []
+
+    def test_empty_list_risk_is_returned_when_connection_failure_is_suppressed(self):
+        d = self._make_dashboard(drop=True, skip_failed=True)
+        resource = {"id": "abc-def-ghi", "restricted_roles": ["role-gone"]}
+
+        assert d.connect_resources("abc-def-ghi", resource).empty_binding_escalation is True
+        assert resource["restricted_roles"] == []
+
+    def test_flag_on_middle_drop_keeps_neighbors(self):
+        d = self._make_dashboard(drop=True)
+        self._seed_valid_role(d, src="ra", dst="ra-dst")
+        self._seed_valid_role(d, src="rc", dst="rc-dst")
+        resource = {"id": "abc", "restricted_roles": ["ra", "role-gone", "rc"]}
+        d.connect_resources("abc", resource)  # no raise
+        assert resource["restricted_roles"] == ["ra-dst", "rc-dst"]
+
+    def test_no_restricted_roles_is_noop(self):
+        d = self._make_dashboard(drop=True)
+        resource = {"id": "abc"}  # no restricted_roles at all
+        d.connect_resources("abc", resource)  # no raise, nothing to do

--- a/tests/unit/test_monitors.py
+++ b/tests/unit/test_monitors.py
@@ -11,11 +11,13 @@ empty options.groupby are skipped at sync time rather than failing with a 400.
 """
 
 import asyncio
+from collections import defaultdict
 import pytest
 from unittest.mock import MagicMock
 
 from datadog_sync.model.monitors import Monitors
-from datadog_sync.utils.resource_utils import SkipResource
+from datadog_sync.utils.resource_utils import SkipResource, ResourceConnectionError
+from datadog_sync.utils.workers import Counter
 
 
 class TestMonitorsPreResourceActionHook:
@@ -635,3 +637,102 @@ class TestMonitorsRestrictionPolicyPrincipals:
         asyncio.run(monitors.pre_apply_hook())
         assert monitors.org_principal is None
         mock_client.get.assert_not_awaited()
+
+
+class TestMonitorsConnectResourcesDrop:
+    """connect_resources drop/keep/hard-fail for monitors' access-control shapes:
+    the flat `restricted_roles` list and `restriction_policy.bindings.principals` composites.
+    'stale' == absent from destination AND source; 'valid' == present in destination.
+    """
+
+    def _make_monitors(self, drop=False, skip_failed=False):
+        config = MagicMock()
+        config.state = MagicMock()
+        config.state.source = defaultdict(dict)
+        config.state.destination = defaultdict(dict)
+        config.state.ensure_resource_loaded = MagicMock()
+        config.drop_unresolvable_principals = drop
+        config.skip_failed_resource_connections = skip_failed
+        config.counter = Counter()
+        config.logger = MagicMock()
+        return Monitors(config)
+
+    def _seed_valid_role(self, m, src="role-good", dst="role-good-dst"):
+        m.config.state.destination["roles"][src] = {"id": dst}
+
+    def test_restriction_policy_flag_off_stale_hard_fails(self):
+        m = self._make_monitors(drop=False)
+        resource = {
+            "id": 1,
+            "query": "avg(last_5m):sum:x{*} > 1",
+            "restriction_policy": {"bindings": [{"principals": ["role:role-gone"], "relation": "editor"}]},
+        }
+        with pytest.raises(ResourceConnectionError):
+            m.connect_resources("1", resource)
+
+    def test_restriction_policy_flag_on_drops_stale(self):
+        m = self._make_monitors(drop=True)
+        self._seed_valid_role(m)
+        resource = {
+            "id": 1,
+            "query": "avg(last_5m):sum:x{*} > 1",
+            "restriction_policy": {
+                "bindings": [{"principals": ["role:role-good", "role:role-gone"], "relation": "editor"}]
+            },
+        }
+        m.connect_resources("1", resource)  # no raise
+        assert resource["restriction_policy"]["bindings"][0]["principals"] == ["role:role-good-dst"]
+        assert m.config.counter.stale_principals_dropped_by_type["monitors"] == ["1"]
+
+    def test_restriction_policy_empty_binding_raises_risk(self):
+        m = self._make_monitors(drop=True)
+        resource = {
+            "id": 1,
+            "restriction_policy": {"bindings": [{"principals": ["role:role-gone"], "relation": "editor"}]},
+        }
+        with pytest.raises(ResourceConnectionError) as exc_info:
+            m.connect_resources("1", resource)
+        assert exc_info.value.empty_binding_risk is True
+
+    def test_restricted_roles_flat_flag_on_drops_stale(self):
+        m = self._make_monitors(drop=True)
+        self._seed_valid_role(m, src="role-good", dst="role-good-dst")
+        resource = {"id": 1, "restricted_roles": ["role-good", "role-gone"]}
+        m.connect_resources("1", resource)  # no raise
+        assert resource["restricted_roles"] == ["role-good-dst"]
+
+    def test_restricted_roles_flat_all_stale_empty_risk(self):
+        m = self._make_monitors(drop=True)
+        resource = {"id": 1, "restricted_roles": ["role-gone"]}
+        with pytest.raises(ResourceConnectionError) as exc_info:
+            m.connect_resources("1", resource)
+        assert exc_info.value.empty_binding_risk is True
+        assert resource["restricted_roles"] == []
+
+    def test_restricted_roles_flat_empty_risk_is_returned_when_connection_failure_is_suppressed(self):
+        m = self._make_monitors(drop=True, skip_failed=True)
+        resource = {"id": 1, "restricted_roles": ["role-gone"]}
+
+        assert m.connect_resources("1", resource).empty_binding_escalation is True
+        assert resource["restricted_roles"] == []
+
+    def test_restricted_roles_flat_middle_drop_keeps_neighbors(self):
+        m = self._make_monitors(drop=True)
+        self._seed_valid_role(m, src="ra", dst="ra-dst")
+        self._seed_valid_role(m, src="rc", dst="rc-dst")
+        resource = {"id": 1, "restricted_roles": ["ra", "role-gone", "rc"]}
+        m.connect_resources("1", resource)  # no raise
+        assert resource["restricted_roles"] == ["ra-dst", "rc-dst"]
+
+    def test_flag_off_restricted_roles_unchanged_behavior(self):
+        m = self._make_monitors(drop=False)
+        resource = {"id": 1, "restricted_roles": ["role-gone"]}
+        with pytest.raises(ResourceConnectionError):
+            m.connect_resources("1", resource)
+        # Flag off => not dropped
+        assert resource["restricted_roles"] == ["role-gone"]
+
+    def test_extract_source_ids_principals_unaffected(self):
+        m = self._make_monitors(drop=True)
+        binding = {"principals": ["role:role-gone"], "relation": "editor"}
+        assert m.extract_source_ids("principals", binding, "roles") == ["role-gone"]

--- a/tests/unit/test_restriction_policies.py
+++ b/tests/unit/test_restriction_policies.py
@@ -11,10 +11,13 @@ pre_resource_action_hook handles both success and failure paths correctly.
 """
 
 import asyncio
+from collections import defaultdict
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
 from datadog_sync.model.restriction_policies import RestrictionPolicies
+from datadog_sync.utils.resource_utils import ResourceConnectionError
+from datadog_sync.utils.workers import Counter
 
 
 class TestRestrictionPoliciesOrgPrincipal:
@@ -99,3 +102,199 @@ class TestRestrictionPoliciesOrgPrincipal:
 
         assert r["attributes"]["bindings"][0]["principals"][0] == "org:source-pub-id"
         assert r["attributes"]["bindings"][0]["principals"][1] == "user:some-user"
+
+
+class TestRestrictionPoliciesConnectResources:
+    """connect_resources drop/keep/hard-fail behavior for --drop-unresolvable-principals.
+
+    'stale' == absent from BOTH destination and source (permanently gone).
+    'pending' == present in source, absent from destination ('not yet synced').
+    'valid' == present in destination (resolves and remaps).
+    """
+
+    def _make_resource(self, drop=False, skip_failed=False):
+        config = MagicMock()
+        config.state = MagicMock()
+        config.state.source = defaultdict(dict)
+        config.state.destination = defaultdict(dict)
+        config.state.ensure_resource_loaded = MagicMock()
+        config.drop_unresolvable_principals = drop
+        config.skip_failed_resource_connections = skip_failed
+        config.counter = Counter()
+        config.logger = MagicMock()
+        resource = RestrictionPolicies(config)
+        # Seed the primary "id" connection so it always resolves; keeps these tests
+        # focused on principal handling rather than the dashboard id link.
+        config.state.destination["dashboards"]["dash-src"] = {"id": "dash-dst"}
+        return resource
+
+    def _seed_valid_role(self, resource, src="role-good", dst="role-good-dst"):
+        resource.config.state.destination["roles"][src] = {"id": dst}
+
+    def _seed_pending_role(self, resource, src="role-pending"):
+        resource.config.state.source["roles"][src] = {"id": src}
+
+    def _policy(self, bindings):
+        return {"id": "dashboard:dash-src", "attributes": {"bindings": bindings}}
+
+    # --- flag OFF: byte-for-byte unchanged behavior --------------------------------
+
+    def test_flag_off_stale_principal_hard_fails(self):
+        resource = self._make_resource(drop=False)
+        policy = self._policy([{"principals": ["role:role-gone"], "relation": "editor"}])
+
+        with pytest.raises(ResourceConnectionError):
+            resource.connect_resources("dashboard:dash-src", policy)
+
+        resource.config.counter  # no drop recorded
+        assert resource.config.counter.stale_principals_dropped_by_type == {}
+
+    def test_flag_off_valid_principal_remaps_and_succeeds(self):
+        resource = self._make_resource(drop=False)
+        self._seed_valid_role(resource)
+        policy = self._policy([{"principals": ["role:role-good"], "relation": "editor"}])
+
+        resource.connect_resources("dashboard:dash-src", policy)  # no raise
+
+        assert policy["attributes"]["bindings"][0]["principals"] == ["role:role-good-dst"]
+
+    # --- flag ON: drop stale, keep syncing -----------------------------------------
+
+    def test_flag_on_drops_stale_keeps_valid_and_syncs(self):
+        resource = self._make_resource(drop=True)
+        self._seed_valid_role(resource)
+        policy = self._policy([{"principals": ["role:role-good", "role:role-gone"], "relation": "editor"}])
+
+        resource.connect_resources("dashboard:dash-src", policy)  # no raise
+
+        assert policy["attributes"]["bindings"][0]["principals"] == ["role:role-good-dst"]
+        resource.config.logger.warning.assert_called()
+        assert resource.config.counter.stale_principals_dropped_by_type["restriction_policies"] == [
+            "dashboard:dash-src"
+        ]
+
+    def test_flag_on_pending_principal_still_hard_fails(self):
+        resource = self._make_resource(drop=True)
+        self._seed_pending_role(resource)  # in source, not destination
+        policy = self._policy([{"principals": ["role:role-pending"], "relation": "editor"}])
+
+        with pytest.raises(ResourceConnectionError) as exc_info:
+            resource.connect_resources("dashboard:dash-src", policy)
+
+        # Not an access-elevation case -- it's the legitimate retry-later path.
+        assert exc_info.value.empty_binding_risk is False
+        assert resource.config.counter.stale_principals_dropped_by_type == {}
+
+    def test_flag_on_binding_emptied_raises_empty_binding_risk(self):
+        resource = self._make_resource(drop=True)
+        policy = self._policy([{"principals": ["role:role-gone"], "relation": "editor"}])
+
+        with pytest.raises(ResourceConnectionError) as exc_info:
+            resource.connect_resources("dashboard:dash-src", policy)
+
+        assert exc_info.value.empty_binding_risk is True
+        resource.config.logger.error.assert_called()
+        assert policy["attributes"]["bindings"][0]["principals"] == []
+
+    def test_multiple_bindings_only_one_empties_still_raises(self):
+        resource = self._make_resource(drop=True)
+        self._seed_valid_role(resource)
+        policy = self._policy(
+            [
+                {"principals": ["role:role-good"], "relation": "viewer"},
+                {"principals": ["role:role-gone"], "relation": "editor"},
+            ]
+        )
+
+        with pytest.raises(ResourceConnectionError) as exc_info:
+            resource.connect_resources("dashboard:dash-src", policy)
+
+        assert exc_info.value.empty_binding_risk is True
+        # Resource-level skip: the surviving binding was still filtered/remapped in place.
+        assert policy["attributes"]["bindings"][0]["principals"] == ["role:role-good-dst"]
+        assert policy["attributes"]["bindings"][1]["principals"] == []
+
+    def test_skip_failed_resource_connections_suppresses_empty_binding_raise(self):
+        resource = self._make_resource(drop=True, skip_failed=True)
+        policy = self._policy([{"principals": ["role:role-gone"], "relation": "editor"}])
+
+        # skip_failed_resource_connections stays authoritative: no raise even for the
+        # empty-binding risk case.
+        connection_result = resource.connect_resources("dashboard:dash-src", policy)
+
+        assert policy["attributes"]["bindings"][0]["principals"] == []
+        assert connection_result.empty_binding_escalation is True
+        message = resource.config.logger.error.call_args.args[0]
+        assert "continuing sync" in message
+        assert "DESTINATION RESOURCE MAY BE UNRESTRICTED" in message
+        assert "refusing to sync" not in message
+
+    def test_middle_principal_drop_does_not_skip_neighbors(self):
+        # Enumerate/index-shift regression: stale entry in the MIDDLE of 3.
+        resource = self._make_resource(drop=True)
+        self._seed_valid_role(resource, src="role-a", dst="role-a-dst")
+        self._seed_valid_role(resource, src="role-c", dst="role-c-dst")
+        policy = self._policy([{"principals": ["role:role-a", "role:role-gone", "role:role-c"], "relation": "editor"}])
+
+        resource.connect_resources("dashboard:dash-src", policy)  # no raise
+
+        # Both neighbors survive, in order; the middle stale one is gone.
+        assert policy["attributes"]["bindings"][0]["principals"] == [
+            "role:role-a-dst",
+            "role:role-c-dst",
+        ]
+
+    def test_extract_source_ids_unaffected_by_drop_logic(self):
+        # extract_source_ids must still surface an id that connect_resources would drop.
+        resource = self._make_resource(drop=True)
+        binding = {"principals": ["role:role-gone"], "relation": "editor"}
+
+        assert resource.extract_source_ids("principals", binding, "roles") == ["role-gone"]
+
+    def test_non_principal_id_connection_still_hard_fails(self):
+        # A dangling dashboard "id" link fails via the generic path regardless of the flag.
+        resource = self._make_resource(drop=True)
+        self._seed_valid_role(resource)
+        # Point at a dashboard id that is NOT in destination state.
+        policy = {
+            "id": "dashboard:missing-dash",
+            "attributes": {"bindings": [{"principals": ["role:role-good"], "relation": "editor"}]},
+        }
+
+        with pytest.raises(ResourceConnectionError) as exc_info:
+            resource.connect_resources("dashboard:missing-dash", policy)
+
+        assert exc_info.value.empty_binding_risk is False
+
+    def test_inert_when_off_end_to_end_raises_like_today(self):
+        # Full connect_resources with the flag off + a would-be-dropped principal must
+        # raise exactly as today (no silent drop).
+        resource = self._make_resource(drop=False)
+        policy = self._policy([{"principals": ["role:role-gone"], "relation": "editor"}])
+
+        with pytest.raises(ResourceConnectionError):
+            resource.connect_resources("dashboard:dash-src", policy)
+
+        # Flag off => principal is NOT dropped; it stays in the (rebuilt) list.
+        assert policy["attributes"]["bindings"][0]["principals"] == ["role:role-gone"]
+
+    def test_org_and_non_composite_principals_pass_through(self):
+        # org: principals (already remapped by the hook) and any non-user/role/team or
+        # colon-less token must pass through untouched; an empty-principals binding is skipped.
+        resource = self._make_resource(drop=True)
+        self._seed_valid_role(resource)
+        policy = self._policy(
+            [
+                {"principals": ["org:dest-org", "weirdnoprefix", "role:role-good"], "relation": "editor"},
+                {"principals": [], "relation": "viewer"},
+            ]
+        )
+
+        resource.connect_resources("dashboard:dash-src", policy)  # no raise
+
+        assert policy["attributes"]["bindings"][0]["principals"] == [
+            "org:dest-org",
+            "weirdnoprefix",
+            "role:role-good-dst",
+        ]
+        assert policy["attributes"]["bindings"][1]["principals"] == []

--- a/tests/unit/test_synthetics_private_locations.py
+++ b/tests/unit/test_synthetics_private_locations.py
@@ -1,0 +1,86 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+"""Unit tests for synthetics_private_locations connect_resources drop behavior.
+
+The only access-control connection is the flat `metadata.restricted_roles` list. Under
+--drop-unresolvable-principals a permanently-stale role is dropped; an emptied list still
+hard-fails as an access-elevation guard.
+"""
+
+from collections import defaultdict
+from unittest.mock import MagicMock
+
+import pytest
+
+from datadog_sync.model.synthetics_private_locations import SyntheticsPrivateLocations
+from datadog_sync.utils.resource_utils import ResourceConnectionError
+from datadog_sync.utils.workers import Counter
+
+
+def _make_spl(drop=False, skip_failed=False):
+    config = MagicMock()
+    config.state = MagicMock()
+    config.state.source = defaultdict(dict)
+    config.state.destination = defaultdict(dict)
+    config.state.ensure_resource_loaded = MagicMock()
+    config.drop_unresolvable_principals = drop
+    config.skip_failed_resource_connections = skip_failed
+    config.counter = Counter()
+    config.logger = MagicMock()
+    return SyntheticsPrivateLocations(config)
+
+
+def _seed_valid_role(spl, src="role-good", dst="role-good-dst"):
+    spl.config.state.destination["roles"][src] = {"id": dst}
+
+
+def test_flag_off_stale_role_hard_fails():
+    spl = _make_spl(drop=False)
+    resource = {"id": "pl:abc", "metadata": {"restricted_roles": ["role-gone"]}}
+    with pytest.raises(ResourceConnectionError):
+        spl.connect_resources("pl:abc", resource)
+    assert resource["metadata"]["restricted_roles"] == ["role-gone"]  # not dropped when off
+
+
+def test_flag_on_drops_stale_keeps_valid():
+    spl = _make_spl(drop=True)
+    _seed_valid_role(spl)
+    resource = {"id": "pl:abc", "metadata": {"restricted_roles": ["role-good", "role-gone"]}}
+    spl.connect_resources("pl:abc", resource)  # no raise
+    assert resource["metadata"]["restricted_roles"] == ["role-good-dst"]
+    assert spl.config.counter.stale_principals_dropped_by_type["synthetics_private_locations"] == ["pl:abc"]
+
+
+def test_flag_on_all_stale_empty_list_raises_risk():
+    spl = _make_spl(drop=True)
+    resource = {"id": "pl:abc", "metadata": {"restricted_roles": ["role-gone"]}}
+    with pytest.raises(ResourceConnectionError) as exc_info:
+        spl.connect_resources("pl:abc", resource)
+    assert exc_info.value.empty_binding_risk is True
+    assert resource["metadata"]["restricted_roles"] == []
+
+
+def test_empty_list_risk_is_returned_when_connection_failure_is_suppressed():
+    spl = _make_spl(drop=True, skip_failed=True)
+    resource = {"id": "pl:abc", "metadata": {"restricted_roles": ["role-gone"]}}
+
+    assert spl.connect_resources("pl:abc", resource).empty_binding_escalation is True
+    assert resource["metadata"]["restricted_roles"] == []
+
+
+def test_flag_on_middle_drop_keeps_neighbors():
+    spl = _make_spl(drop=True)
+    _seed_valid_role(spl, src="ra", dst="ra-dst")
+    _seed_valid_role(spl, src="rc", dst="rc-dst")
+    resource = {"id": "pl:abc", "metadata": {"restricted_roles": ["ra", "role-gone", "rc"]}}
+    spl.connect_resources("pl:abc", resource)  # no raise
+    assert resource["metadata"]["restricted_roles"] == ["ra-dst", "rc-dst"]
+
+
+def test_no_metadata_is_noop():
+    spl = _make_spl(drop=True)
+    resource = {"id": "pl:abc"}  # no metadata/restricted_roles
+    spl.connect_resources("pl:abc", resource)  # no raise

--- a/tests/unit/test_synthetics_tests.py
+++ b/tests/unit/test_synthetics_tests.py
@@ -15,11 +15,14 @@ These tests verify:
 
 import asyncio
 import copy
+from collections import defaultdict
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 from datadog_sync.model.synthetics_tests import SyntheticsTests
 from datadog_sync.utils.configuration import Configuration
+from datadog_sync.utils.resource_utils import ResourceConnectionError
+from datadog_sync.utils.workers import Counter
 
 
 class TestSyntheticsTestsStatusBehavior:
@@ -474,5 +477,89 @@ class TestSyntheticsTestsRestrictionPolicyPrincipals:
         assert synthetics_tests.extract_source_ids("principals", binding, "teams") == []
 
 
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+class TestSyntheticsTestsConnectResourcesDrop:
+    """connect_resources drop/keep/hard-fail for synthetics_tests' access-control shapes:
+    flat `options.restricted_roles` and `restriction_policy.bindings.principals` composites.
+    """
+
+    def _make_test(self, drop=False, skip_failed=False):
+        config = MagicMock()
+        config.state = MagicMock()
+        config.state.source = defaultdict(dict)
+        config.state.destination = defaultdict(dict)
+        config.state.ensure_resource_loaded = MagicMock()
+        config.drop_unresolvable_principals = drop
+        config.skip_failed_resource_connections = skip_failed
+        config.counter = Counter()
+        config.logger = MagicMock()
+        return SyntheticsTests(config)
+
+    def _seed_valid_role(self, t, src="role-good", dst="role-good-dst"):
+        t.config.state.destination["roles"][src] = {"id": dst}
+
+    def test_restriction_policy_flag_on_drops_stale(self):
+        t = self._make_test(drop=True)
+        self._seed_valid_role(t)
+        resource = {
+            "public_id": "abc-def-ghi",
+            "restriction_policy": {
+                "bindings": [{"principals": ["role:role-good", "role:role-gone"], "relation": "editor"}]
+            },
+        }
+        t.connect_resources("abc-def-ghi", resource)  # no raise
+        assert resource["restriction_policy"]["bindings"][0]["principals"] == ["role:role-good-dst"]
+        assert t.config.counter.stale_principals_dropped_by_type["synthetics_tests"] == ["abc-def-ghi"]
+
+    def test_restriction_policy_flag_off_stale_hard_fails(self):
+        t = self._make_test(drop=False)
+        resource = {
+            "public_id": "abc-def-ghi",
+            "restriction_policy": {"bindings": [{"principals": ["role:role-gone"], "relation": "editor"}]},
+        }
+        with pytest.raises(ResourceConnectionError):
+            t.connect_resources("abc-def-ghi", resource)
+
+    def test_restriction_policy_empty_binding_raises_risk(self):
+        t = self._make_test(drop=True)
+        resource = {
+            "public_id": "abc-def-ghi",
+            "restriction_policy": {"bindings": [{"principals": ["role:role-gone"], "relation": "editor"}]},
+        }
+        with pytest.raises(ResourceConnectionError) as exc_info:
+            t.connect_resources("abc-def-ghi", resource)
+        assert exc_info.value.empty_binding_risk is True
+
+    def test_options_restricted_roles_flat_drops_stale(self):
+        t = self._make_test(drop=True)
+        self._seed_valid_role(t, src="role-good", dst="role-good-dst")
+        resource = {"public_id": "abc", "options": {"restricted_roles": ["role-good", "role-gone"]}}
+        t.connect_resources("abc", resource)  # no raise
+        assert resource["options"]["restricted_roles"] == ["role-good-dst"]
+
+    def test_options_restricted_roles_all_stale_empty_risk(self):
+        t = self._make_test(drop=True)
+        resource = {"public_id": "abc", "options": {"restricted_roles": ["role-gone"]}}
+        with pytest.raises(ResourceConnectionError) as exc_info:
+            t.connect_resources("abc", resource)
+        assert exc_info.value.empty_binding_risk is True
+        assert resource["options"]["restricted_roles"] == []
+
+    def test_options_restricted_roles_empty_risk_is_returned_when_connection_failure_is_suppressed(self):
+        t = self._make_test(drop=True, skip_failed=True)
+        resource = {"public_id": "abc", "options": {"restricted_roles": ["role-gone"]}}
+
+        assert t.connect_resources("abc", resource).empty_binding_escalation is True
+        assert resource["options"]["restricted_roles"] == []
+
+    def test_options_restricted_roles_middle_drop_keeps_neighbors(self):
+        t = self._make_test(drop=True)
+        self._seed_valid_role(t, src="ra", dst="ra-dst")
+        self._seed_valid_role(t, src="rc", dst="rc-dst")
+        resource = {"public_id": "abc", "options": {"restricted_roles": ["ra", "role-gone", "rc"]}}
+        t.connect_resources("abc", resource)  # no raise
+        assert resource["options"]["restricted_roles"] == ["ra-dst", "rc-dst"]
+
+    def test_extract_source_ids_principals_unaffected(self):
+        t = self._make_test(drop=True)
+        binding = {"principals": ["role:role-gone"], "relation": "editor"}
+        assert t.extract_source_ids("principals", binding, "roles") == ["role-gone"]


### PR DESCRIPTION
## Context

Stacked PR **2 of 4**. Base: `drop-unresolvable-principals-scaffolding` (PR #629).

## This PR

Overrides `connect_resources` on `RestrictionPolicies` so that, under `--drop-unresolvable-principals`, a principal absent from **both** destination and source is dropped from its binding and the policy still syncs, instead of the whole restriction policy being skipped on a single dead reference.

- Principals present in source but not destination keep today's hard-fail/retry behavior.
- If dropping empties a binding whose source list was non-empty, it is treated as a normal resource-connection failure. Without `--skip-failed-resource-connections`, the resource is skipped. With that flag enabled, the failure is intentionally suppressed and sync continues; an immediate ERROR explicitly says `DESTINATION RESOURCE MAY BE UNRESTRICTED`, and the successful action receives the dedicated risk metric and end-of-run ERROR summary.
- The "id" (dashboard/slo/notebook) connections keep the generic path unchanged.
- `extract_source_ids` intentionally remains unaffected so `--minimize-reads` lazy-loading can still resolve which principals to check.

## Testing

`TestRestrictionPoliciesConnectResources` covers flag off, drop-and-continue, source-present hard-fail, both empty-binding connection modes, metric/log propagation, multi-binding partial-empty, middle-element index-shift regression, `extract_source_ids`, org/non-composite pass-through, and dangling IDs. Focused tests green; `ruff` clean.
