### PR TITLE
fix(monitors,synthetics_tests): drop stale restricted_roles/principals under new flag (3/4)

### DIFF
--- a/datadog_sync/model/dashboards.py
+++ b/datadog_sync/model/dashboards.py
@@ -4,11 +4,18 @@
 # Copyright 2019 Datadog, Inc.
 
 from __future__ import annotations
+from collections import defaultdict
 from copy import deepcopy
 from typing import TYPE_CHECKING, Optional, List, Dict, Tuple, cast
 
-from datadog_sync.utils.base_resource import BaseResource, ResourceConfig
-from datadog_sync.utils.resource_utils import CustomClientHTTPError, SkipResource, check_diff, prep_resource
+from datadog_sync.utils.base_resource import BaseResource, ResourceConfig, ResourceConnectionResult
+from datadog_sync.utils.resource_utils import (
+    CustomClientHTTPError,
+    SkipResource,
+    check_diff,
+    find_attr,
+    prep_resource,
+)
 
 if TYPE_CHECKING:
     from datadog_sync.utils.custom_client import CustomClient
@@ -170,6 +177,37 @@ class Dashboards(BaseResource):
         destination_client = self.config.destination_client
         await destination_client.delete(
             self.resource_config.base_path + f"/{self.config.state.destination[self.resource_type][_id]['id']}"
+        )
+
+    def connect_resources(self, _id: str, resource: Dict) -> ResourceConnectionResult:
+        """Drop-aware override.
+
+        Widget connections (monitor alert_ids, powerpacks, slos) keep the generic
+        find_attr/connect_id path. The flat `restricted_roles` list goes through the shared
+        drop-aware filter so a permanently-stale role can be dropped (under
+        --drop-unresolvable-principals) while an emptied list still hard-fails as an
+        access-elevation guard.
+        """
+        if not self.resource_config.resource_connections:
+            return ResourceConnectionResult()
+
+        failed_connections_dict = defaultdict(list)
+        for resource_to_connect, attrs in self.resource_config.resource_connections.items():
+            for attr_connection in attrs:
+                if attr_connection == "restricted_roles":
+                    continue  # handled by the drop-aware filter below
+                c = find_attr(attr_connection, resource_to_connect, resource, self.connect_id)
+                if c:
+                    failed_connections_dict[resource_to_connect].extend(c)
+
+        role_failed, roles_risk = self._filter_stale_flat_roles(_id, resource, "restricted_roles")
+        if role_failed:
+            failed_connections_dict["roles"].extend(role_failed)
+
+        return ResourceConnectionResult(
+            empty_binding_escalation=self._raise_connection_error_if_any(
+                _id, failed_connections_dict, roles_risk
+            )
         )
 
     def connect_id(self, key: str, r_obj: Dict, resource_to_connect: str) -> Optional[List[str]]:

--- a/datadog_sync/model/monitors.py
+++ b/datadog_sync/model/monitors.py
@@ -4,14 +4,15 @@
 # Copyright 2019 Datadog, Inc.
 
 from __future__ import annotations
+from collections import defaultdict
 import logging
 import re
 from typing import TYPE_CHECKING, Optional, List, Dict, Tuple, cast
 
 from datadog_sync.constants import LOGGER_NAME
-from datadog_sync.utils.base_resource import BaseResource, ResourceConfig, TaggingConfig
+from datadog_sync.utils.base_resource import BaseResource, ResourceConfig, ResourceConnectionResult, TaggingConfig
 from datadog_sync.utils.custom_client import PaginationConfig
-from datadog_sync.utils.resource_utils import CustomClientHTTPError, SkipResource
+from datadog_sync.utils.resource_utils import CustomClientHTTPError, SkipResource, find_attr
 
 _log = logging.getLogger(LOGGER_NAME)
 
@@ -238,6 +239,49 @@ class Monitors(BaseResource):
             params={"force": "true"},
         )
 
+    def connect_resources(self, _id: str, resource: Dict) -> ResourceConnectionResult:
+        """Drop-aware override.
+
+        query / composite-monitor / slo-alert connections keep the generic
+        find_attr/connect_id path. The two access-control shapes -- the flat
+        `restricted_roles` list and the `restriction_policy.bindings.principals` composites
+        -- go through the shared drop-aware filters so permanently-stale references can be
+        dropped (under --drop-unresolvable-principals) while an emptied binding/list still
+        hard-fails as an access-elevation guard.
+        """
+        if not self.resource_config.resource_connections:
+            return ResourceConnectionResult()
+
+        failed_connections_dict = defaultdict(list)
+        for resource_to_connect, attrs in self.resource_config.resource_connections.items():
+            for attr_connection in attrs:
+                if attr_connection in ("restricted_roles", "restriction_policy.bindings.principals"):
+                    continue  # handled by the drop-aware filters below
+                c = find_attr(attr_connection, resource_to_connect, resource, self.connect_id)
+                if c:
+                    failed_connections_dict[resource_to_connect].extend(c)
+
+        empty_risk = False
+        restriction_policy = resource.get("restriction_policy")
+        if restriction_policy:
+            principal_failed, binding_risk = self._filter_stale_binding_principals(
+                _id, restriction_policy.get("bindings")
+            )
+            for rt, ids in principal_failed.items():
+                failed_connections_dict[rt].extend(ids)
+            empty_risk = empty_risk or binding_risk
+
+        role_failed, roles_risk = self._filter_stale_flat_roles(_id, resource, "restricted_roles")
+        if role_failed:
+            failed_connections_dict["roles"].extend(role_failed)
+        empty_risk = empty_risk or roles_risk
+
+        return ResourceConnectionResult(
+            empty_binding_escalation=self._raise_connection_error_if_any(
+                _id, failed_connections_dict, empty_risk
+            )
+        )
+
     def connect_id(self, key: str, r_obj: Dict, resource_to_connect: str) -> Optional[List[str]]:
         monitors = self.config.state.destination[resource_to_connect]
 
@@ -308,6 +352,9 @@ class Monitors(BaseResource):
 
     def extract_source_ids(self, key: str, r_obj: Dict, resource_to_connect: str) -> Optional[List[str]]:
         # Mirror of connect_id -- keep in sync when connect_id changes.
+        # Intentionally UNAFFECTED by --drop-unresolvable-principals: must keep returning
+        # every referenced id (including ones connect_resources will later drop) so
+        # --minimize-reads lazy-loading can look them up in source to make the drop decision.
         if key == "query" and r_obj.get("type") == "composite" and resource_to_connect != "service_level_objectives":
             return re.findall("[0-9]+", r_obj[key])
         elif key == "query" and resource_to_connect == "service_level_objectives" and r_obj.get("type") == "slo alert":

--- a/datadog_sync/model/synthetics_private_locations.py
+++ b/datadog_sync/model/synthetics_private_locations.py
@@ -6,11 +6,12 @@
 from __future__ import annotations
 import json
 import re
+from collections import defaultdict
 
 from typing import TYPE_CHECKING, List, Dict, Optional, Tuple
 
-from datadog_sync.utils.base_resource import BaseResource, ResourceConfig, TaggingConfig
-from datadog_sync.utils.resource_utils import SkipResource
+from datadog_sync.utils.base_resource import BaseResource, ResourceConfig, ResourceConnectionResult, TaggingConfig
+from datadog_sync.utils.resource_utils import SkipResource, find_attr
 
 if TYPE_CHECKING:
     from datadog_sync.utils.custom_client import CustomClient
@@ -100,6 +101,35 @@ class SyntheticsPrivateLocations(BaseResource):
         destination_client = self.config.destination_client
         await destination_client.delete(
             self.resource_config.base_path + f"/{self.config.state.destination[self.resource_type][_id]['id']}"
+        )
+
+    def connect_resources(self, _id: str, resource: Dict) -> ResourceConnectionResult:
+        """Drop-aware override for the flat `metadata.restricted_roles` list.
+
+        A permanently-stale role can be dropped (under --drop-unresolvable-principals) while
+        an emptied list still hard-fails as an access-elevation guard. Any future
+        non-restricted_roles connection keeps the generic find_attr/connect_id path.
+        """
+        if not self.resource_config.resource_connections:
+            return ResourceConnectionResult()
+
+        failed_connections_dict = defaultdict(list)
+        for resource_to_connect, attrs in self.resource_config.resource_connections.items():
+            for attr_connection in attrs:
+                if attr_connection == "metadata.restricted_roles":
+                    continue  # handled by the drop-aware filter below
+                c = find_attr(attr_connection, resource_to_connect, resource, self.connect_id)
+                if c:
+                    failed_connections_dict[resource_to_connect].extend(c)
+
+        role_failed, roles_risk = self._filter_stale_flat_roles(_id, resource.get("metadata"), "restricted_roles")
+        if role_failed:
+            failed_connections_dict["roles"].extend(role_failed)
+
+        return ResourceConnectionResult(
+            empty_binding_escalation=self._raise_connection_error_if_any(
+                _id, failed_connections_dict, roles_risk
+            )
         )
 
     def connect_id(self, key: str, r_obj: Dict, resource_to_connect: str) -> Optional[List[str]]:

--- a/datadog_sync/model/synthetics_tests.py
+++ b/datadog_sync/model/synthetics_tests.py
@@ -9,11 +9,13 @@ import aiohttp
 import certifi
 import json
 import ssl
+from collections import defaultdict
 from copy import deepcopy
 from typing import TYPE_CHECKING, Optional, List, Dict, Tuple, cast
 from yarl import URL
 
-from datadog_sync.utils.base_resource import BaseResource, ResourceConfig, TaggingConfig
+from datadog_sync.utils.base_resource import BaseResource, ResourceConfig, ResourceConnectionResult, TaggingConfig
+from datadog_sync.utils.resource_utils import find_attr
 from datadog_sync.model.synthetics_mobile_applications_versions import SyntheticsMobileApplicationsVersions
 
 if TYPE_CHECKING:
@@ -422,6 +424,49 @@ class SyntheticsTests(BaseResource):
         dest_resource = self.config.state.destination[self.resource_type][_id]
         await self._delete_test(destination_client, dest_resource.get("type"), dest_resource["public_id"])
 
+    def connect_resources(self, _id: str, resource: Dict) -> ResourceConnectionResult:
+        """Drop-aware override.
+
+        All non-access-control connections (private locations, subtests, global variables,
+        rum/mobile apps) keep the generic find_attr/connect_id path. The flat
+        `options.restricted_roles` list and the `restriction_policy.bindings.principals`
+        composites go through the shared drop-aware filters so permanently-stale references
+        can be dropped (under --drop-unresolvable-principals) while an emptied binding/list
+        still hard-fails as an access-elevation guard.
+        """
+        if not self.resource_config.resource_connections:
+            return ResourceConnectionResult()
+
+        failed_connections_dict = defaultdict(list)
+        for resource_to_connect, attrs in self.resource_config.resource_connections.items():
+            for attr_connection in attrs:
+                if attr_connection in ("options.restricted_roles", "restriction_policy.bindings.principals"):
+                    continue  # handled by the drop-aware filters below
+                c = find_attr(attr_connection, resource_to_connect, resource, self.connect_id)
+                if c:
+                    failed_connections_dict[resource_to_connect].extend(c)
+
+        empty_risk = False
+        restriction_policy = resource.get("restriction_policy")
+        if restriction_policy:
+            principal_failed, binding_risk = self._filter_stale_binding_principals(
+                _id, restriction_policy.get("bindings")
+            )
+            for rt, ids in principal_failed.items():
+                failed_connections_dict[rt].extend(ids)
+            empty_risk = empty_risk or binding_risk
+
+        role_failed, roles_risk = self._filter_stale_flat_roles(_id, resource.get("options"), "restricted_roles")
+        if role_failed:
+            failed_connections_dict["roles"].extend(role_failed)
+        empty_risk = empty_risk or roles_risk
+
+        return ResourceConnectionResult(
+            empty_binding_escalation=self._raise_connection_error_if_any(
+                _id, failed_connections_dict, empty_risk
+            )
+        )
+
     def connect_id(self, key: str, r_obj: Dict, resource_to_connect: str) -> Optional[List[str]]:
         failed_connections: List[str] = []
         if resource_to_connect == "synthetics_private_locations":
@@ -504,6 +549,9 @@ class SyntheticsTests(BaseResource):
 
     def extract_source_ids(self, key: str, r_obj: Dict, resource_to_connect: str) -> Optional[List[str]]:
         # Mirror of connect_id -- keep in sync when connect_id changes.
+        # Intentionally UNAFFECTED by --drop-unresolvable-principals: must keep returning
+        # every referenced id (including ones connect_resources will later drop) so
+        # --minimize-reads lazy-loading can look them up in source to make the drop decision.
         # Only synthetics_private_locations and mobile application versions need special handling.
         # rum_applications, synthetics_tests (subtests), synthetics_global_variables, roles, and
         # synthetics_mobile_applications (applicationId key) all use plain IDs at the leaf —

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -12,12 +12,14 @@ clone-on-update fallback.
 """
 
 import asyncio
+from collections import defaultdict
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from datadog_sync.model.dashboards import Dashboards
-from datadog_sync.utils.resource_utils import CustomClientHTTPError, SkipResource
+from datadog_sync.utils.resource_utils import CustomClientHTTPError, ResourceConnectionError, SkipResource
+from datadog_sync.utils.workers import Counter
 
 
 def _read_only_error() -> CustomClientHTTPError:
@@ -285,3 +287,65 @@ class TestDashboardsReadOnlyConflict:
         with pytest.raises(CustomClientHTTPError):
             asyncio.run(dashboards.update_resource("abc-123", {"title": "src"}))
         dashboards.config.destination_client.post.assert_not_awaited()
+
+
+class TestDashboardsConnectResourcesDrop:
+    """connect_resources drop/keep/hard-fail for dashboards' flat `restricted_roles`."""
+
+    def _make_dashboard(self, drop=False, skip_failed=False):
+        config = MagicMock()
+        config.state = MagicMock()
+        config.state.source = defaultdict(dict)
+        config.state.destination = defaultdict(dict)
+        config.state.ensure_resource_loaded = MagicMock()
+        config.drop_unresolvable_principals = drop
+        config.skip_failed_resource_connections = skip_failed
+        config.counter = Counter()
+        config.logger = MagicMock()
+        return Dashboards(config)
+
+    def _seed_valid_role(self, d, src="role-good", dst="role-good-dst"):
+        d.config.state.destination["roles"][src] = {"id": dst}
+
+    def test_flag_off_stale_role_hard_fails(self):
+        d = self._make_dashboard(drop=False)
+        resource = {"id": "abc-def-ghi", "restricted_roles": ["role-gone"]}
+        with pytest.raises(ResourceConnectionError):
+            d.connect_resources("abc-def-ghi", resource)
+        assert resource["restricted_roles"] == ["role-gone"]  # not dropped when flag off
+
+    def test_flag_on_drops_stale_keeps_valid(self):
+        d = self._make_dashboard(drop=True)
+        self._seed_valid_role(d)
+        resource = {"id": "abc-def-ghi", "restricted_roles": ["role-good", "role-gone"]}
+        d.connect_resources("abc-def-ghi", resource)  # no raise
+        assert resource["restricted_roles"] == ["role-good-dst"]
+        assert d.config.counter.stale_principals_dropped_by_type["dashboards"] == ["abc-def-ghi"]
+
+    def test_flag_on_all_stale_empty_list_raises_risk(self):
+        d = self._make_dashboard(drop=True)
+        resource = {"id": "abc-def-ghi", "restricted_roles": ["role-gone"]}
+        with pytest.raises(ResourceConnectionError) as exc_info:
+            d.connect_resources("abc-def-ghi", resource)
+        assert exc_info.value.empty_binding_risk is True
+        assert resource["restricted_roles"] == []
+
+    def test_empty_list_risk_is_returned_when_connection_failure_is_suppressed(self):
+        d = self._make_dashboard(drop=True, skip_failed=True)
+        resource = {"id": "abc-def-ghi", "restricted_roles": ["role-gone"]}
+
+        assert d.connect_resources("abc-def-ghi", resource).empty_binding_escalation is True
+        assert resource["restricted_roles"] == []
+
+    def test_flag_on_middle_drop_keeps_neighbors(self):
+        d = self._make_dashboard(drop=True)
+        self._seed_valid_role(d, src="ra", dst="ra-dst")
+        self._seed_valid_role(d, src="rc", dst="rc-dst")
+        resource = {"id": "abc", "restricted_roles": ["ra", "role-gone", "rc"]}
+        d.connect_resources("abc", resource)  # no raise
+        assert resource["restricted_roles"] == ["ra-dst", "rc-dst"]
+
+    def test_no_restricted_roles_is_noop(self):
+        d = self._make_dashboard(drop=True)
+        resource = {"id": "abc"}  # no restricted_roles at all
+        d.connect_resources("abc", resource)  # no raise, nothing to do

--- a/tests/unit/test_monitors.py
+++ b/tests/unit/test_monitors.py
@@ -11,11 +11,13 @@ empty options.groupby are skipped at sync time rather than failing with a 400.
 """
 
 import asyncio
+from collections import defaultdict
 import pytest
 from unittest.mock import MagicMock
 
 from datadog_sync.model.monitors import Monitors
-from datadog_sync.utils.resource_utils import SkipResource
+from datadog_sync.utils.resource_utils import SkipResource, ResourceConnectionError
+from datadog_sync.utils.workers import Counter
 
 
 class TestMonitorsPreResourceActionHook:
@@ -635,3 +637,102 @@ class TestMonitorsRestrictionPolicyPrincipals:
         asyncio.run(monitors.pre_apply_hook())
         assert monitors.org_principal is None
         mock_client.get.assert_not_awaited()
+
+
+class TestMonitorsConnectResourcesDrop:
+    """connect_resources drop/keep/hard-fail for monitors' access-control shapes:
+    the flat `restricted_roles` list and `restriction_policy.bindings.principals` composites.
+    'stale' == absent from destination AND source; 'valid' == present in destination.
+    """
+
+    def _make_monitors(self, drop=False, skip_failed=False):
+        config = MagicMock()
+        config.state = MagicMock()
+        config.state.source = defaultdict(dict)
+        config.state.destination = defaultdict(dict)
+        config.state.ensure_resource_loaded = MagicMock()
+        config.drop_unresolvable_principals = drop
+        config.skip_failed_resource_connections = skip_failed
+        config.counter = Counter()
+        config.logger = MagicMock()
+        return Monitors(config)
+
+    def _seed_valid_role(self, m, src="role-good", dst="role-good-dst"):
+        m.config.state.destination["roles"][src] = {"id": dst}
+
+    def test_restriction_policy_flag_off_stale_hard_fails(self):
+        m = self._make_monitors(drop=False)
+        resource = {
+            "id": 1,
+            "query": "avg(last_5m):sum:x{*} > 1",
+            "restriction_policy": {"bindings": [{"principals": ["role:role-gone"], "relation": "editor"}]},
+        }
+        with pytest.raises(ResourceConnectionError):
+            m.connect_resources("1", resource)
+
+    def test_restriction_policy_flag_on_drops_stale(self):
+        m = self._make_monitors(drop=True)
+        self._seed_valid_role(m)
+        resource = {
+            "id": 1,
+            "query": "avg(last_5m):sum:x{*} > 1",
+            "restriction_policy": {
+                "bindings": [{"principals": ["role:role-good", "role:role-gone"], "relation": "editor"}]
+            },
+        }
+        m.connect_resources("1", resource)  # no raise
+        assert resource["restriction_policy"]["bindings"][0]["principals"] == ["role:role-good-dst"]
+        assert m.config.counter.stale_principals_dropped_by_type["monitors"] == ["1"]
+
+    def test_restriction_policy_empty_binding_raises_risk(self):
+        m = self._make_monitors(drop=True)
+        resource = {
+            "id": 1,
+            "restriction_policy": {"bindings": [{"principals": ["role:role-gone"], "relation": "editor"}]},
+        }
+        with pytest.raises(ResourceConnectionError) as exc_info:
+            m.connect_resources("1", resource)
+        assert exc_info.value.empty_binding_risk is True
+
+    def test_restricted_roles_flat_flag_on_drops_stale(self):
+        m = self._make_monitors(drop=True)
+        self._seed_valid_role(m, src="role-good", dst="role-good-dst")
+        resource = {"id": 1, "restricted_roles": ["role-good", "role-gone"]}
+        m.connect_resources("1", resource)  # no raise
+        assert resource["restricted_roles"] == ["role-good-dst"]
+
+    def test_restricted_roles_flat_all_stale_empty_risk(self):
+        m = self._make_monitors(drop=True)
+        resource = {"id": 1, "restricted_roles": ["role-gone"]}
+        with pytest.raises(ResourceConnectionError) as exc_info:
+            m.connect_resources("1", resource)
+        assert exc_info.value.empty_binding_risk is True
+        assert resource["restricted_roles"] == []
+
+    def test_restricted_roles_flat_empty_risk_is_returned_when_connection_failure_is_suppressed(self):
+        m = self._make_monitors(drop=True, skip_failed=True)
+        resource = {"id": 1, "restricted_roles": ["role-gone"]}
+
+        assert m.connect_resources("1", resource).empty_binding_escalation is True
+        assert resource["restricted_roles"] == []
+
+    def test_restricted_roles_flat_middle_drop_keeps_neighbors(self):
+        m = self._make_monitors(drop=True)
+        self._seed_valid_role(m, src="ra", dst="ra-dst")
+        self._seed_valid_role(m, src="rc", dst="rc-dst")
+        resource = {"id": 1, "restricted_roles": ["ra", "role-gone", "rc"]}
+        m.connect_resources("1", resource)  # no raise
+        assert resource["restricted_roles"] == ["ra-dst", "rc-dst"]
+
+    def test_flag_off_restricted_roles_unchanged_behavior(self):
+        m = self._make_monitors(drop=False)
+        resource = {"id": 1, "restricted_roles": ["role-gone"]}
+        with pytest.raises(ResourceConnectionError):
+            m.connect_resources("1", resource)
+        # Flag off => not dropped
+        assert resource["restricted_roles"] == ["role-gone"]
+
+    def test_extract_source_ids_principals_unaffected(self):
+        m = self._make_monitors(drop=True)
+        binding = {"principals": ["role:role-gone"], "relation": "editor"}
+        assert m.extract_source_ids("principals", binding, "roles") == ["role-gone"]

--- a/tests/unit/test_synthetics_private_locations.py
+++ b/tests/unit/test_synthetics_private_locations.py
@@ -1,0 +1,86 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+"""Unit tests for synthetics_private_locations connect_resources drop behavior.
+
+The only access-control connection is the flat `metadata.restricted_roles` list. Under
+--drop-unresolvable-principals a permanently-stale role is dropped; an emptied list still
+hard-fails as an access-elevation guard.
+"""
+
+from collections import defaultdict
+from unittest.mock import MagicMock
+
+import pytest
+
+from datadog_sync.model.synthetics_private_locations import SyntheticsPrivateLocations
+from datadog_sync.utils.resource_utils import ResourceConnectionError
+from datadog_sync.utils.workers import Counter
+
+
+def _make_spl(drop=False, skip_failed=False):
+    config = MagicMock()
+    config.state = MagicMock()
+    config.state.source = defaultdict(dict)
+    config.state.destination = defaultdict(dict)
+    config.state.ensure_resource_loaded = MagicMock()
+    config.drop_unresolvable_principals = drop
+    config.skip_failed_resource_connections = skip_failed
+    config.counter = Counter()
+    config.logger = MagicMock()
+    return SyntheticsPrivateLocations(config)
+
+
+def _seed_valid_role(spl, src="role-good", dst="role-good-dst"):
+    spl.config.state.destination["roles"][src] = {"id": dst}
+
+
+def test_flag_off_stale_role_hard_fails():
+    spl = _make_spl(drop=False)
+    resource = {"id": "pl:abc", "metadata": {"restricted_roles": ["role-gone"]}}
+    with pytest.raises(ResourceConnectionError):
+        spl.connect_resources("pl:abc", resource)
+    assert resource["metadata"]["restricted_roles"] == ["role-gone"]  # not dropped when off
+
+
+def test_flag_on_drops_stale_keeps_valid():
+    spl = _make_spl(drop=True)
+    _seed_valid_role(spl)
+    resource = {"id": "pl:abc", "metadata": {"restricted_roles": ["role-good", "role-gone"]}}
+    spl.connect_resources("pl:abc", resource)  # no raise
+    assert resource["metadata"]["restricted_roles"] == ["role-good-dst"]
+    assert spl.config.counter.stale_principals_dropped_by_type["synthetics_private_locations"] == ["pl:abc"]
+
+
+def test_flag_on_all_stale_empty_list_raises_risk():
+    spl = _make_spl(drop=True)
+    resource = {"id": "pl:abc", "metadata": {"restricted_roles": ["role-gone"]}}
+    with pytest.raises(ResourceConnectionError) as exc_info:
+        spl.connect_resources("pl:abc", resource)
+    assert exc_info.value.empty_binding_risk is True
+    assert resource["metadata"]["restricted_roles"] == []
+
+
+def test_empty_list_risk_is_returned_when_connection_failure_is_suppressed():
+    spl = _make_spl(drop=True, skip_failed=True)
+    resource = {"id": "pl:abc", "metadata": {"restricted_roles": ["role-gone"]}}
+
+    assert spl.connect_resources("pl:abc", resource).empty_binding_escalation is True
+    assert resource["metadata"]["restricted_roles"] == []
+
+
+def test_flag_on_middle_drop_keeps_neighbors():
+    spl = _make_spl(drop=True)
+    _seed_valid_role(spl, src="ra", dst="ra-dst")
+    _seed_valid_role(spl, src="rc", dst="rc-dst")
+    resource = {"id": "pl:abc", "metadata": {"restricted_roles": ["ra", "role-gone", "rc"]}}
+    spl.connect_resources("pl:abc", resource)  # no raise
+    assert resource["metadata"]["restricted_roles"] == ["ra-dst", "rc-dst"]
+
+
+def test_no_metadata_is_noop():
+    spl = _make_spl(drop=True)
+    resource = {"id": "pl:abc"}  # no metadata/restricted_roles
+    spl.connect_resources("pl:abc", resource)  # no raise

--- a/tests/unit/test_synthetics_tests.py
+++ b/tests/unit/test_synthetics_tests.py
@@ -15,11 +15,14 @@ These tests verify:
 
 import asyncio
 import copy
+from collections import defaultdict
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 from datadog_sync.model.synthetics_tests import SyntheticsTests
 from datadog_sync.utils.configuration import Configuration
+from datadog_sync.utils.resource_utils import ResourceConnectionError
+from datadog_sync.utils.workers import Counter
 
 
 class TestSyntheticsTestsStatusBehavior:
@@ -474,5 +477,89 @@ class TestSyntheticsTestsRestrictionPolicyPrincipals:
         assert synthetics_tests.extract_source_ids("principals", binding, "teams") == []
 
 
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+class TestSyntheticsTestsConnectResourcesDrop:
+    """connect_resources drop/keep/hard-fail for synthetics_tests' access-control shapes:
+    flat `options.restricted_roles` and `restriction_policy.bindings.principals` composites.
+    """
+
+    def _make_test(self, drop=False, skip_failed=False):
+        config = MagicMock()
+        config.state = MagicMock()
+        config.state.source = defaultdict(dict)
+        config.state.destination = defaultdict(dict)
+        config.state.ensure_resource_loaded = MagicMock()
+        config.drop_unresolvable_principals = drop
+        config.skip_failed_resource_connections = skip_failed
+        config.counter = Counter()
+        config.logger = MagicMock()
+        return SyntheticsTests(config)
+
+    def _seed_valid_role(self, t, src="role-good", dst="role-good-dst"):
+        t.config.state.destination["roles"][src] = {"id": dst}
+
+    def test_restriction_policy_flag_on_drops_stale(self):
+        t = self._make_test(drop=True)
+        self._seed_valid_role(t)
+        resource = {
+            "public_id": "abc-def-ghi",
+            "restriction_policy": {
+                "bindings": [{"principals": ["role:role-good", "role:role-gone"], "relation": "editor"}]
+            },
+        }
+        t.connect_resources("abc-def-ghi", resource)  # no raise
+        assert resource["restriction_policy"]["bindings"][0]["principals"] == ["role:role-good-dst"]
+        assert t.config.counter.stale_principals_dropped_by_type["synthetics_tests"] == ["abc-def-ghi"]
+
+    def test_restriction_policy_flag_off_stale_hard_fails(self):
+        t = self._make_test(drop=False)
+        resource = {
+            "public_id": "abc-def-ghi",
+            "restriction_policy": {"bindings": [{"principals": ["role:role-gone"], "relation": "editor"}]},
+        }
+        with pytest.raises(ResourceConnectionError):
+            t.connect_resources("abc-def-ghi", resource)
+
+    def test_restriction_policy_empty_binding_raises_risk(self):
+        t = self._make_test(drop=True)
+        resource = {
+            "public_id": "abc-def-ghi",
+            "restriction_policy": {"bindings": [{"principals": ["role:role-gone"], "relation": "editor"}]},
+        }
+        with pytest.raises(ResourceConnectionError) as exc_info:
+            t.connect_resources("abc-def-ghi", resource)
+        assert exc_info.value.empty_binding_risk is True
+
+    def test_options_restricted_roles_flat_drops_stale(self):
+        t = self._make_test(drop=True)
+        self._seed_valid_role(t, src="role-good", dst="role-good-dst")
+        resource = {"public_id": "abc", "options": {"restricted_roles": ["role-good", "role-gone"]}}
+        t.connect_resources("abc", resource)  # no raise
+        assert resource["options"]["restricted_roles"] == ["role-good-dst"]
+
+    def test_options_restricted_roles_all_stale_empty_risk(self):
+        t = self._make_test(drop=True)
+        resource = {"public_id": "abc", "options": {"restricted_roles": ["role-gone"]}}
+        with pytest.raises(ResourceConnectionError) as exc_info:
+            t.connect_resources("abc", resource)
+        assert exc_info.value.empty_binding_risk is True
+        assert resource["options"]["restricted_roles"] == []
+
+    def test_options_restricted_roles_empty_risk_is_returned_when_connection_failure_is_suppressed(self):
+        t = self._make_test(drop=True, skip_failed=True)
+        resource = {"public_id": "abc", "options": {"restricted_roles": ["role-gone"]}}
+
+        assert t.connect_resources("abc", resource).empty_binding_escalation is True
+        assert resource["options"]["restricted_roles"] == []
+
+    def test_options_restricted_roles_middle_drop_keeps_neighbors(self):
+        t = self._make_test(drop=True)
+        self._seed_valid_role(t, src="ra", dst="ra-dst")
+        self._seed_valid_role(t, src="rc", dst="rc-dst")
+        resource = {"public_id": "abc", "options": {"restricted_roles": ["ra", "role-gone", "rc"]}}
+        t.connect_resources("abc", resource)  # no raise
+        assert resource["options"]["restricted_roles"] == ["ra-dst", "rc-dst"]
+
+    def test_extract_source_ids_principals_unaffected(self):
+        t = self._make_test(drop=True)
+        binding = {"principals": ["role:role-gone"], "relation": "editor"}
+        assert t.extract_source_ids("principals", binding, "roles") == ["role-gone"]


### PR DESCRIPTION
## Context

Stacked PR **3 of 4**. Base: `drop-unresolvable-principals-restriction-policies` (PR #630).

## This PR

Applies the same drop-aware pattern (PR #629 helpers) to the two resource types carrying both a flat `restricted_roles` list and a `restriction_policy.bindings.principals` composite:

- **monitors**: `restricted_roles` + `restriction_policy.bindings.principals`
- **synthetics_tests**: `options.restricted_roles` + `restriction_policy.bindings.principals`

Each `connect_resources` override keeps non-access-control connections on the generic path and filters access-control references through the shared helpers. An emptied list is a normal resource-connection failure: it skips by default, while `--skip-failed-resource-connections=true` intentionally continues with the explicit unrestricted-destination ERROR, risk metric, and end-of-run ERROR summary introduced in PR #629. `extract_source_ids` remains unaffected. Behavior is unchanged when the new drop flag is off.

## Testing

The monitor and synthetics suites cover both composite and flat-list shapes, including drop, default empty-risk failure, suppressed empty-risk propagation, middle-element regression, and flag-off behavior. Focused tests green; `ruff` clean.
