### PR TITLE
ci: disable cloud metadata queries in integration tests

### DIFF
--- a/.github/workflows/test_integrations.yml
+++ b/.github/workflows/test_integrations.yml
@@ -46,6 +46,7 @@ jobs:
           - 8126:8126
         env:
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          DD_CLOUD_PROVIDER_METADATA: "[]"
           DD_HOSTNAME: "none"
           DD_INSIDE_CI: "true"
     steps:


### PR DESCRIPTION
## Summary

- Disable cloud-provider metadata endpoint queries in the integration-test Agent.
- Leave the trace endpoint used by the tests unchanged.

## What this prevents

During service-container teardown, the Agent currently prints a UUID-shaped Azure cloud account identifier twice in the public workflow log. Based on the GitHub-hosted runner environment and the Agent message, this is the Azure subscription/account ID for the runner infrastructure, not a Datadog customer identifier.

The identifier is not a credential, token, or secret and does not grant access by itself, so the direct security severity is low. It is nevertheless a real production-infrastructure identifier that the integration tests do not need to discover or publish.

GitHub publishes service-container output during job teardown. Configuring the Agent with an empty cloud-provider metadata list prevents the metadata endpoint query that produces this output; the tests only require the Agent trace endpoint.

## Validation

- `git diff --check`
- No test changes; this is an Agent service configuration change.