### PR TITLE
fix(notebooks): sanitize 400-rejecting time/sort payloads without mutating state

### DIFF
--- a/datadog_sync/model/notebooks.py
+++ b/datadog_sync/model/notebooks.py
@@ -4,7 +4,9 @@
 # Copyright 2019 Datadog, Inc.
 
 from __future__ import annotations
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Optional, List, Dict, Tuple, cast
+from copy import deepcopy
 
 from datadog_sync.utils.base_resource import BaseResource, ResourceConfig
 from datadog_sync.utils.custom_client import PaginationConfig
@@ -118,19 +120,21 @@ class Notebooks(BaseResource):
 
     async def create_resource(self, _id: str, resource: Dict) -> Tuple[str, Dict]:
         destination_client = self.config.destination_client
-        payload = {"data": resource}
+        payload = {"data": self._sanitize_for_api(resource)}
         resp = await destination_client.post(self.resource_config.base_path, payload)
+        self._restore_state_attrs(resp["data"], resource)
         self.handle_special_case_attr(resp["data"])
 
         return _id, resp["data"]
 
     async def update_resource(self, _id: str, resource: Dict) -> Tuple[str, Dict]:
         destination_client = self.config.destination_client
-        payload = {"data": resource}
+        payload = {"data": self._sanitize_for_api(resource)}
         resp = await destination_client.put(
             self.resource_config.base_path + f"/{self.config.state.destination[self.resource_type][_id]['id']}",
             payload,
         )
+        self._restore_state_attrs(resp["data"], resource)
         self.handle_special_case_attr(resp["data"])
 
         return _id, resp["data"]
@@ -156,3 +160,119 @@ class Notebooks(BaseResource):
         tags = resource["attributes"].get("tags")
         if tags:
             resource["attributes"]["tags"] = [t for t in tags if t.split(":")[0] not in Notebooks._ai_usage_tag_keys]
+
+    # ------------------------------------------------------------------
+    # API-payload sanitization + state restoration
+    # ------------------------------------------------------------------
+    # Two constructs in real source notebooks are rejected by the destination
+    # Notebooks API with 400 Bad Request, so the resource can never be synced:
+    #
+    #   1. `attributes.time` with start == end
+    #      -> {"errors":["API input validation failed: {'time': {'_schema':
+    #          ['Start time ... must be less than end time ...']}}"]}
+    #   2. a `sort` object inside a cell's `transformations` list carrying an
+    #      extra `"type":"sort"` key
+    #      -> {"errors":["API input validation failed: {'cells': {N: {'errors':
+    #          [{'detail': "$.query.query.transformations[0].sort: Additional
+    #          properties are not allowed ('type' was unexpected)"...}]}}}"]}
+    #
+    # The fix sends an API-safe *copy* to the destination (nudge start back
+    # one second; drop the offending `type` key) but leaves the resource
+    # stored in state untouched. Because the API stores the sanitized values,
+    # the raw response would differ from the source on exactly these fields
+    # and re-diff every run; `_restore_state_attrs` copies the original
+    # source values back onto the response before it is written to
+    # destination state, so source and destination state compare equal and
+    # the resource does not update every run.
+
+    @staticmethod
+    def _subtract_one_second(iso_str: str) -> str:
+        # datetime.fromisoformat (3.7+) does not accept a trailing 'Z' until
+        # 3.11; normalize so we work on every supported interpreter.
+        normalized = iso_str.replace("Z", "+00:00") if iso_str.endswith("Z") else iso_str
+        return (datetime.fromisoformat(normalized) - timedelta(seconds=1)).isoformat()
+
+    @staticmethod
+    def _sanitize_for_api(resource: Dict) -> Dict:
+        """Return a deep-copied, API-safe copy of `resource` for POST/PUT.
+
+        Mutates only the copy; the caller's `resource` (used for state and
+        diffing) is left byte-for-byte unchanged.
+        """
+        payload = deepcopy(resource)
+        attrs = payload.get("attributes", {})
+
+        # 1. time window: nudge start back one second when start == end so the
+        #    API's `start < end` validation passes.
+        time = attrs.get("time")
+        if isinstance(time, dict) and time.get("start") and time.get("end") and time["start"] == time["end"]:
+            time["start"] = Notebooks._subtract_one_second(time["start"])
+
+        # 2. strip the rejected `"type":"sort"` key from `sort` objects
+        #    anywhere in the cells tree (the API rejects it as an additional
+        #    property on transformation sort objects).
+        Notebooks._strip_sort_type(attrs.get("cells"))
+
+        return payload
+
+    @staticmethod
+    def _strip_sort_type(node) -> None:
+        """Recursively remove `type` from `sort` dicts whose value is "sort".
+
+        Only transformation sort objects carry `"type":"sort"`; other sort
+        shapes (e.g. `{"count": N, "order_by": [...]}`) do not, so this
+        is a no-op on them.
+        """
+        if isinstance(node, dict):
+            sort = node.get("sort")
+            if isinstance(sort, dict) and sort.get("type") == "sort":
+                sort.pop("type", None)
+            for value in node.values():
+                Notebooks._strip_sort_type(value)
+        elif isinstance(node, list):
+            for item in node:
+                Notebooks._strip_sort_type(item)
+
+    @staticmethod
+    def _restore_state_attrs(dest: Dict, source: Dict) -> None:
+        """Copy the sanitized fields back from `source` onto the API response
+        `dest` so destination state compares equal to source state.
+
+        The destination API stores the sanitized payload (start nudged, sort
+        `type` dropped) and returns those values; without restoration the
+        destination would diff from the source every run and trigger a
+        perpetual update. We restore exactly the fields we sanitized:
+        `attributes.time` and the `type` key on `sort` objects.
+        """
+        dest_attrs = dest.get("attributes", {})
+        source_attrs = source.get("attributes", {})
+
+        if "time" in source_attrs:
+            dest_attrs["time"] = deepcopy(source_attrs["time"])
+
+        Notebooks._restore_sort_type(source_attrs.get("cells"), dest_attrs.get("cells"))
+
+    @staticmethod
+    def _restore_sort_type(src, dst) -> None:
+        """Walk `src` and `dst` in parallel; where `src` has a `sort` dict
+        carrying a `type` key, stamp that `type` onto the parallel `sort`
+        dict in `dst`.
+
+        The API strips `type` from sort on read, so without this the
+        destination sort would be missing `type` and diff from source. The
+        walk assumes structural parity between source and the API response
+        (same keys / list lengths), which holds because the response echoes
+        the payload we sent.
+        """
+        if isinstance(src, dict) and isinstance(dst, dict):
+            src_sort = src.get("sort")
+            if isinstance(src_sort, dict) and "type" in src_sort:
+                dst_sort = dst.get("sort")
+                if isinstance(dst_sort, dict):
+                    dst_sort["type"] = src_sort["type"]
+            for key, src_value in src.items():
+                if key in dst:
+                    Notebooks._restore_sort_type(src_value, dst[key])
+        elif isinstance(src, list) and isinstance(dst, list):
+            for src_item, dst_item in zip(src, dst):
+                Notebooks._restore_sort_type(src_item, dst_item)

--- a/tests/unit/test_notebooks_api_sanitization.py
+++ b/tests/unit/test_notebooks_api_sanitization.py
@@ -1,0 +1,314 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+"""Tests for the Notebooks API-payload sanitization + state restoration.
+
+Pins the contract for the two 400 Bad Request constructs the destination
+Notebooks API rejects and that sync-cli must paper over without mutating the
+resource stored in state (so source and destination state compare equal and
+the resource does not update every run):
+
+1. ``attributes.time`` with ``start == end`` -> the API requires
+   ``start < end``. We nudge ``start`` back one second on the *copy* sent to
+   the API, then restore the original ``time`` onto the response stored in
+   destination state.
+2. a ``sort`` object inside a cell's ``transformations`` list carrying an
+   extra ``"type": "sort"`` key -> the API rejects it as an additional
+   property. We strip ``type`` from the copy sent to the API, then stamp it
+   back onto the response stored in destination state.
+
+The invariant under test: after ``create_resource`` / ``update_resource``
+the dict returned for destination state is equal to the source ``resource``
+on every diffed field (``id`` is excluded from diff, so the destination id
+may differ), while the payload actually sent to the API carried the
+sanitized values.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+from copy import deepcopy
+
+import pytest
+
+from datadog_sync.model.notebooks import Notebooks
+
+
+@pytest.fixture
+def notebooks():
+    mock_config = MagicMock()
+    mock_config.state = MagicMock()
+    mock_config.destination_client = AsyncMock()
+    return Notebooks(mock_config)
+
+
+def _nb(notebook_id, *, time=None, cells=None):
+    return {
+        "id": notebook_id,
+        "type": "notebooks",
+        "attributes": {
+            "name": "N",
+            "cells": cells if cells is not None else [],
+            "time": time if time is not None else {"live_span": "1h"},
+            "schema_version": 1,
+        },
+    }
+
+
+def _analysis_cell_with_sort_type():
+    """A cell whose transformation sort carries the rejected ``type`` key.
+
+    Synthetic shape mirroring the API contract that triggers the 400:
+    ``definition.query.query.transformations[0].sort = {"type": "sort", ...}``.
+    All identifiers are obviously synthetic.
+    """
+    return {
+        "type": "notebook_cells",
+        "id": "cell-src-a",
+        "attributes": {
+            "definition": {
+                "type": "analysis_transformation",
+                "query": {
+                    "name": "transformation_0",
+                    "query": {
+                        "type": "structured_analysis",
+                        "source_dataset": "datasource_test",
+                        "transformations": [
+                            {
+                                "type": "aggregation",
+                                "sort": {"type": "sort", "order": "desc", "column": "col_count"},
+                                "compute": [{"column": "", "aggregation": "count"}],
+                                "group_by": [{"column": "col_entity"}],
+                            },
+                            {"type": "limit", "limit": 1000000},
+                        ],
+                    },
+                },
+                "data_source": "analysis_dataset",
+            }
+        },
+    }
+
+
+def _query_table_cell_with_order_by_sort():
+    """A query_table cell whose ``sort`` uses ``order_by`` (no ``type`` key).
+
+    This sort shape must NOT be touched by the sanitizer: only transformation
+    sort objects carry ``"type": "sort"``.
+    """
+    return {
+        "type": "notebook_cells",
+        "id": "cell-src-b",
+        "attributes": {
+            "definition": {
+                "type": "query_table",
+                "title": "test-query-table",
+                "requests": [
+                    {
+                        "sort": {"count": 500, "order_by": [{"type": "formula", "index": 0, "order": "desc"}]},
+                        "queries": [
+                            {"name": "query1", "query": "max:foo", "aggregator": "max", "data_source": "metrics"}
+                        ],
+                        "formulas": [{"formula": "query1", "cell_display_mode": "bar"}],
+                        "response_format": "scalar",
+                    }
+                ],
+                "has_search_bar": False,
+            }
+        },
+    }
+
+
+# -- _sanitize_for_api: source is never mutated -------------------------------
+
+
+def test_sanitize_does_not_mutate_source_time(notebooks):
+    source = _nb(1, time={"start": "2025-01-01T00:00:00+00:00", "end": "2025-01-01T00:00:00+00:00"})
+    original = {k: v for k, v in source["attributes"]["time"].items()}
+
+    notebooks._sanitize_for_api(source)
+
+    assert source["attributes"]["time"] == original, "source resource must be left unchanged"
+
+
+def test_sanitize_does_not_mutate_source_sort_type(notebooks):
+    cell = _analysis_cell_with_sort_type()
+    source = _nb(1, cells=[cell])
+    original_sort = {
+        k: v for k, v in cell["attributes"]["definition"]["query"]["query"]["transformations"][0]["sort"].items()
+    }
+
+    notebooks._sanitize_for_api(source)
+
+    assert (
+        cell["attributes"]["definition"]["query"]["query"]["transformations"][0]["sort"] == original_sort
+    ), "source sort must be left unchanged"
+
+
+# -- _sanitize_for_api: time window ------------------------------------------
+
+
+def test_sanitize_nudges_start_back_one_second_when_start_equals_end(notebooks):
+    source = _nb(1, time={"start": "2025-01-01T00:00:00+00:00", "end": "2025-01-01T00:00:00+00:00"})
+
+    payload = notebooks._sanitize_for_api(source)
+
+    assert payload["attributes"]["time"]["start"] == "2024-12-31T23:59:59+00:00"
+    assert payload["attributes"]["time"]["end"] == "2025-01-01T00:00:00+00:00"
+
+
+def test_sanitize_handles_z_suffix_timezone(notebooks):
+    source = _nb(1, time={"start": "2025-01-01T00:00:00Z", "end": "2025-01-01T00:00:00Z"})
+
+    payload = notebooks._sanitize_for_api(source)
+
+    assert payload["attributes"]["time"]["start"] == "2024-12-31T23:59:59+00:00"
+
+
+def test_sanitize_leaves_time_alone_when_start_lt_end(notebooks):
+    source = _nb(1, time={"start": "2024-12-31T23:59:59+00:00", "end": "2025-01-01T00:00:00+00:00"})
+
+    payload = notebooks._sanitize_for_api(source)
+
+    assert payload["attributes"]["time"]["start"] == "2024-12-31T23:59:59+00:00"
+
+
+def test_sanitize_leaves_time_alone_when_only_live_span(notebooks):
+    source = _nb(1, time={"live_span": "1h"})
+
+    payload = notebooks._sanitize_for_api(source)
+
+    assert payload["attributes"]["time"] == {"live_span": "1h"}
+
+
+# -- _sanitize_for_api: sort type --------------------------------------------
+
+
+def test_sanitize_strips_type_from_transformation_sort(notebooks):
+    source = _nb(1, cells=[_analysis_cell_with_sort_type()])
+
+    payload = notebooks._sanitize_for_api(source)
+
+    sort = payload["attributes"]["cells"][0]["attributes"]["definition"]["query"]["query"]["transformations"][0]["sort"]
+    assert "type" not in sort, "sanitized payload must not carry the rejected type key"
+    assert sort == {"order": "desc", "column": "col_count"}
+
+
+def test_sanitize_does_not_touch_order_by_sort(notebooks):
+    """The query_table ``sort`` (order_by shape, no top-level ``type``) must be
+    passed through untouched — only transformation sorts carry ``type:sort``."""
+    source = _nb(1, cells=[_query_table_cell_with_order_by_sort()])
+    original = {
+        "count": 500,
+        "order_by": [{"type": "formula", "index": 0, "order": "desc"}],
+    }
+
+    payload = notebooks._sanitize_for_api(source)
+
+    assert (
+        payload["attributes"]["cells"][0]["attributes"]["definition"]["requests"][0]["sort"] == original
+    ), "order_by sort must be untouched"
+
+
+# -- create_resource / update_resource: payload sanitized, state restored -----
+
+
+def test_create_resource_sends_sanitized_payload_and_restores_state(notebooks):
+    """End-to-end contract for create:
+
+    - the POST payload carries the sanitized (API-safe) values, and
+    - the dict returned for destination state equals the source on every
+      diffed field (the API response's sanitized values are restored to the
+      source's originals), so the resource does not re-diff every run.
+    """
+    source = _nb(
+        1,
+        time={"start": "2025-01-01T00:00:00+00:00", "end": "2025-01-01T00:00:00+00:00"},
+        cells=[_analysis_cell_with_sort_type()],
+    )
+
+    # API echoes back the sanitized payload (start nudged, sort type stripped)
+    # plus a new destination id.
+    def _echo(path, payload):
+        echoed = deepcopy(payload["data"])
+        echoed["id"] = 4242
+        return {"data": echoed}
+
+    notebooks.config.destination_client.post = AsyncMock(side_effect=_echo)
+
+    _id, stored = asyncio.run(notebooks.create_resource("1", source))
+
+    sent = notebooks.config.destination_client.post.await_args.args[1]["data"]
+    assert sent["attributes"]["time"]["start"] == "2024-12-31T23:59:59+00:00", "API payload must be sanitized"
+    sent_sort = sent["attributes"]["cells"][0]["attributes"]["definition"]["query"]["query"]["transformations"][0][
+        "sort"
+    ]
+    assert "type" not in sent_sort, "API payload sort must have type stripped"
+
+    # Destination state is restored to match source on the sanitized fields.
+    assert (
+        stored["attributes"]["time"] == source["attributes"]["time"]
+    ), "destination state time must be restored to the source's original (start==end)"
+    assert (
+        stored["attributes"]["cells"][0]["attributes"]["definition"]["query"]["query"]["transformations"][0]["sort"]
+        == source["attributes"]["cells"][0]["attributes"]["definition"]["query"]["query"]["transformations"][0]["sort"]
+    ), "destination state sort must be restored to the source's original (type present)"
+    # The destination id from the response is preserved (needed for updates).
+    assert stored["id"] == 4242
+
+
+def test_update_resource_sends_sanitized_payload_and_restores_state(notebooks):
+    """Same contract as create, but for the PUT path (uses destination id)."""
+    source = _nb(
+        1,
+        time={"start": "2025-01-01T00:00:00+00:00", "end": "2025-01-01T00:00:00+00:00"},
+        cells=[_analysis_cell_with_sort_type()],
+    )
+    notebooks.config.state.destination = {"notebooks": {"1": {"id": 99}}}
+
+    def _echo(path, payload):
+        echoed = deepcopy(payload["data"])
+        echoed["id"] = 99
+        return {"data": echoed}
+
+    notebooks.config.destination_client.put = AsyncMock(side_effect=_echo)
+
+    _id, stored = asyncio.run(notebooks.update_resource("1", source))
+
+    # PUT targeted the destination id, not the source id.
+    assert notebooks.config.destination_client.put.await_args.args[0] == "/api/v1/notebooks/99"
+    sent = notebooks.config.destination_client.put.await_args.args[1]["data"]
+    assert sent["attributes"]["time"]["start"] == "2024-12-31T23:59:59+00:00"
+    sent_sort = sent["attributes"]["cells"][0]["attributes"]["definition"]["query"]["query"]["transformations"][0][
+        "sort"
+    ]
+    assert "type" not in sent_sort
+
+    assert stored["attributes"]["time"] == source["attributes"]["time"]
+    assert (
+        stored["attributes"]["cells"][0]["attributes"]["definition"]["query"]["query"]["transformations"][0]["sort"][
+            "type"
+        ]
+        == "sort"
+    ), "restored destination state must carry the original sort type"
+
+
+def test_create_resource_noop_when_no_sanitization_needed(notebooks):
+    """A notebook that needs no sanitization round-trips unchanged (modulo id)."""
+    source = _nb(1, time={"live_span": "1h"}, cells=[_query_table_cell_with_order_by_sort()])
+
+    def _echo(path, payload):
+        echoed = deepcopy(payload["data"])
+        echoed["id"] = 77
+        return {"data": echoed}
+
+    notebooks.config.destination_client.post = AsyncMock(side_effect=_echo)
+
+    _id, stored = asyncio.run(notebooks.create_resource("1", source))
+
+    assert stored["attributes"]["time"] == {"live_span": "1h"}
+    assert (
+        stored["attributes"]["cells"][0]["attributes"]["definition"]["requests"][0]["sort"]
+        == source["attributes"]["cells"][0]["attributes"]["definition"]["requests"][0]["sort"]
+    )


### PR DESCRIPTION
## Summary

Two constructs in real source notebooks are rejected by the destination Notebooks API with `400 Bad Request`, making the resource unsyncable:

1. **`attributes.time` with `start == end`** → `API input validation failed: {'time': {'_schema': ['Start time ... must be less than end time ...']}}`
2. **a `sort` object inside a cell's `transformations` list carrying an extra `"type":"sort"` key** → `API input validation failed: {'cells': {N: {'errors': [{'detail': "$.query.query.transformations[0].sort: Additional properties are not allowed ('type' was unexpected)"...}]}}}`

## Change

`create_resource` / `update_resource` now send an **API-safe deep copy** to the destination instead of the raw resource:

- nudge `time.start` back one second when `start == end` (so the API's `start < end` validation passes); handles `Z` suffix for pre-3.11 interpreters
- strip the rejected `"type":"sort"` key from `sort` objects anywhere in the cells tree (only transformation sorts carry `"type":"sort"`; `order_by`-style sorts are untouched)

The resource **stored in state is left byte-for-byte unchanged**. Because the API stores the sanitized values, the raw response would otherwise differ from the source on exactly these fields and re-diff every run; `_restore_state_attrs` copies the original source values (`time` and the `sort.type` key) back onto the API response before it is written to destination state, so **source and destination state compare equal and the resource does not update every run**.

## Why not normalize in `handle_special_case_attr`?

That would mutate the stored JSON for *both* source and destination, which would hide the original (invalid) source values from the operator and from any downstream consumer of the state file. The transform is intentionally applied only at the API boundary and reversed on the response, keeping the state file a faithful copy of the source.

## Testing

- New unit tests: `tests/unit/test_notebooks_api_sanitization.py` (11 tests) pin:
  - the source resource is never mutated by `_sanitize_for_api`
  - `start` is nudged back 1s only when `start == end` (and not when `start < end` or only `live_span` is set)
  - `Z` suffix normalization
  - `type` is stripped from transformation `sort` but `order_by` sorts are untouched
  - `create_resource` / `update_resource` send the sanitized payload **and** restore the original values onto the returned destination state (so it equals the source on every diffed field), while preserving the destination id
- All fixtures use obviously synthetic identifiers (`cell-src-a`, `col_count`, `2025-01-01T00:00:00Z`).
- Full unit suite: **1213 passed**.
- `ruff --line-length 120` and `black --line-length 120` clean on changed files.

## Notes

- This is read-only w.r.t. the source notebook definitions; it does not "fix" the notebooks in the source org, it only makes them syncable.
- The `sync-cli: missing connections: Failed to connect resource` errors sometimes seen on the same runs are a separate issue (different notebooks, still counted as succeeded) and are out of scope here.
