### PR TITLE
Skip read-only integration pipelines instead of failing

### DIFF
--- a/datadog_sync/model/logs_pipelines.py
+++ b/datadog_sync/model/logs_pipelines.py
@@ -104,7 +104,12 @@ class LogsPipelines(BaseResource):
             # Extract the source from the query
             source = self.extract_source_from_query(resource.get("filter", {}).get("query"))
             if not source:
-                raise Exception(f"Source not found in the query for integration pipeline '{resource['name']}'")
+                raise SkipResource(
+                    _id,
+                    self.resource_type,
+                    f"Source not found in the query for integration pipeline '{resource['name']}'. "
+                    "Integration pipelines are auto-managed by Datadog and cannot be created via the public API.",
+                )
             payload = {
                 "ddsource": source,
                 "ddtags": ",".join(DEFAULT_TAGS),
@@ -134,9 +139,20 @@ class LogsPipelines(BaseResource):
                     await sleep(5)
 
             if not created:
-                raise Exception(
-                    f"Integration pipeline '{resource['name']}' is not created after x seconds. "
-                    "It will be rechecked in the next sync."
+                # Integration pipelines are auto-managed by Datadog and cannot be
+                # created via the public API.  The logs-intake trigger above is a
+                # best-effort attempt to prompt the destination org's integration
+                # system to provision the pipeline; when it does not appear within
+                # the polling window the pipeline is almost certainly one that the
+                # destination org will never have (e.g. an integration that is not
+                # enabled there).  Skip instead of failing so the run does not
+                # report 66 persistent failures every cycle.
+                raise SkipResource(
+                    _id,
+                    self.resource_type,
+                    f"Integration pipeline '{resource['name']}' could not be triggered at the destination "
+                    "after polling timeout. Integration pipelines are auto-managed by Datadog and may "
+                    "not be available at the destination org.",
                 )
 
         self.config.state.destination[self.resource_type][_id] = self.destination_integration_pipelines[


### PR DESCRIPTION
## Problem

Integration pipelines (`is_read_only: true`) are auto-managed by Datadog and cannot be created or modified via the public API. The `create_resource` method attempts to trigger creation via the logs intake API, but when that fails it raises a bare `Exception`, causing **66 persistent failures on every sync run** for orgs like Allstate that have many integration pipelines not present at the destination.

The `update_resource` method already correctly raises `SkipResource` for read-only pipelines, but `create_resource` was inconsistent — it raised `Exception` in two failure paths, which crashes the sync-cli subprocess (`exit status 1`) and causes the managed-sync wrapper to report all affected pipelines as failed.

## Evidence

From the Allstate (org `1245efdc`) managed-sync run completed 2026-08-25 (trace `3393806310996596045`):

- **66/212** pipelines fail every run with `http_4xx_404`
- All 66 are `is_read_only: true` — built-in integration pipelines (e.g. "aws vpc flow logs", "android logs", "ios logs", "java", "apache", "python")
- The 146 succeeding pipelines are all `is_read_only: false` (customer-created)
- The same 66 IDs have failed across multiple runs spanning weeks — this is not transient
- `logs_pipelines_order` is also stuck at 0/1 (1 skipped) because the order sync can never complete while read-only pipelines are missing at the destination

## Fix

Replace both `raise Exception(...)` calls in `create_resource` with `raise SkipResource(...)`:

1. **Source extraction failure** — when a read-only pipeline's filter query doesn't contain a parseable source, skip instead of failing
2. **Polling timeout** — when the logs-intake trigger doesn't create the pipeline within the 60-second polling window, skip instead of failing

Both use the same `SkipResource` exception that `update_resource` already uses for read-only pipelines (line ~190). The trigger-and-poll attempt is preserved (it may succeed for some integration pipelines), but when it doesn't, we skip instead of crashing the batch.

## Impact

- **Before**: 66 read-only pipelines → `Exception` → batch fails → counted as **failed** every run
- **After**: 66 read-only pipelines → `SkipResource` → counted as **skipped** (consistent with `update_resource`)
- `logs_pipelines` success rate goes from 68.9% (146/212) to 100% (146/146 attempted, 66 skipped)
- `logs_pipelines_order` may also start succeeding since the order resource will no longer be blocked by failed pipeline entries