### PR TITLE
fix: preserve recurring downtime cadence

### DIFF
--- a/datadog_sync/model/downtime_schedules.py
+++ b/datadog_sync/model/downtime_schedules.py
@@ -3,6 +3,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019 Datadog, Inc.
 from __future__ import annotations
+import asyncio
 import json
 import logging
 import re
@@ -46,10 +47,6 @@ class _CancelDestinationDowntime(Exception):
     """Signal that an exhausted source must cancel an active destination."""
 
 
-class _RecurrenceExpansionLimit(Exception):
-    """Raised when an RRULE requires unsafe amounts of synchronous work."""
-
-
 @dataclass(frozen=True)
 class _ActiveWindow:
     start: datetime
@@ -78,7 +75,6 @@ class _PreparedRecurrenceUpdate:
 
 
 class DowntimeSchedules(BaseResource):
-    _MAX_RRULE_OCCURRENCES = 100_000
     _MAX_API_RECURRENCES = 5
     _BRIDGE_RRULE = "FREQ=DAILY;COUNT=1"
     resource_type = "downtime_schedules"
@@ -217,11 +213,7 @@ class DowntimeSchedules(BaseResource):
         generation_rule = cls._rrule_with_utc_until(generation_rule, start)
         recurrence_rule = rrulestr(generation_rule, dtstart=start)
         valid_occurrences = 0
-        for generated_occurrences, occurrence in enumerate(recurrence_rule, start=1):
-            if generated_occurrences > cls._MAX_RRULE_OCCURRENCES:
-                raise _RecurrenceExpansionLimit(
-                    f"Recurrence requires more than {cls._MAX_RRULE_OCCURRENCES} occurrences to normalize."
-                )
+        for occurrence in recurrence_rule:
             if not datetime_exists(occurrence):
                 continue
 
@@ -498,21 +490,18 @@ class DowntimeSchedules(BaseResource):
             create_schedule=create_schedule,
         )
 
-    def _normalize_recurrence_schedule(
+    async def _normalize_recurrence_schedule(
         self,
         _id: str,
         schedule: Dict,
         cutoff: datetime,
         skip_if_empty: bool = True,
     ) -> bool:
-        """Rebase recurrences for a fallback API write."""
+        """Rebase recurrences for a fallback API write without blocking the event loop."""
         if not schedule.get("recurrences"):
             return True
 
-        try:
-            active_recurrences = self._normalized_recurrences(schedule, cutoff)
-        except _RecurrenceExpansionLimit as error:
-            raise SkipResource(str(_id), self.resource_type, str(error)) from error
+        active_recurrences = await asyncio.to_thread(self._normalized_recurrences, schedule, cutoff)
         schedule["recurrences"] = active_recurrences
         if not active_recurrences:
             if skip_if_empty:
@@ -551,7 +540,7 @@ class DowntimeSchedules(BaseResource):
     def _is_downtime_not_found(cls, error: CustomClientHTTPError) -> bool:
         return any(_DOWNTIME_NOT_FOUND_MARKER in message for message in cls._http_error_messages(error))
 
-    def _normalize_create_schedule(self, _id: str, resource: Dict) -> None:
+    async def _normalize_create_schedule(self, _id: str, resource: Dict) -> None:
         schedule = resource["attributes"].get("schedule")
         if not schedule:
             return
@@ -587,16 +576,13 @@ class DowntimeSchedules(BaseResource):
         # request latency cannot shift its fixed duration beyond the source end.
         if schedule.get("recurrences"):
             cutoff = now + timedelta(seconds=60)
-            try:
-                plan = self._analyze_recurrence_schedule(schedule, now, cutoff)
-                recurrences = self._materialize_recurrence_plan(
-                    _id,
-                    plan,
-                    now,
-                    include_bridge=True,
-                )
-            except _RecurrenceExpansionLimit as error:
-                raise SkipResource(str(_id), self.resource_type, str(error)) from error
+            plan = await asyncio.to_thread(self._analyze_recurrence_schedule, schedule, now, cutoff)
+            recurrences = self._materialize_recurrence_plan(
+                _id,
+                plan,
+                now,
+                include_bridge=True,
+            )
             if not recurrences:
                 raise SkipResource(
                     str(_id),
@@ -608,7 +594,7 @@ class DowntimeSchedules(BaseResource):
     async def pre_resource_action_hook(self, _id, resource: Dict) -> None:
         self._prepared_recurrence_updates.pop(str(_id), None)
         if _id not in self.config.state.destination[self.resource_type]:
-            self._normalize_create_schedule(_id, resource)
+            await self._normalize_create_schedule(_id, resource)
         else:
             # If start or end times of the resource are in the past, we set to the current destination `start` and `end`
             # this is to avoid unnecessary diff outputs
@@ -629,16 +615,14 @@ class DowntimeSchedules(BaseResource):
                         source_schedule["end"] = destination_schedule["end"]
                 if "recurrences" in source_schedule:
                     now = datetime.now(timezone.utc)
-                    try:
-                        self._prepare_update_recurrences(
-                            _id,
-                            source_schedule,
-                            destination_schedule,
-                            now,
-                            now + timedelta(seconds=60),
-                        )
-                    except _RecurrenceExpansionLimit as error:
-                        raise SkipResource(str(_id), self.resource_type, str(error)) from error
+                    await asyncio.to_thread(
+                        self._prepare_update_recurrences,
+                        _id,
+                        source_schedule,
+                        destination_schedule,
+                        now,
+                        now + timedelta(seconds=60),
+                    )
 
     async def pre_apply_hook(self) -> None:
         pass
@@ -686,14 +670,14 @@ class DowntimeSchedules(BaseResource):
             await self._delete_resource(_id)
             resource.pop("id", None)
             resource["attributes"]["schedule"] = deepcopy(prepared.create_schedule)
-            self._normalize_create_schedule(_id, resource)
+            await self._normalize_create_schedule(_id, resource)
             log.info(f"[downtime_schedules - {_id}] replacing mismatched active destination downtime")
             return await self.create_resource(_id, resource)
 
         if prepared is not None and prepared.action == _RecurrenceUpdateAction.OMIT_SCHEDULE:
             resource["attributes"].pop("schedule", None)
         elif prepared is not None and prepared.action == _RecurrenceUpdateAction.NORMALIZE_PATCH:
-            self._normalize_recurrence_schedule(
+            await self._normalize_recurrence_schedule(
                 _id,
                 schedule,
                 datetime.now(timezone.utc) + timedelta(seconds=60),
@@ -706,7 +690,7 @@ class DowntimeSchedules(BaseResource):
             # hook (including the 404 recreate fallback tests).
             recreate_schedule = deepcopy(schedule)
             cutoff = datetime.now(timezone.utc) + timedelta(seconds=60)
-            has_future_recurrence = self._normalize_recurrence_schedule(
+            has_future_recurrence = await self._normalize_recurrence_schedule(
                 _id,
                 schedule,
                 cutoff,
@@ -716,10 +700,11 @@ class DowntimeSchedules(BaseResource):
                 destination_schedule = (
                     self.config.state.destination[self.resource_type][_id].get("attributes", {}).get("schedule", {})
                 )
-                try:
-                    destination_recurrences = self._normalized_recurrences(destination_schedule, cutoff)
-                except _RecurrenceExpansionLimit as error:
-                    raise SkipResource(str(_id), self.resource_type, str(error)) from error
+                destination_recurrences = await asyncio.to_thread(
+                    self._normalized_recurrences,
+                    destination_schedule,
+                    cutoff,
+                )
                 if destination_recurrences:
                     raise _CancelDestinationDowntime
                 resource["attributes"].pop("schedule")
@@ -743,7 +728,7 @@ class DowntimeSchedules(BaseResource):
                 resource.pop("id", None)
                 if recreate_schedule is not None:
                     resource["attributes"]["schedule"] = recreate_schedule
-                self._normalize_create_schedule(_id, resource)
+                await self._normalize_create_schedule(_id, resource)
                 log.info(f"[downtime_schedules - {_id}] recreating missing mapped downtime on destination")
                 return await self.create_resource(_id, resource)
             raise

--- a/datadog_sync/model/downtime_schedules.py
+++ b/datadog_sync/model/downtime_schedules.py
@@ -39,6 +39,7 @@ _DUPLICATE_DOWNTIME_MARKER = "duplicate of one or more existing downtimes"
 _DOWNTIME_NOT_FOUND_MARKER = "Downtime not found"
 _SINGLE_DUPLICATE_ID_RE = re.compile(r"existing downtimes:\s*\[\s*(['\"])(?P<id>[^'\"]+)\1\s*\]\s*$")
 _RRULE_COUNT_RE = re.compile(r"(?:^|;)COUNT=(?P<count>\d+)(?=;|$)", re.IGNORECASE)
+_RRULE_UNTIL_RE = re.compile(r"(?:^|;)UNTIL=(?P<until>[^;]+)(?=;|$)", re.IGNORECASE)
 
 
 class _CancelDestinationDowntime(Exception):
@@ -185,6 +186,20 @@ class DowntimeSchedules(BaseResource):
             count_end += 1
         return rrule[:count_start] + rrule[count_end:]
 
+    @staticmethod
+    def _rrule_with_utc_until(rrule: str, start: datetime) -> str:
+        """Convert UNTIL to UTC for dateutil without changing the API RRULE."""
+        until_match = _RRULE_UNTIL_RE.search(rrule)
+        if until_match is None:
+            return rrule
+
+        until = parse(until_match.group("until"))
+        if until.tzinfo is None:
+            until = until.replace(tzinfo=start.tzinfo)
+        until_utc = until.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        until_start, until_end = until_match.span("until")
+        return rrule[:until_start] + until_utc + rrule[until_end:]
+
     @classmethod
     def _next_valid_occurrence(
         cls,
@@ -199,6 +214,7 @@ class DowntimeSchedules(BaseResource):
             return None, 0
 
         generation_rule = cls._rrule_without_count(rrule, count_match) if count_match else rrule
+        generation_rule = cls._rrule_with_utc_until(generation_rule, start)
         recurrence_rule = rrulestr(generation_rule, dtstart=start)
         valid_occurrences = 0
         for generated_occurrences, occurrence in enumerate(recurrence_rule, start=1):

--- a/datadog_sync/model/downtime_schedules.py
+++ b/datadog_sync/model/downtime_schedules.py
@@ -6,9 +6,11 @@ from __future__ import annotations
 import json
 import logging
 import re
+from copy import deepcopy
 from typing import TYPE_CHECKING, Optional, List, Dict, Tuple
 from datetime import datetime, timedelta, timezone
 
+from deepdiff import DeepDiff
 from dateutil.parser import parse
 from dateutil.rrule import rrulestr
 from dateutil.tz import gettz
@@ -147,6 +149,69 @@ class DowntimeSchedules(BaseResource):
         count_start, count_end = count_match.span("count")
         return rrule[:count_start] + str(remaining) + rrule[count_end:]
 
+    @classmethod
+    def _normalized_recurrences(cls, schedule: Dict, cutoff: datetime) -> List[Dict]:
+        """Return recurrence copies rebased to the first occurrence after cutoff."""
+        recurrences = schedule.get("recurrences")
+        if not recurrences:
+            return []
+
+        timezone_name = schedule.get("timezone") or "UTC"
+        cutoff_local = cutoff.astimezone(cls._schedule_timezone(timezone_name))
+        active_recurrences = []
+        for recurrence in deepcopy(recurrences):
+            start_raw = recurrence.get("start")
+            rule_raw = recurrence.get("rrule")
+            if not start_raw or not rule_raw:
+                active_recurrences.append(recurrence)
+                continue
+
+            start = cls._parse_recurrence_start(start_raw, timezone_name)
+            if start > cutoff_local:
+                active_recurrences.append(recurrence)
+                continue
+
+            recurrence_rule = rrulestr(rule_raw, dtstart=start)
+            next_start = recurrence_rule.after(cutoff_local, inc=False)
+            if next_start is None:
+                continue
+
+            recurrence["start"] = cls._iso_local(next_start)
+            recurrence["rrule"] = cls._rebase_count(rule_raw, recurrence_rule, next_start)
+            active_recurrences.append(recurrence)
+
+        return active_recurrences
+
+    def _normalize_recurrence_schedule(self, _id: str, schedule: Dict, cutoff: datetime) -> None:
+        """Rebase recurrences for an API write and skip schedules with none left."""
+        if not schedule.get("recurrences"):
+            return
+
+        active_recurrences = self._normalized_recurrences(schedule, cutoff)
+        schedule["recurrences"] = active_recurrences
+        if not active_recurrences:
+            raise SkipResource(
+                str(_id),
+                self.resource_type,
+                "Downtime recurrence has no future occurrences.",
+            )
+
+    @classmethod
+    def _reconcile_update_recurrences(
+        cls,
+        source_schedule: Dict,
+        destination_schedule: Dict,
+        cutoff: datetime,
+    ) -> None:
+        """Hide representation-only rebasing while preserving semantic changes."""
+        if "recurrences" not in source_schedule or "recurrences" not in destination_schedule:
+            return
+
+        source_recurrences = cls._normalized_recurrences(source_schedule, cutoff)
+        destination_recurrences = cls._normalized_recurrences(destination_schedule, cutoff)
+        if not DeepDiff(source_recurrences, destination_recurrences, ignore_order=True):
+            source_schedule["recurrences"] = deepcopy(destination_schedule["recurrences"])
+
     @staticmethod
     def _http_error_messages(error: CustomClientHTTPError) -> List[str]:
         """Return string messages from a JSON API error response."""
@@ -208,41 +273,7 @@ class DowntimeSchedules(BaseResource):
         # schedule's timezone. Advance each start that is past or too close
         # for a create request to the next RRULE occurrence so its weekday
         # and wall-clock cadence are preserved.
-        recurrences = schedule.get("recurrences")
-        if not recurrences:
-            return
-
-        timezone_name = schedule.get("timezone") or "UTC"
-        create_cutoff_local = (now + timedelta(seconds=60)).astimezone(self._schedule_timezone(timezone_name))
-        active_recurrences = []
-        for recurrence in recurrences:
-            start_raw = recurrence.get("start")
-            rule_raw = recurrence.get("rrule")
-            if not start_raw or not rule_raw:
-                active_recurrences.append(recurrence)
-                continue
-
-            start = self._parse_recurrence_start(start_raw, timezone_name)
-            if start > create_cutoff_local:
-                active_recurrences.append(recurrence)
-                continue
-
-            recurrence_rule = rrulestr(rule_raw, dtstart=start)
-            next_start = recurrence_rule.after(create_cutoff_local, inc=False)
-            if next_start is None:
-                continue
-
-            recurrence["start"] = self._iso_local(next_start)
-            recurrence["rrule"] = self._rebase_count(rule_raw, recurrence_rule, next_start)
-            active_recurrences.append(recurrence)
-
-        schedule["recurrences"] = active_recurrences
-        if not active_recurrences:
-            raise SkipResource(
-                str(_id),
-                self.resource_type,
-                "Downtime recurrence has no future occurrences.",
-            )
+        self._normalize_recurrence_schedule(_id, schedule, now + timedelta(seconds=60))
 
     async def pre_resource_action_hook(self, _id, resource: Dict) -> None:
         if _id not in self.config.state.destination[self.resource_type]:
@@ -263,6 +294,11 @@ class DowntimeSchedules(BaseResource):
                     start_created = parse(one_time_created["end"])
                     if start_source.timestamp() < start_created.timestamp():
                         one_time_source["end"] = one_time_created["end"]
+                self._reconcile_update_recurrences(
+                    one_time_source,
+                    one_time_created,
+                    datetime.now(timezone.utc) + timedelta(seconds=60),
+                )
 
     async def pre_apply_hook(self) -> None:
         pass
@@ -289,6 +325,13 @@ class DowntimeSchedules(BaseResource):
     async def update_resource(self, _id: str, resource: Dict) -> Tuple[str, Dict]:
         destination_client = self.config.destination_client
         resource["id"] = self.config.state.destination[self.resource_type][_id]["id"]
+        schedule = resource["attributes"].get("schedule")
+        if schedule:
+            self._normalize_recurrence_schedule(
+                _id,
+                schedule,
+                datetime.now(timezone.utc) + timedelta(seconds=60),
+            )
         payload = {"data": resource}
         try:
             resp = await destination_client.patch(

--- a/datadog_sync/model/downtime_schedules.py
+++ b/datadog_sync/model/downtime_schedules.py
@@ -203,7 +203,10 @@ class DowntimeSchedules(BaseResource):
         start: datetime,
         cutoff: datetime,
     ) -> Tuple[Optional[datetime], Optional[int]]:
-        """Return the first real local occurrence after cutoff and remaining COUNT."""
+        """Return the first real local occurrence after cutoff and remaining COUNT.
+
+        The v2 downtime API limits RRULE frequencies to HOURLY or coarser.
+        """
         count_match = _RRULE_COUNT_RE.search(rrule)
         count = int(count_match.group("count")) if count_match else None
         if count is not None and count <= 0:
@@ -390,7 +393,11 @@ class DowntimeSchedules(BaseResource):
             list(destination_plan.future_recurrences),
             ignore_order=True,
         )
-        return not futures_differ and cls._active_windows_equivalent(source_plan, destination_plan, now)
+        return (
+            source_plan.timezone_name == destination_plan.timezone_name
+            and not futures_differ
+            and cls._active_windows_equivalent(source_plan, destination_plan, now)
+        )
 
     def _prepare_update_recurrences(
         self,
@@ -677,12 +684,18 @@ class DowntimeSchedules(BaseResource):
         if prepared is not None and prepared.action == _RecurrenceUpdateAction.OMIT_SCHEDULE:
             resource["attributes"].pop("schedule", None)
         elif prepared is not None and prepared.action == _RecurrenceUpdateAction.NORMALIZE_PATCH:
-            await self._normalize_recurrence_schedule(
+            # The final recurrence may cross the write cutoff after planning.
+            # Omit only its schedule so unrelated updates still apply.
+            has_future_recurrence = await self._normalize_recurrence_schedule(
                 _id,
                 schedule,
                 datetime.now(timezone.utc) + timedelta(seconds=60),
+                skip_if_empty=False,
             )
-            schedule.pop("current_downtime", None)
+            if has_future_recurrence:
+                schedule.pop("current_downtime", None)
+            else:
+                resource["attributes"].pop("schedule", None)
         elif prepared is not None:
             schedule.pop("current_downtime", None)
         elif schedule:

--- a/datadog_sync/model/downtime_schedules.py
+++ b/datadog_sync/model/downtime_schedules.py
@@ -335,7 +335,9 @@ class DowntimeSchedules(BaseResource):
         destination_client = self.config.destination_client
         resource["id"] = self.config.state.destination[self.resource_type][_id]["id"]
         schedule = resource["attributes"].get("schedule")
+        omitted_schedule = None
         if schedule:
+            original_schedule = deepcopy(schedule)
             has_active_recurrence = self._normalize_recurrence_schedule(
                 _id,
                 schedule,
@@ -343,6 +345,7 @@ class DowntimeSchedules(BaseResource):
                 skip_if_empty=False,
             )
             if not has_active_recurrence:
+                omitted_schedule = original_schedule
                 resource["attributes"].pop("schedule")
         payload = {"data": resource}
         try:
@@ -359,6 +362,8 @@ class DowntimeSchedules(BaseResource):
                 # Re-run create-only schedule normalization because the first
                 # pre-action hook took the update branch.
                 resource.pop("id", None)
+                if omitted_schedule is not None:
+                    resource["attributes"]["schedule"] = omitted_schedule
                 self._normalize_create_schedule(_id, resource)
                 log.info(f"[downtime_schedules - {_id}] recreating missing mapped downtime on destination")
                 return await self.create_resource(_id, resource)

--- a/datadog_sync/model/downtime_schedules.py
+++ b/datadog_sync/model/downtime_schedules.py
@@ -452,7 +452,7 @@ class DowntimeSchedules(BaseResource):
                         now,
                         include_bridge=True,
                     )
-                elif abs((source_active.start - destination_active.start).total_seconds()) > 60:
+                elif source_active.start != destination_active.start:
                     if self._active_windows_equivalent(source_plan, destination_plan, now):
                         # The API rejects changing an active child's start. A
                         # bridge created during an earlier sync naturally has a

--- a/datadog_sync/model/downtime_schedules.py
+++ b/datadog_sync/model/downtime_schedules.py
@@ -8,7 +8,10 @@ import logging
 import re
 from typing import TYPE_CHECKING, Optional, List, Dict, Tuple
 from datetime import datetime, timedelta, timezone
+
 from dateutil.parser import parse
+from dateutil.rrule import rrulestr
+from dateutil.tz import gettz
 
 from datadog_sync.constants import LOGGER_NAME
 from datadog_sync.utils.base_resource import BaseResource, ResourceConfig
@@ -31,6 +34,7 @@ log = logging.getLogger(LOGGER_NAME)
 _DUPLICATE_DOWNTIME_MARKER = "duplicate of one or more existing downtimes"
 _DOWNTIME_NOT_FOUND_MARKER = "Downtime not found"
 _SINGLE_DUPLICATE_ID_RE = re.compile(r"existing downtimes:\s*\[\s*(['\"])(?P<id>[^'\"]+)\1\s*\]\s*$")
+_RRULE_COUNT_RE = re.compile(r"(?:^|;)COUNT=(?P<count>\d+)(?=;|$)", re.IGNORECASE)
 
 
 class DowntimeSchedules(BaseResource):
@@ -106,6 +110,44 @@ class DowntimeSchedules(BaseResource):
         return dt.isoformat().replace("+00:00", "Z")
 
     @staticmethod
+    def _schedule_timezone(timezone_name: str):
+        """Resolve an IANA timezone using python-dateutil's bundled data."""
+        schedule_timezone = gettz(timezone_name)
+        if schedule_timezone is None:
+            raise ValueError(f"Unknown schedule timezone: {timezone_name}")
+        return schedule_timezone
+
+    @classmethod
+    def _parse_recurrence_start(cls, value: str, timezone_name: str) -> datetime:
+        """Parse a recurring start in the schedule's local timezone."""
+        schedule_timezone = cls._schedule_timezone(timezone_name)
+        parsed = parse(value)
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=schedule_timezone)
+        return parsed.astimezone(schedule_timezone)
+
+    @staticmethod
+    def _iso_local(dt: datetime) -> str:
+        """Recurring starts are local datetimes; the timezone is separate."""
+        return dt.replace(tzinfo=None).isoformat()
+
+    @staticmethod
+    def _rebase_count(rrule: str, recurrence_rule, next_start: datetime) -> str:
+        """Reduce COUNT by occurrences consumed before the rebased start."""
+        count_match = _RRULE_COUNT_RE.search(rrule)
+        if count_match is None:
+            return rrule
+
+        remaining = int(count_match.group("count"))
+        for occurrence in recurrence_rule:
+            if occurrence >= next_start:
+                break
+            remaining -= 1
+
+        count_start, count_end = count_match.span("count")
+        return rrule[:count_start] + str(remaining) + rrule[count_end:]
+
+    @staticmethod
     def _http_error_messages(error: CustomClientHTTPError) -> List[str]:
         """Return string messages from a JSON API error response."""
         body = error.response_body
@@ -161,6 +203,45 @@ class DowntimeSchedules(BaseResource):
             start_dt = self._parse_utc(start_raw)
             if start_dt <= now:
                 schedule["start"] = self._iso_utc(now + timedelta(seconds=60))
+
+        # Recurring schedules store offset-free starts interpreted in the
+        # schedule's timezone. Advance each past start to the next RRULE
+        # occurrence so its weekday and wall-clock cadence are preserved.
+        recurrences = schedule.get("recurrences")
+        if not recurrences:
+            return
+
+        timezone_name = schedule.get("timezone") or "UTC"
+        now_local = now.astimezone(self._schedule_timezone(timezone_name))
+        active_recurrences = []
+        for recurrence in recurrences:
+            start_raw = recurrence.get("start")
+            rule_raw = recurrence.get("rrule")
+            if not start_raw or not rule_raw:
+                active_recurrences.append(recurrence)
+                continue
+
+            start = self._parse_recurrence_start(start_raw, timezone_name)
+            if start > now_local:
+                active_recurrences.append(recurrence)
+                continue
+
+            recurrence_rule = rrulestr(rule_raw, dtstart=start)
+            next_start = recurrence_rule.after(now_local, inc=False)
+            if next_start is None:
+                continue
+
+            recurrence["start"] = self._iso_local(next_start)
+            recurrence["rrule"] = self._rebase_count(rule_raw, recurrence_rule, next_start)
+            active_recurrences.append(recurrence)
+
+        schedule["recurrences"] = active_recurrences
+        if not active_recurrences:
+            raise SkipResource(
+                str(_id),
+                self.resource_type,
+                "Downtime recurrence has no future occurrences.",
+            )
 
     async def pre_resource_action_hook(self, _id, resource: Dict) -> None:
         if _id not in self.config.state.destination[self.resource_type]:

--- a/datadog_sync/model/downtime_schedules.py
+++ b/datadog_sync/model/downtime_schedules.py
@@ -205,14 +205,15 @@ class DowntimeSchedules(BaseResource):
                 schedule["start"] = self._iso_utc(now + timedelta(seconds=60))
 
         # Recurring schedules store offset-free starts interpreted in the
-        # schedule's timezone. Advance each past start to the next RRULE
-        # occurrence so its weekday and wall-clock cadence are preserved.
+        # schedule's timezone. Advance each start that is past or too close
+        # for a create request to the next RRULE occurrence so its weekday
+        # and wall-clock cadence are preserved.
         recurrences = schedule.get("recurrences")
         if not recurrences:
             return
 
         timezone_name = schedule.get("timezone") or "UTC"
-        now_local = now.astimezone(self._schedule_timezone(timezone_name))
+        create_cutoff_local = (now + timedelta(seconds=60)).astimezone(self._schedule_timezone(timezone_name))
         active_recurrences = []
         for recurrence in recurrences:
             start_raw = recurrence.get("start")
@@ -222,12 +223,12 @@ class DowntimeSchedules(BaseResource):
                 continue
 
             start = self._parse_recurrence_start(start_raw, timezone_name)
-            if start > now_local:
+            if start > create_cutoff_local:
                 active_recurrences.append(recurrence)
                 continue
 
             recurrence_rule = rrulestr(rule_raw, dtstart=start)
-            next_start = recurrence_rule.after(now_local, inc=False)
+            next_start = recurrence_rule.after(create_cutoff_local, inc=False)
             if next_start is None:
                 continue
 

--- a/datadog_sync/model/downtime_schedules.py
+++ b/datadog_sync/model/downtime_schedules.py
@@ -412,10 +412,11 @@ class DowntimeSchedules(BaseResource):
         source_plan = self._analyze_recurrence_schedule(source_schedule, now, cutoff)
         destination_plan = self._analyze_recurrence_schedule(destination_schedule, now, cutoff)
         create_schedule = deepcopy(source_schedule)
+        destination_recurrences = destination_schedule.get("recurrences", [])
         action = _RecurrenceUpdateAction.PATCH
 
         if self._recurrence_plans_equivalent(source_plan, destination_plan, now):
-            source_schedule["recurrences"] = deepcopy(destination_schedule["recurrences"])
+            source_schedule["recurrences"] = deepcopy(destination_recurrences)
             if source_plan.active_window is not None or destination_plan.active_window is not None:
                 action = _RecurrenceUpdateAction.OMIT_SCHEDULE
             elif source_plan.future_recurrences:
@@ -430,7 +431,7 @@ class DowntimeSchedules(BaseResource):
                     # The source has less than one representable minute left.
                     # Preserve an equivalent active destination and defer any
                     # cadence change until both windows have ended.
-                    source_schedule["recurrences"] = deepcopy(destination_schedule["recurrences"])
+                    source_schedule["recurrences"] = deepcopy(destination_recurrences)
                     action = _RecurrenceUpdateAction.OMIT_SCHEDULE
                 elif source_plan.future_recurrences:
                     source_schedule["recurrences"] = self._materialize_recurrence_plan(
@@ -458,7 +459,7 @@ class DowntimeSchedules(BaseResource):
                         # different start from the source occurrence, so defer
                         # recurrence-only changes until that equivalent active
                         # window ends. Unrelated fields may still be patched.
-                        source_schedule["recurrences"] = deepcopy(destination_schedule["recurrences"])
+                        source_schedule["recurrences"] = deepcopy(destination_recurrences)
                         action = _RecurrenceUpdateAction.OMIT_SCHEDULE
                         log.info(
                             f"[downtime_schedules - {_id}] deferred recurrence change "
@@ -489,7 +490,7 @@ class DowntimeSchedules(BaseResource):
                 source_schedule["recurrences"] = []
                 action = _RecurrenceUpdateAction.CANCEL
             else:
-                source_schedule["recurrences"] = deepcopy(destination_schedule["recurrences"])
+                source_schedule["recurrences"] = deepcopy(destination_recurrences)
                 action = _RecurrenceUpdateAction.OMIT_SCHEDULE
 
         self._prepared_recurrence_updates[str(_id)] = _PreparedRecurrenceUpdate(
@@ -626,7 +627,7 @@ class DowntimeSchedules(BaseResource):
                     end_created = parse(destination_schedule["end"])
                     if end_source.timestamp() < end_created.timestamp():
                         source_schedule["end"] = destination_schedule["end"]
-                if "recurrences" in source_schedule and "recurrences" in destination_schedule:
+                if "recurrences" in source_schedule:
                     now = datetime.now(timezone.utc)
                     try:
                         self._prepare_update_recurrences(

--- a/datadog_sync/model/downtime_schedules.py
+++ b/datadog_sync/model/downtime_schedules.py
@@ -13,7 +13,7 @@ from datetime import datetime, timedelta, timezone
 from deepdiff import DeepDiff
 from dateutil.parser import parse
 from dateutil.rrule import rrulestr
-from dateutil.tz import gettz
+from dateutil.tz import datetime_exists, gettz
 
 from datadog_sync.constants import LOGGER_NAME
 from datadog_sync.utils.base_resource import BaseResource, ResourceConfig
@@ -39,7 +39,16 @@ _SINGLE_DUPLICATE_ID_RE = re.compile(r"existing downtimes:\s*\[\s*(['\"])(?P<id>
 _RRULE_COUNT_RE = re.compile(r"(?:^|;)COUNT=(?P<count>\d+)(?=;|$)", re.IGNORECASE)
 
 
+class _CancelDestinationDowntime(Exception):
+    """Signal that an exhausted source must cancel an active destination."""
+
+
+class _RecurrenceExpansionLimit(Exception):
+    """Raised when an RRULE requires unsafe amounts of synchronous work."""
+
+
 class DowntimeSchedules(BaseResource):
+    _MAX_RRULE_OCCURRENCES = 100_000
     resource_type = "downtime_schedules"
     resource_config = ResourceConfig(
         resource_connections={"monitors": ["attributes.monitor_identifier.monitor_id"]},
@@ -134,18 +143,55 @@ class DowntimeSchedules(BaseResource):
         return dt.replace(tzinfo=None).isoformat()
 
     @staticmethod
-    def _rebase_count(rrule: str, recurrence_rule, next_start: datetime) -> str:
-        """Reduce COUNT by occurrences consumed before the rebased start."""
+    def _rrule_without_count(rrule: str, count_match) -> str:
+        """Remove COUNT while preserving the remaining semicolon-delimited rule."""
+        count_start, count_end = count_match.span()
+        if count_start == 0 and count_end < len(rrule) and rrule[count_end] == ";":
+            count_end += 1
+        return rrule[:count_start] + rrule[count_end:]
+
+    @classmethod
+    def _next_valid_occurrence(
+        cls,
+        rrule: str,
+        start: datetime,
+        cutoff: datetime,
+    ) -> Tuple[Optional[datetime], Optional[int]]:
+        """Return the first real local occurrence after cutoff and remaining COUNT."""
+        count_match = _RRULE_COUNT_RE.search(rrule)
+        count = int(count_match.group("count")) if count_match else None
+        if count is not None and count <= 0:
+            return None, 0
+
+        generation_rule = cls._rrule_without_count(rrule, count_match) if count_match else rrule
+        recurrence_rule = rrulestr(generation_rule, dtstart=start)
+        valid_occurrences = 0
+        for generated_occurrences, occurrence in enumerate(recurrence_rule, start=1):
+            if generated_occurrences > cls._MAX_RRULE_OCCURRENCES:
+                raise _RecurrenceExpansionLimit(
+                    f"Recurrence requires more than {cls._MAX_RRULE_OCCURRENCES} occurrences to normalize."
+                )
+            if not datetime_exists(occurrence):
+                continue
+
+            valid_occurrences += 1
+            if count is not None and valid_occurrences > count:
+                return None, 0
+            if occurrence > cutoff:
+                remaining = count - valid_occurrences + 1 if count is not None else None
+                return occurrence, remaining
+            if count is not None and valid_occurrences == count:
+                return None, 0
+
+        return None, 0 if count is not None else None
+
+    @staticmethod
+    def _replace_count(rrule: str, remaining: Optional[int]) -> str:
+        if remaining is None:
+            return rrule
         count_match = _RRULE_COUNT_RE.search(rrule)
         if count_match is None:
             return rrule
-
-        remaining = int(count_match.group("count"))
-        for occurrence in recurrence_rule:
-            if occurrence >= next_start:
-                break
-            remaining -= 1
-
         count_start, count_end = count_match.span("count")
         return rrule[:count_start] + str(remaining) + rrule[count_end:]
 
@@ -167,17 +213,18 @@ class DowntimeSchedules(BaseResource):
                 continue
 
             start = cls._parse_recurrence_start(start_raw, timezone_name)
-            if start > cutoff_local:
+            count_match = _RRULE_COUNT_RE.search(rule_raw)
+            count = int(count_match.group("count")) if count_match else None
+            if start > cutoff_local and datetime_exists(start) and (count is None or count > 0):
                 active_recurrences.append(recurrence)
                 continue
 
-            recurrence_rule = rrulestr(rule_raw, dtstart=start)
-            next_start = recurrence_rule.after(cutoff_local, inc=False)
+            next_start, remaining = cls._next_valid_occurrence(rule_raw, start, cutoff_local)
             if next_start is None:
                 continue
 
             recurrence["start"] = cls._iso_local(next_start)
-            recurrence["rrule"] = cls._rebase_count(rule_raw, recurrence_rule, next_start)
+            recurrence["rrule"] = cls._replace_count(rule_raw, remaining)
             active_recurrences.append(recurrence)
 
         return active_recurrences
@@ -193,7 +240,10 @@ class DowntimeSchedules(BaseResource):
         if not schedule.get("recurrences"):
             return True
 
-        active_recurrences = self._normalized_recurrences(schedule, cutoff)
+        try:
+            active_recurrences = self._normalized_recurrences(schedule, cutoff)
+        except _RecurrenceExpansionLimit as error:
+            raise SkipResource(str(_id), self.resource_type, str(error)) from error
         schedule["recurrences"] = active_recurrences
         if not active_recurrences:
             if skip_if_empty:
@@ -303,11 +353,14 @@ class DowntimeSchedules(BaseResource):
                     start_created = parse(one_time_created["end"])
                     if start_source.timestamp() < start_created.timestamp():
                         one_time_source["end"] = one_time_created["end"]
-                self._reconcile_update_recurrences(
-                    one_time_source,
-                    one_time_created,
-                    datetime.now(timezone.utc) + timedelta(seconds=60),
-                )
+                try:
+                    self._reconcile_update_recurrences(
+                        one_time_source,
+                        one_time_created,
+                        datetime.now(timezone.utc) + timedelta(seconds=60),
+                    )
+                except _RecurrenceExpansionLimit as error:
+                    raise SkipResource(str(_id), self.resource_type, str(error)) from error
 
     async def pre_apply_hook(self) -> None:
         pass
@@ -331,6 +384,13 @@ class DowntimeSchedules(BaseResource):
 
         return _id, resp["data"]
 
+    async def _update_resource(self, _id: str, resource: Dict) -> None:
+        try:
+            await super()._update_resource(_id, resource)
+        except _CancelDestinationDowntime:
+            await self._delete_resource(_id)
+            log.info(f"[downtime_schedules - {_id}] canceled active destination after source recurrence expired")
+
     async def update_resource(self, _id: str, resource: Dict) -> Tuple[str, Dict]:
         destination_client = self.config.destination_client
         resource["id"] = self.config.state.destination[self.resource_type][_id]["id"]
@@ -338,13 +398,23 @@ class DowntimeSchedules(BaseResource):
         omitted_schedule = None
         if schedule:
             original_schedule = deepcopy(schedule)
+            cutoff = datetime.now(timezone.utc) + timedelta(seconds=60)
             has_active_recurrence = self._normalize_recurrence_schedule(
                 _id,
                 schedule,
-                datetime.now(timezone.utc) + timedelta(seconds=60),
+                cutoff,
                 skip_if_empty=False,
             )
             if not has_active_recurrence:
+                destination_schedule = (
+                    self.config.state.destination[self.resource_type][_id].get("attributes", {}).get("schedule", {})
+                )
+                try:
+                    destination_recurrences = self._normalized_recurrences(destination_schedule, cutoff)
+                except _RecurrenceExpansionLimit as error:
+                    raise SkipResource(str(_id), self.resource_type, str(error)) from error
+                if destination_recurrences:
+                    raise _CancelDestinationDowntime
                 omitted_schedule = original_schedule
                 resource["attributes"].pop("schedule")
         payload = {"data": resource}

--- a/datadog_sync/model/downtime_schedules.py
+++ b/datadog_sync/model/downtime_schedules.py
@@ -7,6 +7,8 @@ import json
 import logging
 import re
 from copy import deepcopy
+from dataclasses import dataclass
+from enum import Enum
 from typing import TYPE_CHECKING, Optional, List, Dict, Tuple
 from datetime import datetime, timedelta, timezone
 
@@ -47,8 +49,37 @@ class _RecurrenceExpansionLimit(Exception):
     """Raised when an RRULE requires unsafe amounts of synchronous work."""
 
 
+@dataclass(frozen=True)
+class _ActiveWindow:
+    start: datetime
+    end: Optional[datetime]
+
+
+@dataclass(frozen=True)
+class _RecurrencePlan:
+    timezone_name: str
+    active_window: Optional[_ActiveWindow]
+    future_recurrences: Tuple[Dict, ...]
+
+
+class _RecurrenceUpdateAction(Enum):
+    PATCH = "patch"
+    NORMALIZE_PATCH = "normalize_patch"
+    OMIT_SCHEDULE = "omit_schedule"
+    CANCEL = "cancel"
+    RECREATE = "recreate"
+
+
+@dataclass(frozen=True)
+class _PreparedRecurrenceUpdate:
+    action: _RecurrenceUpdateAction
+    create_schedule: Dict
+
+
 class DowntimeSchedules(BaseResource):
     _MAX_RRULE_OCCURRENCES = 100_000
+    _MAX_API_RECURRENCES = 5
+    _BRIDGE_RRULE = "FREQ=DAILY;COUNT=1"
     resource_type = "downtime_schedules"
     resource_config = ResourceConfig(
         resource_connections={"monitors": ["attributes.monitor_identifier.monitor_id"]},
@@ -77,6 +108,10 @@ class DowntimeSchedules(BaseResource):
         remaining_func=lambda *args: 1,
     )
     # Additional DowntimeSchedules specific attributes
+
+    def __init__(self, config) -> None:
+        super().__init__(config)
+        self._prepared_recurrence_updates: Dict[str, _PreparedRecurrenceUpdate] = {}
 
     async def get_resources(self, client: CustomClient) -> List[Dict]:
         # `include=created_by` populates `relationships.created_by.data.id` on
@@ -229,6 +264,223 @@ class DowntimeSchedules(BaseResource):
 
         return active_recurrences
 
+    @classmethod
+    def _active_window(cls, schedule: Dict, now: datetime) -> Optional[_ActiveWindow]:
+        """Return the API-derived current window when it is active now."""
+        current = schedule.get("current_downtime")
+        if not isinstance(current, dict) or not current.get("start"):
+            return None
+
+        start = cls._parse_utc(current["start"])
+        end = cls._parse_utc(current["end"]) if current.get("end") else None
+        if start <= now and (end is None or now < end):
+            return _ActiveWindow(start=start, end=end)
+        return None
+
+    @classmethod
+    def _analyze_recurrence_schedule(
+        cls,
+        schedule: Dict,
+        now: datetime,
+        cutoff: datetime,
+    ) -> _RecurrencePlan:
+        """Separate an active API window from normalized future cadence."""
+        return _RecurrencePlan(
+            timezone_name=schedule.get("timezone") or "UTC",
+            active_window=cls._active_window(schedule, now),
+            future_recurrences=tuple(cls._normalized_recurrences(schedule, cutoff)),
+        )
+
+    @staticmethod
+    def _effective_active_window(plan: _RecurrencePlan, now: datetime) -> Optional[_ActiveWindow]:
+        """Ignore a residual window too short for the API's one-minute unit."""
+        window = plan.active_window
+        if window is None or window.end is None:
+            return window
+        if (window.end - now).total_seconds() < 60:
+            return None
+        return window
+
+    @classmethod
+    def _bridge_recurrence(cls, _id: str, plan: _RecurrencePlan, now: datetime) -> Optional[Dict]:
+        window = cls._effective_active_window(plan, now)
+        if window is None:
+            return None
+        if window.end is None:
+            raise SkipResource(
+                str(_id),
+                cls.resource_type,
+                "Active recurrence has no finite end and cannot be bridged.",
+            )
+
+        remaining_minutes = int((window.end - now).total_seconds() // 60)
+        if remaining_minutes < 1:
+            return None
+        start = now.astimezone(cls._schedule_timezone(plan.timezone_name))
+        return {
+            "start": cls._iso_local(start),
+            "duration": f"{remaining_minutes}m",
+            "rrule": cls._BRIDGE_RRULE,
+        }
+
+    @classmethod
+    def _materialize_recurrence_plan(
+        cls,
+        _id: str,
+        plan: _RecurrencePlan,
+        now: datetime,
+        include_bridge: bool,
+    ) -> List[Dict]:
+        recurrences = [deepcopy(recurrence) for recurrence in plan.future_recurrences]
+        bridge = cls._bridge_recurrence(_id, plan, now) if include_bridge else None
+        if bridge is not None:
+            if len(recurrences) >= cls._MAX_API_RECURRENCES:
+                raise SkipResource(
+                    str(_id),
+                    cls.resource_type,
+                    f"Active bridge would exceed the API maximum of {cls._MAX_API_RECURRENCES} recurrences.",
+                )
+            recurrences.insert(0, bridge)
+        return recurrences
+
+    @classmethod
+    def _active_windows_equivalent(
+        cls,
+        source_plan: _RecurrencePlan,
+        destination_plan: _RecurrencePlan,
+        now: datetime,
+    ) -> bool:
+        source = source_plan.active_window
+        destination = destination_plan.active_window
+        if source is not None and destination is not None:
+            if source.end is None or destination.end is None:
+                return source.end is destination.end
+
+            # A bridge starts during sync, not when the source occurrence
+            # began. Its duration is rounded down to whole minutes, so an end
+            # up to one minute early is representation-only, including the
+            # bridge's final minute.
+            end_delta = (source.end - destination.end).total_seconds()
+            return -1 <= end_delta < 60
+
+        # The API cannot represent a bridge shorter than one minute. Once the
+        # destination bridge has ended, treat only that sub-minute source tail
+        # as converged rather than repeatedly trying to PATCH an active child.
+        if source is not None and cls._effective_active_window(source_plan, now) is None:
+            return destination is None
+        return source is destination
+
+    @classmethod
+    def _recurrence_plans_equivalent(
+        cls,
+        source_plan: _RecurrencePlan,
+        destination_plan: _RecurrencePlan,
+        now: datetime,
+    ) -> bool:
+        futures_differ = DeepDiff(
+            list(source_plan.future_recurrences),
+            list(destination_plan.future_recurrences),
+            ignore_order=True,
+        )
+        return not futures_differ and cls._active_windows_equivalent(source_plan, destination_plan, now)
+
+    def _prepare_update_recurrences(
+        self,
+        _id: str,
+        source_schedule: Dict,
+        destination_schedule: Dict,
+        now: datetime,
+        cutoff: datetime,
+    ) -> None:
+        """Prepare a PATCH-safe schedule and remember apply-time behavior."""
+        source_plan = self._analyze_recurrence_schedule(source_schedule, now, cutoff)
+        destination_plan = self._analyze_recurrence_schedule(destination_schedule, now, cutoff)
+        create_schedule = deepcopy(source_schedule)
+        action = _RecurrenceUpdateAction.PATCH
+
+        if self._recurrence_plans_equivalent(source_plan, destination_plan, now):
+            source_schedule["recurrences"] = deepcopy(destination_schedule["recurrences"])
+            if source_plan.active_window is not None or destination_plan.active_window is not None:
+                action = _RecurrenceUpdateAction.OMIT_SCHEDULE
+            elif source_plan.future_recurrences:
+                action = _RecurrenceUpdateAction.NORMALIZE_PATCH
+            else:
+                action = _RecurrenceUpdateAction.OMIT_SCHEDULE
+        else:
+            source_active = self._effective_active_window(source_plan, now)
+            destination_active = destination_plan.active_window
+            if source_plan.active_window is not None and source_active is None and destination_active is not None:
+                if self._active_windows_equivalent(source_plan, destination_plan, now):
+                    # The source has less than one representable minute left.
+                    # Preserve an equivalent active destination and defer any
+                    # cadence change until both windows have ended.
+                    source_schedule["recurrences"] = deepcopy(destination_schedule["recurrences"])
+                    action = _RecurrenceUpdateAction.OMIT_SCHEDULE
+                elif source_plan.future_recurrences:
+                    source_schedule["recurrences"] = self._materialize_recurrence_plan(
+                        _id,
+                        source_plan,
+                        now,
+                        include_bridge=True,
+                    )
+                    action = _RecurrenceUpdateAction.RECREATE
+                else:
+                    source_schedule["recurrences"] = []
+                    action = _RecurrenceUpdateAction.CANCEL
+            elif source_active is not None:
+                if destination_active is None:
+                    source_schedule["recurrences"] = self._materialize_recurrence_plan(
+                        _id,
+                        source_plan,
+                        now,
+                        include_bridge=True,
+                    )
+                elif abs((source_active.start - destination_active.start).total_seconds()) > 60:
+                    if self._active_windows_equivalent(source_plan, destination_plan, now):
+                        # The API rejects changing an active child's start. A
+                        # bridge created during an earlier sync naturally has a
+                        # different start from the source occurrence, so defer
+                        # recurrence-only changes until that equivalent active
+                        # window ends. Unrelated fields may still be patched.
+                        source_schedule["recurrences"] = deepcopy(destination_schedule["recurrences"])
+                        action = _RecurrenceUpdateAction.OMIT_SCHEDULE
+                        log.info(
+                            f"[downtime_schedules - {_id}] deferred recurrence change "
+                            "until active destination window ends"
+                        )
+                    else:
+                        # The destination is actively muting the wrong window
+                        # and the API will not PATCH its start. Replace it with a
+                        # bridge plus the source's future cadence. _delete_resource
+                        # clears the stale mapping before POST so a failed create
+                        # converges through the normal create path on the next run.
+                        source_schedule["recurrences"] = self._materialize_recurrence_plan(
+                            _id,
+                            source_plan,
+                            now,
+                            include_bridge=True,
+                        )
+                        action = _RecurrenceUpdateAction.RECREATE
+                # When active starts align, retain the source's original
+                # recurrence anchor. The API derives the existing active child
+                # from it and accepts future-cadence changes without shifting
+                # the active start.
+            elif source_plan.future_recurrences:
+                source_schedule["recurrences"] = [deepcopy(recurrence) for recurrence in source_plan.future_recurrences]
+            elif destination_active is not None or destination_plan.future_recurrences:
+                # An empty recurrence list is intentionally only an internal
+                # diff marker. update_resource consumes CANCEL before writing.
+                source_schedule["recurrences"] = []
+                action = _RecurrenceUpdateAction.CANCEL
+            else:
+                source_schedule["recurrences"] = deepcopy(destination_schedule["recurrences"])
+                action = _RecurrenceUpdateAction.OMIT_SCHEDULE
+
+        self._prepared_recurrence_updates[str(_id)] = _PreparedRecurrenceUpdate(
+            action=action,
+            create_schedule=create_schedule,
+        )
+
     def _normalize_recurrence_schedule(
         self,
         _id: str,
@@ -236,7 +488,7 @@ class DowntimeSchedules(BaseResource):
         cutoff: datetime,
         skip_if_empty: bool = True,
     ) -> bool:
-        """Rebase recurrences for an API write and report whether any remain."""
+        """Rebase recurrences for a fallback API write."""
         if not schedule.get("recurrences"):
             return True
 
@@ -254,22 +506,6 @@ class DowntimeSchedules(BaseResource):
                 )
             return False
         return True
-
-    @classmethod
-    def _reconcile_update_recurrences(
-        cls,
-        source_schedule: Dict,
-        destination_schedule: Dict,
-        cutoff: datetime,
-    ) -> None:
-        """Hide representation-only rebasing while preserving semantic changes."""
-        if "recurrences" not in source_schedule or "recurrences" not in destination_schedule:
-            return
-
-        source_recurrences = cls._normalized_recurrences(source_schedule, cutoff)
-        destination_recurrences = cls._normalized_recurrences(destination_schedule, cutoff)
-        if not DeepDiff(source_recurrences, destination_recurrences, ignore_order=True):
-            source_schedule["recurrences"] = deepcopy(destination_schedule["recurrences"])
 
     @staticmethod
     def _http_error_messages(error: CustomClientHTTPError) -> List[str]:
@@ -328,45 +564,73 @@ class DowntimeSchedules(BaseResource):
             if start_dt <= now:
                 schedule["start"] = self._iso_utc(now + timedelta(seconds=60))
 
-        # Recurring schedules store offset-free starts interpreted in the
-        # schedule's timezone. Advance each start that is past or too close
-        # for a create request to the next RRULE occurrence so its weekday
-        # and wall-clock cadence are preserved.
-        self._normalize_recurrence_schedule(_id, schedule, now + timedelta(seconds=60))
+        # Recurring schedules need two independent representations: a
+        # one-shot bridge for any window active now, and RRULEs rebased to
+        # future cadence. Pin the bridge start to the current local time so
+        # request latency cannot shift its fixed duration beyond the source end.
+        if schedule.get("recurrences"):
+            cutoff = now + timedelta(seconds=60)
+            try:
+                plan = self._analyze_recurrence_schedule(schedule, now, cutoff)
+                recurrences = self._materialize_recurrence_plan(
+                    _id,
+                    plan,
+                    now,
+                    include_bridge=True,
+                )
+            except _RecurrenceExpansionLimit as error:
+                raise SkipResource(str(_id), self.resource_type, str(error)) from error
+            if not recurrences:
+                raise SkipResource(
+                    str(_id),
+                    self.resource_type,
+                    "Downtime recurrence has no future occurrences or active window.",
+                )
+            schedule["recurrences"] = recurrences
 
     async def pre_resource_action_hook(self, _id, resource: Dict) -> None:
+        self._prepared_recurrence_updates.pop(str(_id), None)
         if _id not in self.config.state.destination[self.resource_type]:
             self._normalize_create_schedule(_id, resource)
         else:
             # If start or end times of the resource are in the past, we set to the current destination `start` and `end`
             # this is to avoid unnecessary diff outputs
             if resource["attributes"].get("schedule"):
-                one_time_source = resource["attributes"].get("schedule")
-                one_time_created = self.config.state.destination[self.resource_type][_id]["attributes"].get("schedule")
-                if one_time_created.get("start") and one_time_source.get("start"):
-                    start_source = parse(one_time_source["start"])
-                    start_created = parse(one_time_created["start"])
+                source_schedule = resource["attributes"]["schedule"]
+                destination_schedule = self.config.state.destination[self.resource_type][_id]["attributes"].get(
+                    "schedule", {}
+                )
+                if destination_schedule.get("start") and source_schedule.get("start"):
+                    start_source = parse(source_schedule["start"])
+                    start_created = parse(destination_schedule["start"])
                     if start_source.timestamp() < start_created.timestamp():
-                        one_time_source["start"] = one_time_created["start"]
-                if one_time_created.get("end") and one_time_source.get("end"):
-                    start_source = parse(one_time_source["end"])
-                    start_created = parse(one_time_created["end"])
-                    if start_source.timestamp() < start_created.timestamp():
-                        one_time_source["end"] = one_time_created["end"]
-                try:
-                    self._reconcile_update_recurrences(
-                        one_time_source,
-                        one_time_created,
-                        datetime.now(timezone.utc) + timedelta(seconds=60),
-                    )
-                except _RecurrenceExpansionLimit as error:
-                    raise SkipResource(str(_id), self.resource_type, str(error)) from error
+                        source_schedule["start"] = destination_schedule["start"]
+                if destination_schedule.get("end") and source_schedule.get("end"):
+                    end_source = parse(source_schedule["end"])
+                    end_created = parse(destination_schedule["end"])
+                    if end_source.timestamp() < end_created.timestamp():
+                        source_schedule["end"] = destination_schedule["end"]
+                if "recurrences" in source_schedule and "recurrences" in destination_schedule:
+                    now = datetime.now(timezone.utc)
+                    try:
+                        self._prepare_update_recurrences(
+                            _id,
+                            source_schedule,
+                            destination_schedule,
+                            now,
+                            now + timedelta(seconds=60),
+                        )
+                    except _RecurrenceExpansionLimit as error:
+                        raise SkipResource(str(_id), self.resource_type, str(error)) from error
 
     async def pre_apply_hook(self) -> None:
         pass
 
     async def create_resource(self, _id: str, resource: Dict) -> Tuple[str, Dict]:
         destination_client = self.config.destination_client
+        schedule = resource.get("attributes", {}).get("schedule")
+        if schedule:
+            schedule.pop("current_downtime", None)
         payload = {"data": resource}
         try:
             resp = await destination_client.post(self.resource_config.base_path, payload)
@@ -393,19 +657,45 @@ class DowntimeSchedules(BaseResource):
 
     async def update_resource(self, _id: str, resource: Dict) -> Tuple[str, Dict]:
         destination_client = self.config.destination_client
+        prepared = self._prepared_recurrence_updates.pop(str(_id), None)
         resource["id"] = self.config.state.destination[self.resource_type][_id]["id"]
         schedule = resource["attributes"].get("schedule")
-        omitted_schedule = None
-        if schedule:
-            original_schedule = deepcopy(schedule)
+        recreate_schedule = deepcopy(prepared.create_schedule) if prepared is not None else None
+
+        if prepared is not None and prepared.action == _RecurrenceUpdateAction.CANCEL:
+            raise _CancelDestinationDowntime
+
+        if prepared is not None and prepared.action == _RecurrenceUpdateAction.RECREATE:
+            await self._delete_resource(_id)
+            resource.pop("id", None)
+            resource["attributes"]["schedule"] = deepcopy(prepared.create_schedule)
+            self._normalize_create_schedule(_id, resource)
+            log.info(f"[downtime_schedules - {_id}] replacing mismatched active destination downtime")
+            return await self.create_resource(_id, resource)
+
+        if prepared is not None and prepared.action == _RecurrenceUpdateAction.OMIT_SCHEDULE:
+            resource["attributes"].pop("schedule", None)
+        elif prepared is not None and prepared.action == _RecurrenceUpdateAction.NORMALIZE_PATCH:
+            self._normalize_recurrence_schedule(
+                _id,
+                schedule,
+                datetime.now(timezone.utc) + timedelta(seconds=60),
+            )
+            schedule.pop("current_downtime", None)
+        elif prepared is not None:
+            schedule.pop("current_downtime", None)
+        elif schedule:
+            # Compatibility for direct callers that do not run the pre-action
+            # hook (including the 404 recreate fallback tests).
+            recreate_schedule = deepcopy(schedule)
             cutoff = datetime.now(timezone.utc) + timedelta(seconds=60)
-            has_active_recurrence = self._normalize_recurrence_schedule(
+            has_future_recurrence = self._normalize_recurrence_schedule(
                 _id,
                 schedule,
                 cutoff,
                 skip_if_empty=False,
             )
-            if not has_active_recurrence:
+            if not has_future_recurrence:
                 destination_schedule = (
                     self.config.state.destination[self.resource_type][_id].get("attributes", {}).get("schedule", {})
                 )
@@ -415,8 +705,10 @@ class DowntimeSchedules(BaseResource):
                     raise SkipResource(str(_id), self.resource_type, str(error)) from error
                 if destination_recurrences:
                     raise _CancelDestinationDowntime
-                omitted_schedule = original_schedule
                 resource["attributes"].pop("schedule")
+            else:
+                schedule.pop("current_downtime", None)
+
         payload = {"data": resource}
         try:
             resp = await destination_client.patch(
@@ -432,8 +724,8 @@ class DowntimeSchedules(BaseResource):
                 # Re-run create-only schedule normalization because the first
                 # pre-action hook took the update branch.
                 resource.pop("id", None)
-                if omitted_schedule is not None:
-                    resource["attributes"]["schedule"] = omitted_schedule
+                if recreate_schedule is not None:
+                    resource["attributes"]["schedule"] = recreate_schedule
                 self._normalize_create_schedule(_id, resource)
                 log.info(f"[downtime_schedules - {_id}] recreating missing mapped downtime on destination")
                 return await self.create_resource(_id, resource)

--- a/datadog_sync/model/downtime_schedules.py
+++ b/datadog_sync/model/downtime_schedules.py
@@ -182,19 +182,28 @@ class DowntimeSchedules(BaseResource):
 
         return active_recurrences
 
-    def _normalize_recurrence_schedule(self, _id: str, schedule: Dict, cutoff: datetime) -> None:
-        """Rebase recurrences for an API write and skip schedules with none left."""
+    def _normalize_recurrence_schedule(
+        self,
+        _id: str,
+        schedule: Dict,
+        cutoff: datetime,
+        skip_if_empty: bool = True,
+    ) -> bool:
+        """Rebase recurrences for an API write and report whether any remain."""
         if not schedule.get("recurrences"):
-            return
+            return True
 
         active_recurrences = self._normalized_recurrences(schedule, cutoff)
         schedule["recurrences"] = active_recurrences
         if not active_recurrences:
-            raise SkipResource(
-                str(_id),
-                self.resource_type,
-                "Downtime recurrence has no future occurrences.",
-            )
+            if skip_if_empty:
+                raise SkipResource(
+                    str(_id),
+                    self.resource_type,
+                    "Downtime recurrence has no future occurrences.",
+                )
+            return False
+        return True
 
     @classmethod
     def _reconcile_update_recurrences(
@@ -327,11 +336,14 @@ class DowntimeSchedules(BaseResource):
         resource["id"] = self.config.state.destination[self.resource_type][_id]["id"]
         schedule = resource["attributes"].get("schedule")
         if schedule:
-            self._normalize_recurrence_schedule(
+            has_active_recurrence = self._normalize_recurrence_schedule(
                 _id,
                 schedule,
                 datetime.now(timezone.utc) + timedelta(seconds=60),
+                skip_if_empty=False,
             )
+            if not has_active_recurrence:
+                resource["attributes"].pop("schedule")
         payload = {"data": resource}
         try:
             resp = await destination_client.patch(

--- a/tests/unit/test_downtime_schedules.py
+++ b/tests/unit/test_downtime_schedules.py
@@ -337,15 +337,15 @@ def test_recurring_local_until_is_interpreted_in_schedule_timezone(mock_config):
 def test_recurring_large_count_is_normalized_without_rejection(mock_config):
     downtime = DowntimeSchedules(mock_config)
     resource = _make_recurring_resource(
-        [_recurrence("2026-06-01T00:00:00", "FREQ=MINUTELY;COUNT=200000")],
+        [_recurrence("2026-06-01T00:00:00", "FREQ=HOURLY;COUNT=200000")],
         timezone_name="UTC",
     )
 
     _run(downtime.pre_resource_action_hook("new-id", resource))
 
     recurrence = resource["attributes"]["schedule"]["recurrences"][0]
-    assert recurrence["start"] == "2026-08-10T00:02:00"
-    assert recurrence["rrule"] == "FREQ=MINUTELY;COUNT=99198"
+    assert recurrence["start"] == "2026-08-10T01:00:00"
+    assert recurrence["rrule"] == "FREQ=HOURLY;COUNT=198319"
 
 
 @freeze_time("2026-08-11 15:00:00")
@@ -615,6 +615,36 @@ def test_update_payload_omits_expired_schedule_but_preserves_unrelated_change(mo
 
     _run(downtime.pre_resource_action_hook(_id, source))
     _run(downtime.update_resource(_id, source))
+
+    attributes = captured["payload"]["data"]["attributes"]
+    assert "schedule" not in attributes
+    assert attributes["message"] == "Updated message"
+    assert captured["path"] == "/api/v2/downtime/downtime-destination-test"
+
+
+def test_update_payload_preserves_unrelated_change_when_final_recurrence_crosses_cutoff(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    _id = "existing-id"
+    final_recurrence = _recurrence("2026-08-11T19:00:00", "FREQ=DAILY;COUNT=1")
+    destination = _make_recurring_resource([final_recurrence], timezone_name="UTC")
+    destination["id"] = "downtime-destination-test"
+    destination["attributes"]["message"] = "Original message"
+    mock_config.state.destination["downtime_schedules"][_id] = destination
+    source = _make_recurring_resource([final_recurrence], timezone_name="UTC")
+    source["attributes"]["message"] = "Updated message"
+    captured = {}
+
+    async def _patch(path, payload):
+        captured["path"] = path
+        captured["payload"] = payload
+        return {"data": payload["data"]}
+
+    mock_config.destination_client.patch = _patch
+
+    with freeze_time("2026-08-11 18:58:59"):
+        _run(downtime.pre_resource_action_hook(_id, source))
+    with freeze_time("2026-08-11 18:59:01"):
+        _run(downtime.update_resource(_id, source))
 
     attributes = captured["payload"]["data"]["attributes"]
     assert "schedule" not in attributes

--- a/tests/unit/test_downtime_schedules.py
+++ b/tests/unit/test_downtime_schedules.py
@@ -461,3 +461,32 @@ def test_update_payload_advances_recurrence_past_create_safety_window(mock_confi
     recurrence = captured["payload"]["data"]["attributes"]["schedule"]["recurrences"][0]
     assert recurrence["start"] == "2026-08-28T19:00:00"
     assert captured["path"] == "/api/v2/downtime/downtime-destination-test"
+
+
+@freeze_time("2026-08-21 15:00:00")
+def test_update_payload_omits_expired_schedule_but_preserves_unrelated_change(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    _id = "existing-id"
+    expired_recurrence = _recurrence("2026-08-01T09:00:00", "FREQ=DAILY;COUNT=2")
+    destination = _make_recurring_resource([expired_recurrence], timezone_name="UTC")
+    destination["id"] = "downtime-destination-test"
+    destination["attributes"]["message"] = "Original message"
+    mock_config.state.destination["downtime_schedules"][_id] = destination
+    source = _make_recurring_resource([expired_recurrence], timezone_name="UTC")
+    source["attributes"]["message"] = "Updated message"
+    captured = {}
+
+    async def _patch(path, payload):
+        captured["path"] = path
+        captured["payload"] = payload
+        return {"data": payload["data"]}
+
+    mock_config.destination_client.patch = _patch
+
+    _run(downtime.pre_resource_action_hook(_id, source))
+    _run(downtime.update_resource(_id, source))
+
+    attributes = captured["payload"]["data"]["attributes"]
+    assert "schedule" not in attributes
+    assert attributes["message"] == "Updated message"
+    assert captured["path"] == "/api/v2/downtime/downtime-destination-test"

--- a/tests/unit/test_downtime_schedules.py
+++ b/tests/unit/test_downtime_schedules.py
@@ -25,7 +25,7 @@ from dateutil.parser import parse
 from freezegun import freeze_time
 
 from datadog_sync.model.downtime_schedules import DowntimeSchedules
-from datadog_sync.utils.resource_utils import SkipResource
+from datadog_sync.utils.resource_utils import SkipResource, check_diff
 
 
 def _run(coro):
@@ -321,11 +321,7 @@ def test_recurring_empty_recurrences_no_op(mock_config):
     assert resource["attributes"]["schedule"]["recurrences"] == []
 
 
-def test_update_path_untouched_by_this_fix(mock_config):
-    """Explicit boundary: this change only touches the create branch. The
-    update-path branch that clamps source start/end backwards to
-    destination's stored values is intentionally out of scope; a follow-up
-    is planned to address the update-path case."""
+def test_update_path_preserves_one_time_schedule_behavior(mock_config):
     downtime = DowntimeSchedules(mock_config)
     _id = "existing-id"
     mock_config.state.destination["downtime_schedules"][_id] = {
@@ -342,3 +338,126 @@ def test_update_path_untouched_by_this_fix(mock_config):
     dest = mock_config.state.destination["downtime_schedules"][_id]["attributes"]["schedule"]
     assert schedule["start"] == dest["start"]
     assert schedule["end"] == dest["end"]
+
+
+@freeze_time("2026-08-20 15:00:00")
+def test_update_recurring_rebased_anchor_does_not_diff_after_another_occurrence(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    _id = "existing-id"
+    rule = "FREQ=WEEKLY;INTERVAL=1;BYDAY=FR;BYHOUR=19;BYMINUTE=0"
+    destination = _make_recurring_resource(
+        [_recurrence("2026-08-14T19:00:00", rule, duration="30m")],
+    )
+    mock_config.state.destination["downtime_schedules"][_id] = destination
+    source = _make_recurring_resource(
+        [_recurrence("2026-07-24T19:00:00", rule, duration="30m")],
+    )
+
+    _run(downtime.pre_resource_action_hook(_id, source))
+
+    assert not check_diff(downtime.resource_config, source, destination)
+    assert destination["attributes"]["schedule"]["recurrences"][0]["start"] == "2026-08-14T19:00:00"
+
+
+@freeze_time("2026-08-03 15:00:00")
+def test_update_recurring_rebased_count_does_not_diff(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    _id = "existing-id"
+    destination = _make_recurring_resource(
+        [_recurrence("2026-08-04T09:00:00", "FREQ=DAILY;COUNT=2;BYHOUR=9")],
+        timezone_name="UTC",
+    )
+    mock_config.state.destination["downtime_schedules"][_id] = destination
+    source = _make_recurring_resource(
+        [_recurrence("2026-08-01T09:00:00", "FREQ=DAILY;COUNT=5;BYHOUR=9")],
+        timezone_name="UTC",
+    )
+
+    _run(downtime.pre_resource_action_hook(_id, source))
+
+    assert not check_diff(downtime.resource_config, source, destination)
+
+
+@freeze_time("2026-08-11 15:00:00")
+def test_update_recurring_removed_expired_sibling_does_not_diff(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    _id = "existing-id"
+    active_rule = "FREQ=WEEKLY;BYDAY=FR;BYHOUR=10;BYMINUTE=15"
+    destination = _make_recurring_resource([_recurrence("2026-08-14T10:15:00", active_rule, duration="30m")])
+    mock_config.state.destination["downtime_schedules"][_id] = destination
+    source = _make_recurring_resource(
+        [
+            _recurrence("2026-08-01T09:00:00", "FREQ=DAILY;COUNT=2"),
+            _recurrence("2026-08-07T10:15:00", active_rule, duration="30m"),
+        ]
+    )
+
+    _run(downtime.pre_resource_action_hook(_id, source))
+
+    assert not check_diff(downtime.resource_config, source, destination)
+
+
+@pytest.mark.parametrize(
+    ("source_start", "source_rule", "source_duration", "source_timezone"),
+    [
+        ("2026-07-24T19:00:00", "FREQ=WEEKLY;BYDAY=FR;BYHOUR=19;BYMINUTE=0", "45m", "America/New_York"),
+        ("2026-07-24T19:00:00", "FREQ=WEEKLY;INTERVAL=2;BYDAY=FR;BYHOUR=19;BYMINUTE=0", "30m", "America/New_York"),
+        ("2026-08-28T19:00:00", "FREQ=WEEKLY;BYDAY=FR;BYHOUR=19;BYMINUTE=0", "30m", "America/New_York"),
+        ("2026-07-24T19:00:00", "FREQ=WEEKLY;BYDAY=FR;BYHOUR=19;BYMINUTE=0", "30m", "America/Chicago"),
+    ],
+)
+@freeze_time("2026-08-20 15:00:00")
+def test_update_recurring_semantic_change_still_diffs(
+    mock_config,
+    source_start,
+    source_rule,
+    source_duration,
+    source_timezone,
+):
+    downtime = DowntimeSchedules(mock_config)
+    _id = "existing-id"
+    rule = "FREQ=WEEKLY;BYDAY=FR;BYHOUR=19;BYMINUTE=0"
+    destination = _make_recurring_resource([_recurrence("2026-08-14T19:00:00", rule, duration="30m")])
+    mock_config.state.destination["downtime_schedules"][_id] = destination
+    source = _make_recurring_resource(
+        [_recurrence(source_start, source_rule, duration=source_duration)],
+        timezone_name=source_timezone,
+    )
+
+    _run(downtime.pre_resource_action_hook(_id, source))
+
+    assert check_diff(downtime.resource_config, source, destination)
+
+
+@freeze_time("2026-08-21 18:59:30")
+def test_update_payload_advances_recurrence_past_create_safety_window(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    _id = "existing-id"
+    rule = "FREQ=WEEKLY;BYDAY=FR;BYHOUR=19;BYMINUTE=0"
+    destination = _make_recurring_resource(
+        [_recurrence("2026-08-14T19:00:00", rule, duration="30m")],
+        timezone_name="UTC",
+    )
+    destination["id"] = "downtime-destination-test"
+    destination["attributes"]["message"] = "Original message"
+    mock_config.state.destination["downtime_schedules"][_id] = destination
+    source = _make_recurring_resource(
+        [_recurrence("2026-07-24T19:00:00", rule, duration="30m")],
+        timezone_name="UTC",
+    )
+    source["attributes"]["message"] = "Updated message"
+    captured = {}
+
+    async def _patch(path, payload):
+        captured["path"] = path
+        captured["payload"] = payload
+        return {"data": payload["data"]}
+
+    mock_config.destination_client.patch = _patch
+
+    _run(downtime.pre_resource_action_hook(_id, source))
+    _run(downtime.update_resource(_id, source))
+
+    recurrence = captured["payload"]["data"]["attributes"]["schedule"]["recurrences"][0]
+    assert recurrence["start"] == "2026-08-28T19:00:00"
+    assert captured["path"] == "/api/v2/downtime/downtime-destination-test"

--- a/tests/unit/test_downtime_schedules.py
+++ b/tests/unit/test_downtime_schedules.py
@@ -319,6 +319,19 @@ def test_recurring_count_is_reduced_to_remaining_occurrences(mock_config):
     assert recurrence["rrule"] == "FREQ=DAILY;COUNT=2;BYHOUR=9"
 
 
+@freeze_time("2026-08-11 15:00:00")
+def test_recurring_local_until_is_interpreted_in_schedule_timezone(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    rule = "FREQ=DAILY;UNTIL=20260813T090000"
+    resource = _make_recurring_resource([_recurrence("2026-08-01T09:00:00", rule)])
+
+    _run(downtime.pre_resource_action_hook("new-id", resource))
+
+    recurrence = resource["attributes"]["schedule"]["recurrences"][0]
+    assert recurrence["start"] == "2026-08-12T09:00:00"
+    assert recurrence["rrule"] == rule
+
+
 @freeze_time("2026-08-01 00:10:00")
 def test_recurring_expansion_limit_skips_resource(mock_config, monkeypatch):
     downtime = DowntimeSchedules(mock_config)

--- a/tests/unit/test_downtime_schedules.py
+++ b/tests/unit/test_downtime_schedules.py
@@ -19,6 +19,7 @@ New behavior:
 
 import asyncio
 from datetime import datetime, timedelta, timezone
+from threading import Event
 
 import pytest
 from dateutil.parser import parse
@@ -332,17 +333,48 @@ def test_recurring_local_until_is_interpreted_in_schedule_timezone(mock_config):
     assert recurrence["rrule"] == rule
 
 
-@freeze_time("2026-08-01 00:10:00")
-def test_recurring_expansion_limit_skips_resource(mock_config, monkeypatch):
+@freeze_time("2026-08-10 00:00:00")
+def test_recurring_large_count_is_normalized_without_rejection(mock_config):
     downtime = DowntimeSchedules(mock_config)
-    monkeypatch.setattr(DowntimeSchedules, "_MAX_RRULE_OCCURRENCES", 3)
     resource = _make_recurring_resource(
-        [_recurrence("2026-08-01T00:00:00", "FREQ=MINUTELY")],
+        [_recurrence("2026-06-01T00:00:00", "FREQ=MINUTELY;COUNT=200000")],
         timezone_name="UTC",
     )
 
-    with pytest.raises(SkipResource, match="more than 3 occurrences"):
-        _run(downtime.pre_resource_action_hook("new-id", resource))
+    _run(downtime.pre_resource_action_hook("new-id", resource))
+
+    recurrence = resource["attributes"]["schedule"]["recurrences"][0]
+    assert recurrence["start"] == "2026-08-10T00:02:00"
+    assert recurrence["rrule"] == "FREQ=MINUTELY;COUNT=99198"
+
+
+@freeze_time("2026-08-11 15:00:00")
+def test_recurring_expansion_does_not_block_event_loop(mock_config, monkeypatch):
+    downtime = DowntimeSchedules(mock_config)
+    resource = _make_recurring_resource(
+        [_recurrence("2026-08-01T09:00:00", "FREQ=DAILY")],
+        timezone_name="UTC",
+    )
+    expansion_started = Event()
+    allow_expansion = Event()
+    original_next_occurrence = DowntimeSchedules._next_valid_occurrence
+
+    def blocking_next_occurrence(cls, rrule, start, cutoff):
+        expansion_started.set()
+        if not allow_expansion.wait(timeout=1):
+            raise AssertionError("recurrence expansion blocked the event loop")
+        return original_next_occurrence(rrule, start, cutoff)
+
+    monkeypatch.setattr(DowntimeSchedules, "_next_valid_occurrence", classmethod(blocking_next_occurrence))
+
+    async def normalize_while_event_loop_progresses():
+        normalization = asyncio.create_task(downtime.pre_resource_action_hook("new-id", resource))
+        while not expansion_started.is_set():
+            await asyncio.sleep(0)
+        allow_expansion.set()
+        await normalization
+
+    _run(normalize_while_event_loop_progresses())
 
 
 @freeze_time("2026-08-11 15:00:00")

--- a/tests/unit/test_downtime_schedules.py
+++ b/tests/unit/test_downtime_schedules.py
@@ -211,6 +211,45 @@ def test_recurring_start_preserves_local_time_across_dst(mock_config):
     assert "+" not in recurrence["start"]
 
 
+@freeze_time("2026-03-07 15:00:00")
+def test_recurring_start_skips_nonexistent_dst_occurrence(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    rule = "FREQ=DAILY;BYHOUR=2;BYMINUTE=30"
+    resource = _make_recurring_resource([_recurrence("2026-03-07T02:30:00", rule)])
+
+    _run(downtime.pre_resource_action_hook("new-id", resource))
+
+    recurrence = resource["attributes"]["schedule"]["recurrences"][0]
+    assert recurrence["start"] == "2026-03-09T02:30:00"
+    assert recurrence["rrule"] == rule
+
+
+@freeze_time("2026-03-07 15:00:00")
+def test_recurring_count_does_not_consume_nonexistent_dst_occurrence(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    resource = _make_recurring_resource([_recurrence("2026-03-07T02:30:00", "FREQ=DAILY;COUNT=3;BYHOUR=2;BYMINUTE=30")])
+
+    _run(downtime.pre_resource_action_hook("new-id", resource))
+
+    recurrence = resource["attributes"]["schedule"]["recurrences"][0]
+    assert recurrence["start"] == "2026-03-09T02:30:00"
+    assert recurrence["rrule"] == "FREQ=DAILY;COUNT=2;BYHOUR=2;BYMINUTE=30"
+
+
+@freeze_time("2026-10-31 15:00:00")
+def test_recurring_ambiguous_fall_back_start_remains_offset_free(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    rule = "FREQ=DAILY;BYHOUR=1;BYMINUTE=30"
+    resource = _make_recurring_resource([_recurrence("2026-10-31T01:30:00", rule)])
+
+    _run(downtime.pre_resource_action_hook("new-id", resource))
+
+    recurrence = resource["attributes"]["schedule"]["recurrences"][0]
+    assert recurrence["start"] == "2026-11-01T01:30:00"
+    assert recurrence["rrule"] == rule
+    assert "+" not in recurrence["start"]
+
+
 @freeze_time("2026-08-11 15:00:00")
 def test_recurring_future_start_is_untouched(mock_config):
     downtime = DowntimeSchedules(mock_config)
@@ -278,6 +317,19 @@ def test_recurring_count_is_reduced_to_remaining_occurrences(mock_config):
     recurrence = resource["attributes"]["schedule"]["recurrences"][0]
     assert recurrence["start"] == "2026-08-04T09:00:00"
     assert recurrence["rrule"] == "FREQ=DAILY;COUNT=2;BYHOUR=9"
+
+
+@freeze_time("2026-08-01 00:10:00")
+def test_recurring_expansion_limit_skips_resource(mock_config, monkeypatch):
+    downtime = DowntimeSchedules(mock_config)
+    monkeypatch.setattr(DowntimeSchedules, "_MAX_RRULE_OCCURRENCES", 3)
+    resource = _make_recurring_resource(
+        [_recurrence("2026-08-01T00:00:00", "FREQ=MINUTELY")],
+        timezone_name="UTC",
+    )
+
+    with pytest.raises(SkipResource, match="more than 3 occurrences"):
+        _run(downtime.pre_resource_action_hook("new-id", resource))
 
 
 @freeze_time("2026-08-11 15:00:00")
@@ -463,6 +515,39 @@ def test_update_payload_advances_recurrence_past_create_safety_window(mock_confi
     assert captured["path"] == "/api/v2/downtime/downtime-destination-test"
 
 
+@freeze_time("2026-03-07 15:00:00")
+def test_update_payload_skips_nonexistent_dst_occurrence(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    _id = "existing-id"
+    rule = "FREQ=DAILY;COUNT=3;BYHOUR=2;BYMINUTE=30"
+    destination = _make_recurring_resource(
+        [_recurrence("2026-03-07T02:30:00", rule)],
+    )
+    destination["id"] = "downtime-destination-test"
+    destination["attributes"]["message"] = "Original message"
+    mock_config.state.destination["downtime_schedules"][_id] = destination
+    source = _make_recurring_resource(
+        [_recurrence("2026-03-07T02:30:00", rule)],
+    )
+    source["attributes"]["message"] = "Updated message"
+    captured = {}
+
+    async def _patch(path, payload):
+        captured["path"] = path
+        captured["payload"] = payload
+        return {"data": payload["data"]}
+
+    mock_config.destination_client.patch = _patch
+
+    _run(downtime.pre_resource_action_hook(_id, source))
+    _run(downtime.update_resource(_id, source))
+
+    recurrence = captured["payload"]["data"]["attributes"]["schedule"]["recurrences"][0]
+    assert recurrence["start"] == "2026-03-09T02:30:00"
+    assert recurrence["rrule"] == "FREQ=DAILY;COUNT=2;BYHOUR=2;BYMINUTE=30"
+    assert captured["path"] == "/api/v2/downtime/downtime-destination-test"
+
+
 @freeze_time("2026-08-21 15:00:00")
 def test_update_payload_omits_expired_schedule_but_preserves_unrelated_change(mock_config):
     downtime = DowntimeSchedules(mock_config)
@@ -490,3 +575,36 @@ def test_update_payload_omits_expired_schedule_but_preserves_unrelated_change(mo
     assert "schedule" not in attributes
     assert attributes["message"] == "Updated message"
     assert captured["path"] == "/api/v2/downtime/downtime-destination-test"
+
+
+@freeze_time("2026-08-21 15:00:00")
+def test_update_cancels_active_destination_when_source_recurrence_expired(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    _id = "existing-id"
+    destination = _make_recurring_resource(
+        [_recurrence("2026-08-01T09:00:00", "FREQ=DAILY")],
+        timezone_name="UTC",
+    )
+    destination["id"] = "downtime-destination-test"
+    mock_config.state.destination["downtime_schedules"][_id] = destination
+    source = _make_recurring_resource(
+        [_recurrence("2026-08-01T09:00:00", "FREQ=DAILY;COUNT=2")],
+        timezone_name="UTC",
+    )
+    captured = {}
+
+    async def _delete(path):
+        captured["path"] = path
+
+    async def _unexpected_patch(*_args, **_kwargs):
+        pytest.fail("an exhausted source must cancel an active destination")
+
+    mock_config.destination_client.delete = _delete
+    mock_config.destination_client.patch = _unexpected_patch
+
+    _run(downtime.pre_resource_action_hook(_id, source))
+    assert check_diff(downtime.resource_config, source, destination)
+    _run(downtime._update_resource(_id, source))
+
+    assert captured["path"] == "/api/v2/downtime/downtime-destination-test"
+    assert _id not in mock_config.state.destination["downtime_schedules"]

--- a/tests/unit/test_downtime_schedules.py
+++ b/tests/unit/test_downtime_schedules.py
@@ -222,6 +222,21 @@ def test_recurring_future_start_is_untouched(mock_config):
     assert resource["attributes"]["schedule"]["recurrences"][0] == _recurrence("2026-08-12T09:00:00", rule)
 
 
+@freeze_time("2026-08-12 08:59:30")
+def test_recurring_start_within_create_safety_window_advances(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    rule = "FREQ=DAILY;BYHOUR=9;BYMINUTE=0"
+    resource = _make_recurring_resource(
+        [_recurrence("2026-08-01T09:00:00", rule)],
+        timezone_name="UTC",
+    )
+
+    _run(downtime.pre_resource_action_hook("new-id", resource))
+
+    recurrence = resource["attributes"]["schedule"]["recurrences"][0]
+    assert recurrence["start"] == "2026-08-13T09:00:00"
+
+
 @freeze_time("2026-08-11 15:00:00")
 def test_recurring_expired_rule_is_removed_but_active_sibling_is_preserved(mock_config):
     downtime = DowntimeSchedules(mock_config)

--- a/tests/unit/test_downtime_schedules.py
+++ b/tests/unit/test_downtime_schedules.py
@@ -22,6 +22,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 from dateutil.parser import parse
+from freezegun import freeze_time
 
 from datadog_sync.model.downtime_schedules import DowntimeSchedules
 from datadog_sync.utils.resource_utils import SkipResource
@@ -162,6 +163,147 @@ def test_start_only_no_end_field(mock_config):
     schedule = resource["attributes"]["schedule"]
     assert "end" not in schedule
     assert parse(schedule["start"]).timestamp() > _now_ts() - 5
+
+
+# --- Recurring downtime recurrence-level normalization ----------------------
+
+
+def _recurrence(start, rrule, duration="1h"):
+    """Return the documented v2 recurring-downtime payload shape."""
+    return {"start": start, "duration": duration, "rrule": rrule}
+
+
+def _make_recurring_resource(recurrences, timezone_name="America/New_York"):
+    return {
+        "attributes": {
+            "schedule": {
+                "timezone": timezone_name,
+                "recurrences": recurrences,
+            }
+        }
+    }
+
+
+@freeze_time("2026-08-11 15:00:00")
+def test_recurring_past_start_advances_to_next_rrule_occurrence(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    rule = "FREQ=WEEKLY;INTERVAL=1;BYDAY=MO;BYHOUR=9;BYMINUTE=0"
+    resource = _make_recurring_resource([_recurrence("2026-08-03T09:00:00", rule)])
+
+    _run(downtime.pre_resource_action_hook("new-id", resource))
+
+    recurrence = resource["attributes"]["schedule"]["recurrences"][0]
+    assert recurrence["start"] == "2026-08-17T09:00:00"
+    assert recurrence["rrule"] == rule
+    assert recurrence["duration"] == "1h"
+
+
+@freeze_time("2026-03-08 15:00:00")
+def test_recurring_start_preserves_local_time_across_dst(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    resource = _make_recurring_resource([_recurrence("2026-03-06T09:30:00", "FREQ=DAILY;BYHOUR=9;BYMINUTE=30")])
+
+    _run(downtime.pre_resource_action_hook("new-id", resource))
+
+    recurrence = resource["attributes"]["schedule"]["recurrences"][0]
+    assert recurrence["start"] == "2026-03-09T09:30:00"
+    assert not recurrence["start"].endswith("Z")
+    assert "+" not in recurrence["start"]
+
+
+@freeze_time("2026-08-11 15:00:00")
+def test_recurring_future_start_is_untouched(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    rule = "FREQ=DAILY;BYHOUR=9;BYMINUTE=0"
+    resource = _make_recurring_resource([_recurrence("2026-08-12T09:00:00", rule)])
+
+    _run(downtime.pre_resource_action_hook("new-id", resource))
+
+    assert resource["attributes"]["schedule"]["recurrences"][0] == _recurrence("2026-08-12T09:00:00", rule)
+
+
+@freeze_time("2026-08-11 15:00:00")
+def test_recurring_expired_rule_is_removed_but_active_sibling_is_preserved(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    expired = _recurrence("2026-08-01T09:00:00", "FREQ=DAILY;COUNT=2")
+    active_rule = "FREQ=WEEKLY;BYDAY=FR;BYHOUR=10;BYMINUTE=15"
+    active = _recurrence("2026-08-07T10:15:00", active_rule, duration="30m")
+    resource = _make_recurring_resource([expired, active])
+
+    _run(downtime.pre_resource_action_hook("new-id", resource))
+
+    assert resource["attributes"]["schedule"]["recurrences"] == [
+        _recurrence("2026-08-14T10:15:00", active_rule, duration="30m")
+    ]
+
+
+@freeze_time("2026-08-11 15:00:00")
+def test_recurring_all_expired_rules_raise_skip(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    resource = _make_recurring_resource(
+        [
+            _recurrence("2026-08-01T09:00:00", "FREQ=DAILY;COUNT=2"),
+            _recurrence("2026-08-03T09:00:00", "FREQ=DAILY;UNTIL=20260805T130000Z"),
+        ]
+    )
+
+    with pytest.raises(SkipResource) as excinfo:
+        _run(downtime.pre_resource_action_hook("skip-id", resource))
+
+    assert "future occurrences" in str(excinfo.value).lower()
+
+
+@freeze_time("2026-08-03 15:00:00")
+def test_recurring_count_is_reduced_to_remaining_occurrences(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    resource = _make_recurring_resource([_recurrence("2026-08-01T09:00:00", "FREQ=DAILY;COUNT=5;BYHOUR=9")])
+
+    _run(downtime.pre_resource_action_hook("new-id", resource))
+
+    recurrence = resource["attributes"]["schedule"]["recurrences"][0]
+    assert recurrence["start"] == "2026-08-04T09:00:00"
+    assert recurrence["rrule"] == "FREQ=DAILY;COUNT=2;BYHOUR=9"
+
+
+@freeze_time("2026-08-11 15:00:00")
+def test_recurring_missing_start_is_left_for_api_default(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    recurrence = {"duration": "1h", "rrule": "FREQ=DAILY"}
+    resource = _make_recurring_resource([recurrence], timezone_name="UTC")
+
+    _run(downtime.pre_resource_action_hook("new-id", resource))
+
+    assert resource["attributes"]["schedule"]["recurrences"] == [recurrence]
+
+
+@freeze_time("2026-08-11 15:00:00")
+def test_recurring_unknown_timezone_raises_value_error(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    resource = _make_recurring_resource(
+        [_recurrence("2026-08-01T09:00:00", "FREQ=DAILY")],
+        timezone_name="Invalid/Example",
+    )
+
+    with pytest.raises(ValueError, match="Unknown schedule timezone"):
+        _run(downtime.pre_resource_action_hook("new-id", resource))
+
+
+def test_recurring_no_recurrences_key_no_op(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    resource = _make_resource({"timezone": "UTC"})
+
+    _run(downtime.pre_resource_action_hook("new-id", resource))
+
+    assert "recurrences" not in resource["attributes"]["schedule"]
+
+
+def test_recurring_empty_recurrences_no_op(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    resource = _make_recurring_resource([], timezone_name="UTC")
+
+    _run(downtime.pre_resource_action_hook("new-id", resource))
+
+    assert resource["attributes"]["schedule"]["recurrences"] == []
 
 
 def test_update_path_untouched_by_this_fix(mock_config):

--- a/tests/unit/test_downtime_schedules_active_windows.py
+++ b/tests/unit/test_downtime_schedules_active_windows.py
@@ -39,8 +39,8 @@ def _bridge(start="2026-08-11T15:00:00", duration="60m"):
     return {"start": start, "duration": duration, "rrule": "FREQ=DAILY;COUNT=1"}
 
 
-def _resource(recurrences, current_downtime=None, message=None):
-    schedule = {"timezone": "UTC", "recurrences": recurrences}
+def _resource(recurrences, current_downtime=None, message=None, timezone="UTC"):
+    schedule = {"timezone": timezone, "recurrences": recurrences}
     if current_downtime is not None:
         schedule["current_downtime"] = current_downtime
     attributes = {"schedule": schedule}
@@ -174,6 +174,42 @@ def test_update_equivalent_active_window_omits_schedule_from_unrelated_patch(moc
 
     assert "schedule" not in captured["payload"]["data"]["attributes"]
     assert captured["payload"]["data"]["attributes"]["message"] == "After"
+
+
+@freeze_time("2026-08-11 15:00:00")
+def test_update_aligned_active_window_patches_timezone_change(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    source_id = "downtime-source-test"
+    current = _current("2026-08-11T14:00:00+00:00", "2026-08-11T16:00:00+00:00")
+    destination = _seed_destination(
+        mock_config,
+        source_id,
+        _resource(
+            [_recurrence("2026-08-01T10:00:00")],
+            current,
+            timezone="America/New_York",
+        ),
+    )
+    source = _resource(
+        [_recurrence("2026-08-01T10:00:00")],
+        current,
+        timezone="America/Chicago",
+    )
+    captured = {}
+
+    async def _patch(_path, payload):
+        captured["payload"] = deepcopy(payload)
+        return {"data": payload["data"]}
+
+    mock_config.destination_client.patch = _patch
+
+    _run(downtime.pre_resource_action_hook(source_id, source))
+    assert check_diff(downtime.resource_config, source, destination)
+    _run(downtime.update_resource(source_id, source))
+
+    schedule = captured["payload"]["data"]["attributes"]["schedule"]
+    assert schedule["timezone"] == "America/Chicago"
+    assert "current_downtime" not in schedule
 
 
 @freeze_time("2026-08-11 15:00:00")

--- a/tests/unit/test_downtime_schedules_active_windows.py
+++ b/tests/unit/test_downtime_schedules_active_windows.py
@@ -1,0 +1,480 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+"""Active-window behavior for recurring v2 downtime schedules."""
+
+import asyncio
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+from freezegun import freeze_time
+
+from datadog_sync.model.downtime_schedules import DowntimeSchedules
+from datadog_sync.utils.resource_utils import CustomClientHTTPError, SkipResource, check_diff
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _recurrence(start, rrule="FREQ=DAILY", duration="2h"):
+    recurrence = {"duration": duration, "rrule": rrule}
+    if start is not None:
+        recurrence["start"] = start
+    return recurrence
+
+
+def _current(start, end):
+    return {"start": start, "end": end}
+
+
+def _bridge(start="2026-08-11T15:00:00", duration="60m"):
+    return {"start": start, "duration": duration, "rrule": "FREQ=DAILY;COUNT=1"}
+
+
+def _resource(recurrences, current_downtime=None, message=None):
+    schedule = {"timezone": "UTC", "recurrences": recurrences}
+    if current_downtime is not None:
+        schedule["current_downtime"] = current_downtime
+    attributes = {"schedule": schedule}
+    if message is not None:
+        attributes["message"] = message
+    return {"attributes": attributes}
+
+
+def _seed_destination(mock_config, source_id, resource):
+    destination = deepcopy(resource)
+    destination["id"] = "downtime-destination-test"
+    mock_config.state.destination["downtime_schedules"][source_id] = destination
+    return destination
+
+
+@freeze_time("2026-08-11 15:00:00")
+def test_create_active_recurrence_adds_remaining_window_bridge_before_future_cadence(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    resource = _resource(
+        [_recurrence("2026-08-11T14:00:00")],
+        _current("2026-08-11T14:00:00+00:00", "2026-08-11T16:00:00+00:00"),
+    )
+
+    _run(downtime.pre_resource_action_hook("downtime-source-test", resource))
+
+    assert resource["attributes"]["schedule"]["recurrences"] == [
+        _bridge(),
+        _recurrence("2026-08-12T14:00:00"),
+    ]
+
+
+@freeze_time("2026-08-11 15:00:00")
+def test_create_active_count_preserves_only_unconsumed_future_occurrences(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    resource = _resource(
+        [_recurrence("2026-08-10T14:00:00", "FREQ=DAILY;COUNT=3")],
+        _current("2026-08-11T14:00:00+00:00", "2026-08-11T16:00:00+00:00"),
+    )
+
+    _run(downtime.pre_resource_action_hook("downtime-source-test", resource))
+
+    assert resource["attributes"]["schedule"]["recurrences"] == [
+        _bridge(),
+        _recurrence("2026-08-12T14:00:00", "FREQ=DAILY;COUNT=1"),
+    ]
+
+
+@freeze_time("2026-08-11 15:00:00")
+def test_create_active_window_under_one_minute_does_not_overmute(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    resource = _resource(
+        [_recurrence("2026-08-11T14:00:00")],
+        _current("2026-08-11T14:00:00+00:00", "2026-08-11T15:00:45+00:00"),
+    )
+
+    _run(downtime.pre_resource_action_hook("downtime-source-test", resource))
+
+    assert resource["attributes"]["schedule"]["recurrences"] == [_recurrence("2026-08-12T14:00:00")]
+
+
+@freeze_time("2026-08-11 15:00:00")
+def test_create_inactive_recurrence_only_materializes_future_cadence(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    resource = _resource(
+        [_recurrence("2026-08-11T14:00:00")],
+        _current("2026-08-12T14:00:00+00:00", "2026-08-12T16:00:00+00:00"),
+    )
+
+    _run(downtime.pre_resource_action_hook("downtime-source-test", resource))
+
+    assert resource["attributes"]["schedule"]["recurrences"] == [_recurrence("2026-08-12T14:00:00")]
+
+
+@freeze_time("2026-08-11 15:00:00")
+def test_create_active_final_occurrence_materializes_bridge_only(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    resource = _resource(
+        [_recurrence("2026-08-11T14:00:00", "FREQ=DAILY;COUNT=1")],
+        _current("2026-08-11T14:00:00+00:00", "2026-08-11T16:00:00+00:00"),
+    )
+
+    _run(downtime.pre_resource_action_hook("downtime-source-test", resource))
+
+    assert resource["attributes"]["schedule"]["recurrences"] == [_bridge()]
+
+
+@freeze_time("2026-08-11 15:00:00")
+def test_create_inactive_exhausted_recurrence_is_skipped(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    resource = _resource(
+        [_recurrence("2026-08-10T14:00:00", "FREQ=DAILY;COUNT=1")],
+        _current("2026-08-10T14:00:00+00:00", "2026-08-10T16:00:00+00:00"),
+    )
+
+    with pytest.raises(SkipResource, match="no future occurrences or active window"):
+        _run(downtime.pre_resource_action_hook("downtime-source-test", resource))
+
+
+@freeze_time("2026-08-11 15:00:00")
+def test_update_equivalent_active_window_omits_schedule_from_unrelated_patch(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    source_id = "downtime-source-test"
+    destination = _seed_destination(
+        mock_config,
+        source_id,
+        _resource(
+            [_recurrence("2026-08-11T14:00:00")],
+            _current("2026-08-11T14:00:00+00:00", "2026-08-11T16:00:00+00:00"),
+            message="Before",
+        ),
+    )
+    source = _resource(
+        [_recurrence("2026-08-01T14:00:00")],
+        _current("2026-08-11T14:00:00+00:00", "2026-08-11T16:00:00+00:00"),
+        message="After",
+    )
+    captured = {}
+
+    async def _patch(path, payload):
+        captured["path"] = path
+        captured["payload"] = deepcopy(payload)
+        response = deepcopy(destination)
+        response["attributes"]["message"] = "After"
+        return {"data": response}
+
+    mock_config.destination_client.patch = _patch
+
+    _run(downtime.pre_resource_action_hook(source_id, source))
+    assert check_diff(downtime.resource_config, source, destination)
+    _run(downtime.update_resource(source_id, source))
+
+    assert "schedule" not in captured["payload"]["data"]["attributes"]
+    assert captured["payload"]["data"]["attributes"]["message"] == "After"
+
+
+@freeze_time("2026-08-11 15:00:00")
+def test_update_inactive_destination_adds_bridge_without_recreate(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    source_id = "downtime-source-test"
+    _seed_destination(
+        mock_config,
+        source_id,
+        _resource(
+            [_recurrence("2026-08-12T14:00:00")],
+            _current("2026-08-12T14:00:00+00:00", "2026-08-12T16:00:00+00:00"),
+        ),
+    )
+    source = _resource(
+        [_recurrence("2026-08-11T14:00:00")],
+        _current("2026-08-11T14:00:00+00:00", "2026-08-11T16:00:00+00:00"),
+    )
+    captured = {}
+
+    async def _patch(_path, payload):
+        captured["payload"] = deepcopy(payload)
+        return {"data": payload["data"]}
+
+    async def _unexpected_delete(_path):
+        pytest.fail("an inactive destination can be updated in place")
+
+    mock_config.destination_client.patch = _patch
+    mock_config.destination_client.delete = _unexpected_delete
+
+    _run(downtime.pre_resource_action_hook(source_id, source))
+    _run(downtime.update_resource(source_id, source))
+
+    assert captured["payload"]["data"]["attributes"]["schedule"]["recurrences"] == [
+        _bridge(),
+        _recurrence("2026-08-12T14:00:00"),
+    ]
+
+
+@freeze_time("2026-08-11 15:00:00")
+def test_update_equivalent_active_final_occurrence_is_not_canceled(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    source_id = "downtime-source-test"
+    recurrence = _recurrence("2026-08-11T14:00:00", "FREQ=DAILY;COUNT=1")
+    current = _current("2026-08-11T14:00:00+00:00", "2026-08-11T16:00:00+00:00")
+    destination = _seed_destination(mock_config, source_id, _resource([recurrence], current, message="Before"))
+    source = _resource([recurrence], current, message="After")
+    captured = {}
+
+    async def _patch(_path, payload):
+        captured["payload"] = deepcopy(payload)
+        response = deepcopy(destination)
+        response["attributes"]["message"] = "After"
+        return {"data": response}
+
+    async def _unexpected_delete(_path):
+        pytest.fail("the source recurrence is still active")
+
+    mock_config.destination_client.patch = _patch
+    mock_config.destination_client.delete = _unexpected_delete
+
+    _run(downtime.pre_resource_action_hook(source_id, source))
+    _run(downtime.update_resource(source_id, source))
+
+    assert "schedule" not in captured["payload"]["data"]["attributes"]
+
+
+@freeze_time("2026-08-11 15:00:00")
+def test_update_inactive_exhausted_source_cancels_active_final_destination_occurrence(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    source_id = "downtime-source-test"
+    _seed_destination(
+        mock_config,
+        source_id,
+        _resource(
+            [_recurrence("2026-08-11T14:00:00", "FREQ=DAILY;COUNT=1")],
+            _current("2026-08-11T14:00:00+00:00", "2026-08-11T16:00:00+00:00"),
+        ),
+    )
+    source = _resource(
+        [_recurrence("2026-08-10T14:00:00", "FREQ=DAILY;COUNT=1")],
+        _current("2026-08-10T14:00:00+00:00", "2026-08-10T16:00:00+00:00"),
+    )
+    captured = {}
+
+    async def _delete(path):
+        captured["path"] = path
+
+    async def _unexpected_patch(*_args, **_kwargs):
+        pytest.fail("an active destination must be canceled after the source expires")
+
+    mock_config.destination_client.delete = _delete
+    mock_config.destination_client.patch = _unexpected_patch
+
+    _run(downtime.pre_resource_action_hook(source_id, source))
+    assert check_diff(
+        downtime.resource_config,
+        source,
+        mock_config.state.destination["downtime_schedules"][source_id],
+    )
+    _run(downtime._update_resource(source_id, source))
+
+    assert captured["path"] == "/api/v2/downtime/downtime-destination-test"
+
+
+@freeze_time("2026-08-11 15:58:30")
+def test_created_bridge_converges_through_its_final_minute(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    source_id = "downtime-source-test"
+    destination = _seed_destination(
+        mock_config,
+        source_id,
+        _resource(
+            [
+                _recurrence("2026-08-11T15:00:15", "FREQ=DAILY;COUNT=1", duration="59m"),
+                _recurrence("2026-08-12T14:00:00"),
+            ],
+            _current("2026-08-11T15:00:15+00:00", "2026-08-11T15:59:15+00:00"),
+        ),
+    )
+    source = _resource(
+        [_recurrence("2026-08-01T14:00:00")],
+        _current("2026-08-11T14:00:00+00:00", "2026-08-11T16:00:00+00:00"),
+    )
+
+    _run(downtime.pre_resource_action_hook(source_id, source))
+
+    assert not check_diff(downtime.resource_config, source, destination)
+
+
+@freeze_time("2026-08-11 15:00:00")
+def test_update_aligned_active_window_patches_original_anchor_for_future_change(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    source_id = "downtime-source-test"
+    _seed_destination(
+        mock_config,
+        source_id,
+        _resource(
+            [_recurrence("2026-08-11T14:00:00")],
+            _current("2026-08-11T14:00:00+00:00", "2026-08-11T16:00:00+00:00"),
+        ),
+    )
+    source = _resource(
+        [_recurrence("2026-08-01T14:00:00", "FREQ=DAILY;INTERVAL=2")],
+        _current("2026-08-11T14:00:00+00:00", "2026-08-11T16:00:00+00:00"),
+    )
+    captured = {}
+
+    async def _patch(_path, payload):
+        captured["payload"] = deepcopy(payload)
+        return {"data": payload["data"]}
+
+    mock_config.destination_client.patch = _patch
+
+    _run(downtime.pre_resource_action_hook(source_id, source))
+    _run(downtime.update_resource(source_id, source))
+
+    assert captured["payload"]["data"]["attributes"]["schedule"]["recurrences"] == [
+        _recurrence("2026-08-01T14:00:00", "FREQ=DAILY;INTERVAL=2")
+    ]
+
+
+@freeze_time("2026-08-11 15:01:00")
+def test_update_bridge_defers_future_change_until_equivalent_active_window_ends(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    source_id = "downtime-source-test"
+    destination = _seed_destination(
+        mock_config,
+        source_id,
+        _resource(
+            [
+                _recurrence("2026-08-11T15:00:15", "FREQ=DAILY;COUNT=1", duration="59m"),
+                _recurrence("2026-08-12T14:00:00"),
+            ],
+            _current("2026-08-11T15:00:15+00:00", "2026-08-11T15:59:15+00:00"),
+            message="Before",
+        ),
+    )
+    source = _resource(
+        [_recurrence("2026-08-01T14:00:00", "FREQ=DAILY;INTERVAL=2")],
+        _current("2026-08-11T14:00:00+00:00", "2026-08-11T16:00:00+00:00"),
+        message="After",
+    )
+    captured = {}
+
+    async def _patch(_path, payload):
+        captured["payload"] = deepcopy(payload)
+        response = deepcopy(destination)
+        response["attributes"]["message"] = "After"
+        return {"data": response}
+
+    mock_config.destination_client.patch = _patch
+
+    _run(downtime.pre_resource_action_hook(source_id, source))
+    _run(downtime.update_resource(source_id, source))
+
+    assert "schedule" not in captured["payload"]["data"]["attributes"]
+    assert captured["payload"]["data"]["attributes"]["message"] == "After"
+
+
+@freeze_time("2026-08-11 15:00:00")
+def test_update_mismatched_active_window_recreates_bridge_and_future_cadence(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    source_id = "downtime-source-test"
+    _seed_destination(
+        mock_config,
+        source_id,
+        _resource(
+            [_recurrence("2026-08-11T13:00:00")],
+            _current("2026-08-11T13:00:00+00:00", "2026-08-11T18:00:00+00:00"),
+        ),
+    )
+    source = _resource(
+        [_recurrence("2026-08-11T14:00:00")],
+        _current("2026-08-11T14:00:00+00:00", "2026-08-11T16:00:00+00:00"),
+    )
+    captured = {"deleted": [], "posted": []}
+
+    async def _delete(path):
+        captured["deleted"].append(path)
+
+    async def _post(path, payload):
+        captured["posted"].append((path, deepcopy(payload)))
+        return {"data": {"id": "downtime-replacement-test", **deepcopy(payload["data"])}}
+
+    async def _unexpected_patch(*_args, **_kwargs):
+        pytest.fail("the API rejects changing the start of an active destination")
+
+    mock_config.destination_client.delete = _delete
+    mock_config.destination_client.post = _post
+    mock_config.destination_client.patch = _unexpected_patch
+
+    _run(downtime.pre_resource_action_hook(source_id, source))
+    _run(downtime._update_resource(source_id, source))
+
+    assert captured["deleted"] == ["/api/v2/downtime/downtime-destination-test"]
+    assert captured["posted"][0][0] == "/api/v2/downtime"
+    assert captured["posted"][0][1]["data"]["attributes"]["schedule"]["recurrences"] == [
+        _bridge(),
+        _recurrence("2026-08-12T14:00:00"),
+    ]
+    assert mock_config.state.destination["downtime_schedules"][source_id]["id"] == "downtime-replacement-test"
+
+
+@freeze_time("2026-08-11 15:00:00")
+def test_update_not_found_recreates_active_source_with_bridge(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    source_id = "downtime-source-test"
+    _seed_destination(
+        mock_config,
+        source_id,
+        _resource(
+            [_recurrence("2026-08-11T14:00:00")],
+            _current("2026-08-11T14:00:00+00:00", "2026-08-11T16:00:00+00:00"),
+            message="Before",
+        ),
+    )
+    source = _resource(
+        [_recurrence("2026-08-01T14:00:00")],
+        _current("2026-08-11T14:00:00+00:00", "2026-08-11T16:00:00+00:00"),
+        message="After",
+    )
+    captured = {}
+
+    async def _patch(_path, _payload):
+        raise CustomClientHTTPError(
+            SimpleNamespace(status=404, message="not found"),
+            message='{"errors":["Downtime not found"]}',
+        )
+
+    async def _post(_path, payload):
+        captured["payload"] = deepcopy(payload)
+        return {"data": {"id": "downtime-replacement-test"}}
+
+    mock_config.destination_client.patch = _patch
+    mock_config.destination_client.post = _post
+
+    _run(downtime.pre_resource_action_hook(source_id, source))
+    _run(downtime.update_resource(source_id, source))
+
+    assert captured["payload"]["data"]["attributes"]["schedule"]["recurrences"] == [
+        _bridge(),
+        _recurrence("2026-08-12T14:00:00"),
+    ]
+    assert "current_downtime" not in captured["payload"]["data"]["attributes"]["schedule"]
+
+
+@freeze_time("2026-08-11 15:00:00")
+def test_create_active_schedule_at_five_future_recurrence_limit_is_skipped(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    recurrences = [
+        _recurrence("2026-08-04T14:00:00", "FREQ=WEEKLY", duration="2h"),
+        _recurrence("2026-08-05T10:00:00", "FREQ=WEEKLY", duration="30m"),
+        _recurrence("2026-08-06T11:00:00", "FREQ=WEEKLY", duration="30m"),
+        _recurrence("2026-08-07T12:00:00", "FREQ=WEEKLY", duration="30m"),
+        _recurrence("2026-08-08T13:00:00", "FREQ=WEEKLY", duration="30m"),
+    ]
+    resource = _resource(
+        recurrences,
+        _current("2026-08-11T14:00:00+00:00", "2026-08-11T16:00:00+00:00"),
+    )
+
+    with pytest.raises(SkipResource, match="maximum of 5 recurrences"):
+        _run(downtime.pre_resource_action_hook("downtime-source-test", resource))

--- a/tests/unit/test_downtime_schedules_active_windows.py
+++ b/tests/unit/test_downtime_schedules_active_windows.py
@@ -416,6 +416,44 @@ def test_update_bridge_defers_future_change_until_equivalent_active_window_ends(
     assert captured["payload"]["data"]["attributes"]["message"] == "After"
 
 
+@freeze_time("2026-08-11 15:01:00")
+def test_update_recent_bridge_defers_future_change_for_subminute_start_mismatch(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    source_id = "downtime-source-test"
+    destination = _seed_destination(
+        mock_config,
+        source_id,
+        _resource(
+            [
+                _recurrence("2026-08-11T15:00:30", "FREQ=DAILY;COUNT=1", duration="59m"),
+                _recurrence("2026-08-12T15:00:00"),
+            ],
+            _current("2026-08-11T15:00:30+00:00", "2026-08-11T15:59:30+00:00"),
+            message="Before",
+        ),
+    )
+    source = _resource(
+        [_recurrence("2026-08-01T15:00:00", "FREQ=DAILY;INTERVAL=2")],
+        _current("2026-08-11T15:00:00+00:00", "2026-08-11T16:00:00+00:00"),
+        message="After",
+    )
+    captured = {}
+
+    async def _patch(_path, payload):
+        captured["payload"] = deepcopy(payload)
+        response = deepcopy(destination)
+        response["attributes"]["message"] = "After"
+        return {"data": response}
+
+    mock_config.destination_client.patch = _patch
+
+    _run(downtime.pre_resource_action_hook(source_id, source))
+    _run(downtime.update_resource(source_id, source))
+
+    assert "schedule" not in captured["payload"]["data"]["attributes"]
+    assert captured["payload"]["data"]["attributes"]["message"] == "After"
+
+
 @freeze_time("2026-08-11 15:00:00")
 def test_update_mismatched_active_window_recreates_bridge_and_future_cadence(mock_config):
     downtime = DowntimeSchedules(mock_config)

--- a/tests/unit/test_downtime_schedules_active_windows.py
+++ b/tests/unit/test_downtime_schedules_active_windows.py
@@ -214,6 +214,48 @@ def test_update_inactive_destination_adds_bridge_without_recreate(mock_config):
 
 
 @freeze_time("2026-08-11 15:00:00")
+def test_update_one_time_destination_adds_active_recurrence_bridge(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    source_id = "downtime-source-test"
+    destination = _seed_destination(
+        mock_config,
+        source_id,
+        {
+            "attributes": {
+                "schedule": {
+                    "start": "2026-08-12T14:00:00+00:00",
+                    "end": "2026-08-12T16:00:00+00:00",
+                }
+            }
+        },
+    )
+    source = _resource(
+        [_recurrence("2026-08-11T14:00:00")],
+        _current("2026-08-11T14:00:00+00:00", "2026-08-11T16:00:00+00:00"),
+    )
+    captured = {}
+
+    async def _patch(_path, payload):
+        captured["payload"] = deepcopy(payload)
+        return {"data": payload["data"]}
+
+    async def _unexpected_delete(_path):
+        pytest.fail("a one-time destination can be updated in place")
+
+    mock_config.destination_client.patch = _patch
+    mock_config.destination_client.delete = _unexpected_delete
+
+    _run(downtime.pre_resource_action_hook(source_id, source))
+    _run(downtime.update_resource(source_id, source))
+
+    assert captured["payload"]["data"]["attributes"]["schedule"]["recurrences"] == [
+        _bridge(),
+        _recurrence("2026-08-12T14:00:00"),
+    ]
+    assert "recurrences" not in destination["attributes"]["schedule"]
+
+
+@freeze_time("2026-08-11 15:00:00")
 def test_update_equivalent_active_final_occurrence_is_not_canceled(mock_config):
     downtime = DowntimeSchedules(mock_config)
     source_id = "downtime-source-test"

--- a/tests/unit/test_downtime_schedules_conflict_skip.py
+++ b/tests/unit/test_downtime_schedules_conflict_skip.py
@@ -24,10 +24,11 @@ import logging
 from types import SimpleNamespace
 
 import pytest
+from freezegun import freeze_time
 
 from datadog_sync.constants import LOGGER_NAME
 from datadog_sync.model.downtime_schedules import DowntimeSchedules
-from datadog_sync.utils.resource_utils import CustomClientHTTPError
+from datadog_sync.utils.resource_utils import CustomClientHTTPError, SkipResource
 
 DUPLICATE_BODY = (
     '{"errors":["The downtime being created is a duplicate of one or more '
@@ -169,6 +170,39 @@ def test_update_not_found_404_logs_recreation_at_info(downtime, caplog):
         _run(downtime.update_resource("src-id", _make_resource()))
     recs = [r for r in caplog.records if r.name == LOGGER_NAME and "src-id" in r.getMessage()]
     assert recs and all(r.levelno == logging.INFO for r in recs)
+
+
+@freeze_time("2026-08-21 15:00:00")
+def test_update_not_found_does_not_recreate_exhausted_recurrence(downtime):
+    _seed_dest(downtime)
+    downtime.config.destination_client.patch = _http_error_raiser(404, NOT_FOUND_BODY)
+    posted = []
+
+    async def _post(_path, payload):
+        posted.append(payload)
+        return {"data": {"id": "replacement-id", "type": "downtime"}}
+
+    downtime.config.destination_client.post = _post
+    resource = {
+        "attributes": {
+            "message": "Updated message",
+            "schedule": {
+                "timezone": "UTC",
+                "recurrences": [
+                    {
+                        "start": "2026-08-01T09:00:00",
+                        "duration": "30m",
+                        "rrule": "FREQ=DAILY;COUNT=2",
+                    }
+                ],
+            },
+        }
+    }
+
+    with pytest.raises(SkipResource, match="no future occurrences"):
+        _run(downtime.update_resource("src-id", resource))
+
+    assert not posted
 
 
 def test_update_unrelated_404_propagates(downtime):

--- a/tests/unit/test_get_resources_by_ids_experiment.py
+++ b/tests/unit/test_get_resources_by_ids_experiment.py
@@ -186,7 +186,7 @@ def test_higher_mcr_allows_higher_concurrency(mock_config):
 # --- Test 7: marker emission contains literal "rate limit" ---
 
 
-def test_marker_string_matches_managed_sync_pattern():
+def test_marker_string_matches_consumer_pattern():
     """The marker string emitted by _import_get_resources_cb on threshold breach must
     contain a substring that the consumer-side rate-limit detector will match.
 
@@ -202,8 +202,8 @@ def test_marker_string_matches_managed_sync_pattern():
         f"(threshold {threshold}% of {total_ids} requested IDs)"
     )
 
-    # representative consumer pattern list (verbatim subset)
-    managed_sync_patterns = [
+    # Representative consumer pattern list (verbatim subset).
+    consumer_patterns = [
         "status 429 ",
         "status 503 ",
         " 429 ",
@@ -216,7 +216,7 @@ def test_marker_string_matches_managed_sync_pattern():
         "slowdown",
         "request limit",
     ]
-    matches = [p for p in managed_sync_patterns if p in marker.lower()]
+    matches = [p for p in consumer_patterns if p in marker.lower()]
     assert matches, f"marker {marker!r} does NOT match any consumer-side detector pattern"
     assert "rate limit" in matches
 
@@ -225,7 +225,7 @@ def test_buggy_old_marker_does_not_match():
     """Sanity: an early-draft marker 'failure_class=rate_limit_exceeded' should NOT match.
     Reason: underscore vs space."""
     bad_marker = "failure_class=rate_limit_exceeded"
-    managed_sync_patterns = [
+    consumer_patterns = [
         "status 429 ",
         "status 503 ",
         " 429 ",
@@ -238,7 +238,7 @@ def test_buggy_old_marker_does_not_match():
         "slowdown",
         "request limit",
     ]
-    matches = [p for p in managed_sync_patterns if p in bad_marker.lower()]
+    matches = [p for p in consumer_patterns if p in bad_marker.lower()]
     assert not matches, f"old marker shouldn't match but matched {matches}"
 
 
@@ -270,16 +270,14 @@ def _is_rate_limit_output_python_replica(output_bytes: bytes) -> bool:
     return any(p in s for p in patterns)
 
 
-def test_cross_language_marker_triggers_managed_sync_retrylater():
+def test_cross_language_marker_triggers_consumer_retry_path():
     """Cross-language verification: the actual byte sequence sync-cli emits on threshold
-    breach must trigger the consumer's rate-limit-detection retry path.
+    breach must trigger a consumer's rate-limit-detection retry path.
 
-    This replicates a typical consumer's lowercase-substring detector function
-    in Python and asserts our marker matches. Since we can't add tests to dd-source from
-    this experiment, this is the next-best thing: a faithful replica that mirrors the
-    exact match logic (strings.ToLower + strings.Contains)."""
-    # Simulate the bytes our subprocess would emit (logger.error output goes to stderr,
-    # combined with stdout via cmd.CombinedOutput in dd-source's runSyncCLIImportForChunk)
+    This replicates a typical lowercase-substring detector in Python and asserts
+    that the marker matches its strings.ToLower + strings.Contains behavior.
+    """
+    # Simulate the bytes a consumer subprocess would capture from stderr and stdout.
     transient_count = 6
     threshold = 5
     total_ids = 100


### PR DESCRIPTION
## Problem

Recurring v2 downtime schedules store each recurrence start as an offset-free local datetime interpreted in `schedule.timezone`. A past recurrence anchor can be rejected when the schedule is created or updated on the destination.

Moving that anchor to an arbitrary `now + 60s` value changes the RRULE cadence. Rebasing it correctly also creates a representation difference between the original source schedule and the destination schedule, which can otherwise cause repeated updates.

An exhausted recurrence requires different create and update behavior: a create has nothing left to schedule and should be skipped, while an update may still contain unrelated changes that must not be dropped.

## Fix

- Resolve IANA timezones portably with python-dateutil.
- Parse recurring starts in the schedule timezone.
- Interpret offset-free `UNTIL` values in the schedule timezone during expansion while preserving the original API RRULE.
- Advance a past or imminent start to the next occurrence produced by its RRULE, with a 60-second API-write safety window.
- Keep serialized starts offset-free.
- Remove a finite recurrence only when it has no future occurrence.
- Preserve active sibling recurrences and skip creation only when none remain.
- Reduce `COUNT` to the number of occurrences remaining after rebasing.
- Canonicalize source and destination recurrences to the same cutoff before update comparison, suppressing representation-only diffs.
- Preserve diffs for genuine duration, cadence, future-start, and timezone changes.
- Treat timezone as part of recurrence-plan equivalence so aligned active schedules PATCH real timezone changes.
- Rebase actual PATCH payloads so unrelated updates never resend a past recurrence anchor.
- When every recurrence is exhausted before or during an update, omit the schedule from the PATCH payload so unrelated attribute changes are still applied.
- If that PATCH discovers the mapped downtime is missing, restore the omitted schedule before entering the create fallback so an exhausted recurrence is skipped rather than recreated without a schedule.
- Skip nonexistent local times during DST transitions without consuming finite `COUNT` occurrences.
- Run API-supported recurrence expansion outside the event loop and preserve large finite `COUNT` rules.
- Cancel an active destination downtime when the corresponding finite source recurrence has expired.
- Preserve a source recurrence that is active now by adding a one-shot bridge for its remaining whole-minute duration, followed by normalized future recurrences.
- Pin bridge starts to the current local time so request latency cannot extend muting beyond the source end.
- Keep active PATCHes start-safe: omit equivalent schedules, preserve aligned active anchors, defer cadence-only changes for equivalent bridges, and replace mismatched active windows.
- Treat sub-minute active tails as converged because the API duration format cannot represent them.
- Enforce the API maximum of five recurrences rather than emitting an invalid bridge-plus-future payload.
- Keep consumer-side rate-limit detector tests implementation-neutral in public CI output.

One-time schedule start/end behavior is unchanged.

## Tests

Added coverage for:

- Weekly cadence with `BYDAY`, `BYHOUR`, and `BYMINUTE`.
- Non-UTC timezone and DST behavior.
- Offset-free output and the API-write safety window.
- Future starts remaining unchanged.
- Mixed active and expired recurrences.
- All recurrences expired.
- Finite `COUNT`, UTC `UNTIL`, and offset-free local `UNTIL` rules.
- Invalid timezones and missing recurrence fields.
- Stable update comparison after anchors and finite counts are rebased.
- Stable comparison after another occurrence passes and after expired siblings are removed.
- Genuine duration, cadence, future-start, and timezone changes remaining visible.
- Safe recurrence starts in outgoing PATCH payloads.
- Unrelated updates remaining intact when the final recurrence is already expired or crosses the write cutoff after planning.
- Aligned active schedules applying real timezone changes.
- Missing-destination fallback preserving create-time handling for exhausted recurrences.
- DST gaps, ambiguous fall-back times, large finite counts using API-supported frequencies, event-loop fairness, and active-destination cancellation.
- Active create/update windows, final finite occurrences, bridge convergence through the final minute, safe active PATCHes, sub-minute bridge start mismatches, missing-destination recreation, mismatched-window replacement, recurring sources mapped to one-time destination schedules, finite `COUNT`, and the five-recurrence limit.

Validation:

- `pytest -q tests/unit` — 1170 passed, 1 warning.
- Ruff and Black checks on changed files — passed.
