### PR TITLE
feat(logs_indexes): allow flex retention override

### DIFF
--- a/datadog_sync/commands/shared/options.py
+++ b/datadog_sync/commands/shared/options.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import configobj
 from sys import exit
 
-from click import Choice, Option, option, File, Path
+from click import Choice, IntRange, Option, option, File, Path
 
 from datadog_sync import constants
 from typing import TYPE_CHECKING, Any, Callable, Dict, List
@@ -571,7 +571,7 @@ _sync_options = [
     option(
         "--alter-flex-logs-retention-days",
         required=False,
-        type=int,
+        type=IntRange(min=30),
         default=None,
         help="Override num_flex_logs_retention_days on logs indexes where the field is present.",
         cls=CustomOptionClass,

--- a/datadog_sync/commands/shared/options.py
+++ b/datadog_sync/commands/shared/options.py
@@ -569,6 +569,14 @@ _refresh_destination_state_options = [
 
 _sync_options = [
     option(
+        "--alter-flex-logs-retention-days",
+        required=False,
+        type=int,
+        default=None,
+        help="Override num_flex_logs_retention_days on logs indexes where the field is present.",
+        cls=CustomOptionClass,
+    ),
+    option(
         "--create-global-downtime",
         required=False,
         type=bool,

--- a/datadog_sync/model/logs_indexes.py
+++ b/datadog_sync/model/logs_indexes.py
@@ -47,7 +47,9 @@ class LogsIndexes(BaseResource):
         return resource["name"], resource
 
     async def pre_resource_action_hook(self, _id, resource: Dict) -> None:
-        pass
+        retention_days = self.config.alter_flex_logs_retention_days
+        if retention_days is not None and "num_flex_logs_retention_days" in resource:
+            resource["num_flex_logs_retention_days"] = retention_days
 
     async def pre_apply_hook(self) -> None:
         pass

--- a/datadog_sync/utils/configuration.py
+++ b/datadog_sync/utils/configuration.py
@@ -79,6 +79,7 @@ class Configuration(object):
     show_progress_bar: bool
     allow_self_lockout: bool
     datadog_host_override: Optional[str] = None
+    alter_flex_logs_retention_days: Optional[int] = None
     emit_json: bool = False
     # Opt-in: drop principal/role references that are absent from BOTH destination and
     # source state (permanently gone -- e.g. deleted before this org's first-ever import)
@@ -529,6 +530,7 @@ def build_config(cmd: Command, **kwargs: Optional[Any]) -> Configuration:
         show_progress_bar = False
     allow_self_lockout = kwargs.get("allow_self_lockout", False)
     datadog_host_override = kwargs.get("datadog_host_override")
+    alter_flex_logs_retention_days = kwargs.get("alter_flex_logs_retention_days")
 
     # Parse allow_partial_permissions_roles
     allow_partial_permissions_roles = []
@@ -839,6 +841,7 @@ def build_config(cmd: Command, **kwargs: Optional[Any]) -> Configuration:
         show_progress_bar=show_progress_bar,
         allow_self_lockout=allow_self_lockout,
         datadog_host_override=datadog_host_override,
+        alter_flex_logs_retention_days=alter_flex_logs_retention_days,
         emit_json=emit_json,
         command=cmd.value,
         allow_partial_permissions_roles=allow_partial_permissions_roles,

--- a/tests/unit/test_logs_indexes_flex_retention.py
+++ b/tests/unit/test_logs_indexes_flex_retention.py
@@ -27,21 +27,25 @@ def test_cli_accepts_alter_flex_logs_retention_days(command, module_name, expect
     command_module = importlib.import_module(module_name)
 
     with patch.object(command_module, "run_cmd") as mock_run_cmd:
-        result = runner.invoke(cli, [command, "--alter-flex-logs-retention-days=90"])
+        result = runner.invoke(cli, [command, "--alter-flex-logs-retention-days=30"])
 
     assert result.exit_code == 0, result.output
     mock_run_cmd.assert_called_once()
     called_command, kwargs = mock_run_cmd.call_args.args[0], mock_run_cmd.call_args.kwargs
     assert called_command == expected_command
-    assert kwargs["alter_flex_logs_retention_days"] == 90
+    assert kwargs["alter_flex_logs_retention_days"] == 30
 
 
-def test_cli_rejects_non_integer_flex_logs_retention_days():
+@pytest.mark.parametrize("value", ["invalid", "-1", "0", "29"])
+def test_cli_rejects_invalid_flex_logs_retention_days(value):
     runner = CliRunner(mix_stderr=False)
     sync_module = importlib.import_module("datadog_sync.commands.sync")
 
     with patch.object(sync_module, "run_cmd") as mock_run_cmd:
-        result = runner.invoke(cli, ["sync", "--alter-flex-logs-retention-days=invalid"])
+        result = runner.invoke(
+            cli,
+            ["sync", f"--alter-flex-logs-retention-days={value}"],
+        )
 
     assert result.exit_code != 0
     mock_run_cmd.assert_not_called()

--- a/tests/unit/test_logs_indexes_flex_retention.py
+++ b/tests/unit/test_logs_indexes_flex_retention.py
@@ -1,0 +1,74 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+import asyncio
+import importlib
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from datadog_sync.cli import cli
+from datadog_sync.constants import Command
+from datadog_sync.model.logs_indexes import LogsIndexes
+
+
+@pytest.mark.parametrize(
+    "command,module_name,expected_command",
+    [
+        ("sync", "datadog_sync.commands.sync", Command.SYNC),
+        ("migrate", "datadog_sync.commands.migrate", Command.MIGRATE),
+    ],
+)
+def test_cli_accepts_alter_flex_logs_retention_days(command, module_name, expected_command):
+    runner = CliRunner(mix_stderr=False)
+    command_module = importlib.import_module(module_name)
+
+    with patch.object(command_module, "run_cmd") as mock_run_cmd:
+        result = runner.invoke(cli, [command, "--alter-flex-logs-retention-days=90"])
+
+    assert result.exit_code == 0, result.output
+    mock_run_cmd.assert_called_once()
+    called_command, kwargs = mock_run_cmd.call_args.args[0], mock_run_cmd.call_args.kwargs
+    assert called_command == expected_command
+    assert kwargs["alter_flex_logs_retention_days"] == 90
+
+
+def test_cli_rejects_non_integer_flex_logs_retention_days():
+    runner = CliRunner(mix_stderr=False)
+    sync_module = importlib.import_module("datadog_sync.commands.sync")
+
+    with patch.object(sync_module, "run_cmd") as mock_run_cmd:
+        result = runner.invoke(cli, ["sync", "--alter-flex-logs-retention-days=invalid"])
+
+    assert result.exit_code != 0
+    mock_run_cmd.assert_not_called()
+
+
+def test_alter_flex_logs_retention_days_overrides_existing_field(mock_config):
+    mock_config.alter_flex_logs_retention_days = 90
+    resource = {"name": "index-test", "num_flex_logs_retention_days": 30}
+
+    asyncio.run(LogsIndexes(mock_config).pre_resource_action_hook("index-test", resource))
+
+    assert resource["num_flex_logs_retention_days"] == 90
+
+
+def test_alter_flex_logs_retention_days_does_not_add_missing_field(mock_config):
+    mock_config.alter_flex_logs_retention_days = 90
+    resource = {"name": "index-test"}
+
+    asyncio.run(LogsIndexes(mock_config).pre_resource_action_hook("index-test", resource))
+
+    assert "num_flex_logs_retention_days" not in resource
+
+
+def test_unset_alter_flex_logs_retention_days_preserves_existing_field(mock_config):
+    mock_config.alter_flex_logs_retention_days = None
+    resource = {"name": "index-test", "num_flex_logs_retention_days": 30}
+
+    asyncio.run(LogsIndexes(mock_config).pre_resource_action_hook("index-test", resource))
+
+    assert resource["num_flex_logs_retention_days"] == 30


### PR DESCRIPTION
## Summary
- add `--alter-flex-logs-retention-days` to the `sync` and `migrate` commands
- override `num_flex_logs_retention_days` only when that field exists on a logs index
- preserve existing behavior when the option is unset or the field is absent

## Testing
- TDD red: 3 expected failures and 3 passing guard tests before implementation
- focused tox on Python 3.9 and 3.11: 6 passed per environment
- full unit tox: Python 3.11 and 3.13 passed (1116 passed, 8 skipped each); Python 3.9/3.10 retain 6 pre-existing CLI mock failures reproduced on `origin/main`; Python 3.12 interpreter unavailable
- Ruff passed
- Black passed for the new option, model, and test files; `configuration.py` has a pre-existing formatting mismatch reproduced on `origin/main`
