### PR TITLE
feat(users): backfill destination email via a second PATCH when handle differs

### DIFF
--- a/datadog_sync/model/users.py
+++ b/datadog_sync/model/users.py
@@ -155,7 +155,7 @@ class Users(BaseResource):
             self.resource_config.base_path + f"/{user['id']}",
             {"data": {"id": user["id"], "type": user.get("type", "users"), "attributes": {"email": email}}},
         )
-        return resp["data"]
+        return self._merge_role_state(resp["data"], user)
 
     async def _create_service_account(self, _id: str, resource: Dict) -> Tuple[str, Dict]:
         """Create the user via POST /api/v2/service_accounts.

--- a/datadog_sync/model/users.py
+++ b/datadog_sync/model/users.py
@@ -120,11 +120,42 @@ class Users(BaseResource):
         # so the routing check above could read it).
         attributes.pop("service_account", None)
         destination_client = self.config.destination_client
+        handle = attributes.get("handle")
+        email = attributes.get("email")
         # handle is read-only in v2 (derived from email) and must not be sent.
         attributes.pop("disabled", None)
         attributes.pop("handle", None)
+
+        # v2 derives the destination handle from the create-time email. When the
+        # source handle differs from the source email, send the handle as the
+        # create-time email so the destination handle matches the source handle,
+        # then patch the email to the real address in a second call.
+        needs_email_backfill = bool(handle) and bool(email) and handle != email
+        if needs_email_backfill:
+            attributes["email"] = handle
+
         resp = await destination_client.post(self.resource_config.base_path, {"data": resource})
-        return _id, resp["data"]
+        user = resp["data"]
+
+        if needs_email_backfill:
+            try:
+                user = await self._backfill_email(user, email)
+            except CustomClientHTTPError:
+                # The user exists with the handle as a placeholder email. Persist it
+                # so a retry takes the update path (which will patch the email) rather
+                # than re-attempting a create that now 409s on the taken handle.
+                self.config.state.destination[self.resource_type][_id] = user
+                raise
+
+        return _id, user
+
+    async def _backfill_email(self, user: Dict, email: str) -> Dict:
+        destination_client = self.config.destination_client
+        resp = await destination_client.patch(
+            self.resource_config.base_path + f"/{user['id']}",
+            {"data": {"id": user["id"], "type": user.get("type", "users"), "attributes": {"email": email}}},
+        )
+        return resp["data"]
 
     async def _create_service_account(self, _id: str, resource: Dict) -> Tuple[str, Dict]:
         """Create the user via POST /api/v2/service_accounts.

--- a/datadog_sync/model/users.py
+++ b/datadog_sync/model/users.py
@@ -140,7 +140,7 @@ class Users(BaseResource):
         if needs_email_backfill:
             try:
                 user = await self._backfill_email(user, email)
-            except CustomClientHTTPError:
+            except Exception:
                 # The user exists with the handle as a placeholder email. Persist it
                 # so a retry takes the update path (which will patch the email) rather
                 # than re-attempting a create that now 409s on the taken handle.

--- a/tests/unit/test_users.py
+++ b/tests/unit/test_users.py
@@ -170,6 +170,20 @@ class TestV2CreatePayload:
 
         assert mock_config.state.destination["users"]["src-a"] == created_user
 
+    def test_v2_create_email_backfill_timeout_persists_partial_state(self, mock_config):
+        """A transport timeout after create must preserve the created user too."""
+        instance = Users(mock_config)
+        instance._existing_resources_map = {}
+        created_user = {"id": "dest-x", "type": "users", "attributes": {"email": "user-a@example.com"}}
+        mock_config.destination_client.post = AsyncMock(return_value={"data": created_user})
+        mock_config.destination_client.patch = AsyncMock(side_effect=asyncio.TimeoutError())
+        src = _make_user("user-a@example.com", "shared@example.com", "src-a")
+
+        with pytest.raises(asyncio.TimeoutError):
+            asyncio.run(instance.create_resource("src-a", src))
+
+        assert mock_config.state.destination["users"]["src-a"] == created_user
+
     def test_v2_patch_body_excludes_handle(self, mock_config):
         """f2: the v2 update (PATCH) body must not carry the read-only handle."""
         instance = Users(mock_config)
@@ -325,11 +339,13 @@ class TestServiceAccountCreatePath:
         instance = Users(mock_config)
         instance._existing_resources_map = {}
         mock_config.destination_client.post = AsyncMock(return_value={"data": {"id": "dest-sa", "attributes": {}}})
-        src = _make_service_account("svc-a@example.com", "svc-a@example.com", "src-sa")
+        mock_config.destination_client.patch = AsyncMock()
+        src = _make_service_account("service-account-handle", "svc-a@example.com", "src-sa")
 
         _id, r = asyncio.run(instance.create_resource("src-sa", src))
 
         assert _post_paths(mock_config) == ["/api/v2/service_accounts"]
+        mock_config.destination_client.patch.assert_not_awaited()
         _, body = mock_config.destination_client.post.call_args.args
         attrs = body["data"]["attributes"]
         assert attrs["service_account"] is True
@@ -372,6 +388,9 @@ class TestServiceAccountCreatePath:
         instance = Users(mock_config)
         instance._existing_resources_map = {}
         mock_config.destination_client.post = AsyncMock(return_value={"data": {"id": "dest-x", "attributes": {}}})
+        mock_config.destination_client.patch = AsyncMock(
+            return_value={"data": {"id": "dest-x", "type": "users", "attributes": {"email": "shared@example.com"}}}
+        )
         src = _make_user("user-a@example.com", "shared@example.com", "src-a")
         src["attributes"]["service_account"] = False
 

--- a/tests/unit/test_users.py
+++ b/tests/unit/test_users.py
@@ -24,7 +24,7 @@ sent on the plain-user create/update paths.
 """
 
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -100,7 +100,12 @@ class TestV2CreatePayload:
         """f: the v2 create body must not carry read-only handle or disabled."""
         instance = Users(mock_config)
         instance._existing_resources_map = {}
-        mock_config.destination_client.post = AsyncMock(return_value={"data": {"id": "dest-x", "attributes": {}}})
+        mock_config.destination_client.post = AsyncMock(
+            return_value={"data": {"id": "dest-x", "type": "users", "attributes": {}}}
+        )
+        mock_config.destination_client.patch = AsyncMock(
+            return_value={"data": {"id": "dest-x", "type": "users", "attributes": {}}}
+        )
         src = _make_user("user-a@example.com", "shared@example.com", "src-a")
 
         asyncio.run(instance.create_resource("src-a", src))
@@ -110,6 +115,60 @@ class TestV2CreatePayload:
         attrs = body["data"]["attributes"]
         assert "handle" not in attrs
         assert "disabled" not in attrs
+
+    def test_v2_create_email_backfill_when_handle_differs_from_email(self, mock_config):
+        """The create POST uses the handle as the email so the destination
+        derives a matching handle, then a PATCH restores the real email."""
+        instance = Users(mock_config)
+        instance._existing_resources_map = {}
+        mock_config.destination_client.post = AsyncMock(
+            return_value={"data": {"id": "dest-x", "type": "users", "attributes": {"email": "user-a@example.com"}}}
+        )
+        mock_config.destination_client.patch = AsyncMock(
+            return_value={"data": {"id": "dest-x", "type": "users", "attributes": {"email": "shared@example.com"}}}
+        )
+        src = _make_user("user-a@example.com", "shared@example.com", "src-a")
+
+        _id, user = asyncio.run(instance.create_resource("src-a", src))
+
+        _, post_body = mock_config.destination_client.post.call_args.args
+        assert post_body["data"]["attributes"]["email"] == "user-a@example.com"
+
+        patch_path, patch_body = mock_config.destination_client.patch.call_args.args
+        assert patch_path == "/api/v2/users/dest-x"
+        assert patch_body["data"]["attributes"] == {"email": "shared@example.com"}
+        assert user["attributes"]["email"] == "shared@example.com"
+
+    def test_v2_create_no_backfill_when_handle_matches_email(self, mock_config):
+        """No second call is made when the source handle equals the source email."""
+        instance = Users(mock_config)
+        instance._existing_resources_map = {}
+        mock_config.destination_client.post = AsyncMock(
+            return_value={"data": {"id": "dest-x", "type": "users", "attributes": {"email": "same@example.com"}}}
+        )
+        mock_config.destination_client.patch = AsyncMock()
+        src = _make_user("same@example.com", "same@example.com", "src-a")
+
+        asyncio.run(instance.create_resource("src-a", src))
+
+        mock_config.destination_client.patch.assert_not_called()
+
+    def test_v2_create_email_backfill_failure_persists_partial_state(self, mock_config):
+        """If the email-restoring PATCH fails, the created user (with the handle
+        as a placeholder email) is persisted so a retry updates instead of
+        re-creating into a 409 on the now-taken handle."""
+        instance = Users(mock_config)
+        instance._existing_resources_map = {}
+        created_user = {"id": "dest-x", "type": "users", "attributes": {"email": "user-a@example.com"}}
+        mock_config.destination_client.post = AsyncMock(return_value={"data": created_user})
+        fake_response = MagicMock(status=500, message="boom")
+        mock_config.destination_client.patch = AsyncMock(side_effect=CustomClientHTTPError(fake_response, "boom"))
+        src = _make_user("user-a@example.com", "shared@example.com", "src-a")
+
+        with pytest.raises(CustomClientHTTPError):
+            asyncio.run(instance.create_resource("src-a", src))
+
+        assert mock_config.state.destination["users"]["src-a"] == created_user
 
     def test_v2_patch_body_excludes_handle(self, mock_config):
         """f2: the v2 update (PATCH) body must not carry the read-only handle."""
@@ -145,7 +204,12 @@ class TestV2CreatePath:
         """b: create always goes through the v2 endpoint."""
         instance = Users(mock_config)
         instance._existing_resources_map = {}
-        mock_config.destination_client.post = AsyncMock(return_value={"data": {"id": "dest-x", "attributes": {}}})
+        mock_config.destination_client.post = AsyncMock(
+            return_value={"data": {"id": "dest-x", "type": "users", "attributes": {}}}
+        )
+        mock_config.destination_client.patch = AsyncMock(
+            return_value={"data": {"id": "dest-x", "type": "users", "attributes": {}}}
+        )
 
         asyncio.run(instance.create_resource("src-a", _make_user("user-a@example.com", "shared@example.com", "src-a")))
 


### PR DESCRIPTION
## Summary

v2 user creation (`POST /api/v2/users`) derives the destination `handle` from the create-time `email` and does not accept `handle` directly. When a source user's handle isn't itself their email address, this leaves no way to make the destination handle match the source handle.

This PR adds a two-call create path for that case:
1. `POST /api/v2/users` with the source **handle** passed as the create-time `email`, so the destination derives a handle matching the source handle.
2. `PATCH /api/v2/users/{id}` to set the real source `email`.

When the source handle already equals the source email, create is unchanged (a single POST).

## Behavior

- Handle differs from email → POST (email=handle) then PATCH (email=real email).
- Handle equals email, or handle/email missing → single POST, no PATCH.
- If the email-restoring PATCH fails, the created user (with the handle as a placeholder email) is persisted to state so the next run's diff routes it through the update path instead of re-attempting a create that now 409s on the already-taken handle.

## Test plan

- [x] POST uses handle as email, PATCH restores the real email
- [x] No second call when handle already equals email
- [x] PATCH failure persists partial state and still raises
- [x] Existing v2 create/update payload and handle-mapping-key tests unaffected
- [x] Full unit suite (`tox -e py311`)