### PR TITLE
Fix metric metadata bootstrap and sync edge cases

### DIFF
--- a/datadog_sync/model/dashboard_lists.py
+++ b/datadog_sync/model/dashboard_lists.py
@@ -101,7 +101,18 @@ class DashboardLists(BaseResource):
         )
 
     def connect_id(self, key: str, r_obj: Dict, resource_to_connect: str) -> Optional[List[str]]:
+        if resource_to_connect == "dashboards" and self._is_integration_dashboard(r_obj):
+            return None
         return super(DashboardLists, self).connect_id(key, r_obj, resource_to_connect)
+
+    def extract_source_ids(self, key: str, r_obj: Dict, resource_to_connect: str) -> Optional[List[str]]:
+        if resource_to_connect == "dashboards" and self._is_integration_dashboard(r_obj):
+            return None
+        return super().extract_source_ids(key, r_obj, resource_to_connect)
+
+    @staticmethod
+    def _is_integration_dashboard(r_obj: Dict) -> bool:
+        return str(r_obj.get("type", "")).startswith("integration_")
 
     async def update_dash_list_items(self, _id: str, dashboards: Dict, dashboard_list: dict):
         payload = {"dashboards": dashboards}

--- a/datadog_sync/model/dashboards.py
+++ b/datadog_sync/model/dashboards.py
@@ -183,20 +183,33 @@ class Dashboards(BaseResource):
         """Drop-aware override.
 
         Widget connections (monitor alert_ids, powerpacks, slos) keep the generic
-        find_attr/connect_id path. The flat `restricted_roles` list goes through the shared
-        drop-aware filter so a permanently-stale role can be dropped (under
-        --drop-unresolvable-principals) while an emptied list still hard-fails as an
-        access-elevation guard.
+        find_attr/connect_id path, but classify source-absent misses as stale
+        dependencies so dashboards with deleted SLO/monitor/powerpack widgets
+        are skipped deterministically instead of retrying forever. The flat
+        `restricted_roles` list goes through the shared drop-aware filter so a
+        permanently-stale role can be dropped (under --drop-unresolvable-principals)
+        while an emptied list still hard-fails as an access-elevation guard.
         """
         if not self.resource_config.resource_connections:
             return ResourceConnectionResult()
 
         failed_connections_dict = defaultdict(list)
+        stale_connections_dict = defaultdict(list)
         for resource_to_connect, attrs in self.resource_config.resource_connections.items():
             for attr_connection in attrs:
                 if attr_connection == "restricted_roles":
                     continue  # handled by the drop-aware filter below
-                c = find_attr(attr_connection, resource_to_connect, resource, self.connect_id)
+                c = find_attr(
+                    attr_connection,
+                    resource_to_connect,
+                    resource,
+                    lambda key, r_obj, rtc: self._connect_id_or_classify_stale(
+                        key,
+                        r_obj,
+                        rtc,
+                        stale_connections_dict,
+                    ),
+                )
                 if c:
                     failed_connections_dict[resource_to_connect].extend(c)
 
@@ -204,11 +217,14 @@ class Dashboards(BaseResource):
         if role_failed:
             failed_connections_dict["roles"].extend(role_failed)
 
-        return ResourceConnectionResult(
-            empty_binding_escalation=self._raise_connection_error_if_any(
-                _id, failed_connections_dict, roles_risk
-            )
+        empty_binding_escalation = self._raise_connection_error_if_any(
+            _id,
+            failed_connections_dict,
+            roles_risk,
         )
+        self._raise_stale_dependency_skip(_id, stale_connections_dict)
+
+        return ResourceConnectionResult(empty_binding_escalation=empty_binding_escalation)
 
     def connect_id(self, key: str, r_obj: Dict, resource_to_connect: str) -> Optional[List[str]]:
         return super(Dashboards, self).connect_id(key, r_obj, resource_to_connect)

--- a/datadog_sync/model/downtime_schedules.py
+++ b/datadog_sync/model/downtime_schedules.py
@@ -289,6 +289,32 @@ class DowntimeSchedules(BaseResource):
         return None
 
     @classmethod
+    def _one_time_window(cls, schedule: Dict) -> Optional[_ActiveWindow]:
+        """Return the fixed schedule window for non-recurring downtimes."""
+        if (
+            not isinstance(schedule, dict)
+            or "recurrences" in schedule
+            or not schedule.get("start")
+        ):
+            return None
+
+        start = cls._parse_utc(schedule["start"])
+        end = cls._parse_utc(schedule["end"]) if schedule.get("end") else None
+        return _ActiveWindow(start=start, end=end)
+
+    @staticmethod
+    def _window_active(window: Optional[_ActiveWindow], now: datetime) -> bool:
+        return (
+            window is not None
+            and window.start <= now
+            and (window.end is None or now < window.end)
+        )
+
+    @staticmethod
+    def _window_ended(window: Optional[_ActiveWindow], now: datetime) -> bool:
+        return window is not None and window.end is not None and window.end <= now
+
+    @classmethod
     def _analyze_recurrence_schedule(
         cls,
         schedule: Dict,
@@ -497,6 +523,64 @@ class DowntimeSchedules(BaseResource):
             create_schedule=create_schedule,
         )
 
+    def _prepare_update_one_time_schedule(
+        self,
+        _id: str,
+        source_schedule: Dict,
+        destination_schedule: Dict,
+        now: datetime,
+    ) -> None:
+        """Prepare a PATCH-safe one-time schedule.
+
+        The downtime API rejects changing the start time of an in-progress
+        one-time downtime, and rejects scheduling one-time windows in the past.
+        Preserve or replace the active destination instead of sending an
+        illegal PATCH.
+        """
+        source_window = self._one_time_window(source_schedule)
+        if source_window is None:
+            return
+
+        destination_window = self._one_time_window(destination_schedule)
+        create_schedule = deepcopy(source_schedule)
+        action = _RecurrenceUpdateAction.PATCH
+
+        if self._window_ended(source_window, now):
+            if self._window_active(destination_window, now):
+                self._prepared_recurrence_updates[str(_id)] = _PreparedRecurrenceUpdate(
+                    action=_RecurrenceUpdateAction.CANCEL,
+                    create_schedule=create_schedule,
+                )
+                return
+            raise SkipResource(
+                str(_id),
+                self.resource_type,
+                "Downtime end is in the past.",
+            )
+
+        if self._window_active(destination_window, now):
+            if source_window.start > now:
+                self._prepared_recurrence_updates[str(_id)] = (
+                    _PreparedRecurrenceUpdate(
+                        action=_RecurrenceUpdateAction.RECREATE,
+                        create_schedule=create_schedule,
+                    )
+                )
+                return
+            if source_window.start != destination_window.start:
+                source_schedule["start"] = destination_schedule["start"]
+                log.info(
+                    f"[downtime_schedules - {_id}] preserved active destination start "
+                    "for one-time downtime update"
+                )
+        elif source_window.start <= now:
+            source_schedule["start"] = self._iso_utc(now + timedelta(seconds=60))
+
+        self._prepared_recurrence_updates[str(_id)] = _PreparedRecurrenceUpdate(
+            action=action,
+            create_schedule=create_schedule,
+        )
+
     async def _normalize_recurrence_schedule(
         self,
         _id: str,
@@ -603,25 +687,13 @@ class DowntimeSchedules(BaseResource):
         if _id not in self.config.state.destination[self.resource_type]:
             await self._normalize_create_schedule(_id, resource)
         else:
-            # If start or end times of the resource are in the past, we set to the current destination `start` and `end`
-            # this is to avoid unnecessary diff outputs
             if resource["attributes"].get("schedule"):
                 source_schedule = resource["attributes"]["schedule"]
                 destination_schedule = self.config.state.destination[self.resource_type][_id]["attributes"].get(
                     "schedule", {}
                 )
-                if destination_schedule.get("start") and source_schedule.get("start"):
-                    start_source = parse(source_schedule["start"])
-                    start_created = parse(destination_schedule["start"])
-                    if start_source.timestamp() < start_created.timestamp():
-                        source_schedule["start"] = destination_schedule["start"]
-                if destination_schedule.get("end") and source_schedule.get("end"):
-                    end_source = parse(source_schedule["end"])
-                    end_created = parse(destination_schedule["end"])
-                    if end_source.timestamp() < end_created.timestamp():
-                        source_schedule["end"] = destination_schedule["end"]
+                now = datetime.now(timezone.utc)
                 if "recurrences" in source_schedule:
-                    now = datetime.now(timezone.utc)
                     await asyncio.to_thread(
                         self._prepare_update_recurrences,
                         _id,
@@ -629,6 +701,13 @@ class DowntimeSchedules(BaseResource):
                         destination_schedule,
                         now,
                         now + timedelta(seconds=60),
+                    )
+                else:
+                    self._prepare_update_one_time_schedule(
+                        _id,
+                        source_schedule,
+                        destination_schedule,
+                        now,
                     )
 
     async def pre_apply_hook(self) -> None:

--- a/datadog_sync/model/downtime_schedules.py
+++ b/datadog_sync/model/downtime_schedules.py
@@ -7,6 +7,7 @@ import asyncio
 import json
 import logging
 import re
+from collections import defaultdict
 from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum
@@ -19,12 +20,13 @@ from dateutil.rrule import rrulestr
 from dateutil.tz import datetime_exists, gettz
 
 from datadog_sync.constants import LOGGER_NAME
-from datadog_sync.utils.base_resource import BaseResource, ResourceConfig
+from datadog_sync.utils.base_resource import BaseResource, ResourceConfig, ResourceConnectionResult
 from datadog_sync.utils.custom_client import PaginationConfig
 from datadog_sync.utils.resource_utils import (
     CustomClientHTTPError,
     DowntimeSchedulesDateOperator,
     SkipResource,
+    find_attr,
 )
 
 if TYPE_CHECKING:
@@ -840,6 +842,68 @@ class DowntimeSchedules(BaseResource):
                 log.info(f"[downtime_schedules - {_id}] already deleted on destination")
                 return
             raise
+
+    def _connect_monitor_id_or_skip_stale(
+        self,
+        downtime_id: str,
+        key: str,
+        r_obj: Dict,
+        resource_to_connect: str,
+    ) -> Optional[List[str]]:
+        if resource_to_connect != "monitors":
+            return super(DowntimeSchedules, self).connect_id(key, r_obj, resource_to_connect)
+        if not r_obj.get(key):
+            return None
+
+        failed_connections = []
+        ids = r_obj[key] if isinstance(r_obj[key], list) else [r_obj[key]]
+        for idx, value in enumerate(ids):
+            source_monitor_id = str(value)
+            destination_monitors = self.config.state.destination[resource_to_connect]
+            if source_monitor_id not in destination_monitors:
+                self.config.state.ensure_resource_loaded(resource_to_connect, source_monitor_id)
+                destination_monitors = self.config.state.destination[resource_to_connect]
+
+            if source_monitor_id in destination_monitors:
+                resolved = type(value)(destination_monitors[source_monitor_id]["id"])
+                if isinstance(r_obj[key], list):
+                    r_obj[key][idx] = resolved
+                else:
+                    r_obj[key] = resolved
+            elif source_monitor_id in self.config.state.source[resource_to_connect]:
+                failed_connections.append(source_monitor_id)
+            else:
+                raise SkipResource(
+                    str(downtime_id),
+                    self.resource_type,
+                    f"Downtime references stale monitor {source_monitor_id}.",
+                )
+
+        return failed_connections
+
+    def connect_resources(self, _id: str, resource: Dict) -> ResourceConnectionResult:
+        if not self.resource_config.resource_connections:
+            return ResourceConnectionResult()
+
+        failed_connections_dict = defaultdict(list)
+        for resource_to_connect, attrs in self.resource_config.resource_connections.items():
+            for attr_connection in attrs:
+                c = find_attr(
+                    attr_connection,
+                    resource_to_connect,
+                    resource,
+                    lambda key, r_obj, rt: self._connect_monitor_id_or_skip_stale(
+                        _id,
+                        key,
+                        r_obj,
+                        rt,
+                    ),
+                )
+                if c:
+                    failed_connections_dict[resource_to_connect].extend(c)
+
+        self._raise_connection_error_if_any(_id, failed_connections_dict)
+        return ResourceConnectionResult()
 
     def connect_id(self, key: str, r_obj: Dict, resource_to_connect: str) -> Optional[List[str]]:
         return super(DowntimeSchedules, self).connect_id(key, r_obj, resource_to_connect)

--- a/datadog_sync/model/metric_tag_configurations.py
+++ b/datadog_sync/model/metric_tag_configurations.py
@@ -4,6 +4,7 @@
 # Copyright 2019 Datadog, Inc.
 
 from __future__ import annotations
+from copy import deepcopy
 from typing import TYPE_CHECKING, Optional, List, Dict, Tuple, cast
 
 from datadog_sync.utils.base_resource import BaseResource, ResourceConfig
@@ -27,6 +28,21 @@ def _is_missing_metric_error(error: CustomClientHTTPError) -> bool:
 
 def _is_existing_tag_config_conflict(error: CustomClientHTTPError) -> bool:
     return error.status_code == 409 and "patch" in _error_body(error)
+
+
+def _is_missing_metadata_type_error(error: CustomClientHTTPError) -> bool:
+    body = _error_body(error)
+    return error.status_code == 400 and "metadata type must be set prior to configuring tags" in body
+
+
+def _metric_type_from_tag_configuration(resource: Dict) -> Optional[str]:
+    metric_type = resource.get("attributes", {}).get("metric_type")
+    if not isinstance(metric_type, str):
+        return None
+    metric_type = metric_type.strip().lower()
+    if not metric_type or metric_type == "distribution":
+        return None
+    return metric_type
 
 
 class MetricTagConfigurations(BaseResource):
@@ -57,6 +73,14 @@ class MetricTagConfigurations(BaseResource):
     async def pre_apply_hook(self) -> None:
         pass
 
+    async def _set_destination_metric_metadata_type(self, _id: str, resource: Dict) -> bool:
+        metric_type = _metric_type_from_tag_configuration(resource)
+        if metric_type is None:
+            return False
+
+        await self.config.destination_client.put(f"/api/v1/metrics/{_id}", {"type": metric_type})
+        return True
+
     async def create_resource(self, _id: str, resource: Dict) -> Tuple[str, Dict]:
         if _id in self._existing_resources_map:
             self.config.state.destination[self.resource_type][_id] = self._existing_resources_map[_id]
@@ -77,6 +101,17 @@ class MetricTagConfigurations(BaseResource):
                     reason=FAILURE_CLASS_DESTINATION_METRIC_MISSING,
                     outcome_details={"metric_name": _id, "operation": "tag_configuration_create"},
                 )
+            if _is_missing_metadata_type_error(e) and await self._set_destination_metric_metadata_type(_id, resource):
+                try:
+                    resp = await destination_client.post(path, payload)
+                except CustomClientHTTPError as retry_e:
+                    if not _is_existing_tag_config_conflict(retry_e):
+                        raise
+
+                    existing = await destination_client.get(path)
+                    self.config.state.destination[self.resource_type][_id] = existing["data"]
+                    return await self.update_resource(_id, resource)
+                return _id, resp["data"]
             if not _is_existing_tag_config_conflict(e):
                 raise
 
@@ -88,15 +123,13 @@ class MetricTagConfigurations(BaseResource):
 
     async def update_resource(self, _id: str, resource: Dict) -> Tuple[str, Dict]:
         destination_client = self.config.destination_client
-        if "attributes" in resource:
-            resource["attributes"].pop("metric_type", None)
-        payload = {"data": resource}
+        update_resource = deepcopy(resource)
+        if "attributes" in update_resource:
+            update_resource["attributes"].pop("metric_type", None)
+        payload = {"data": update_resource}
+        path = self.resource_config.base_path + f"/{self.config.state.destination[self.resource_type][_id]['id']}/tags"
         try:
-            resp = await destination_client.patch(
-                self.resource_config.base_path
-                + f"/{self.config.state.destination[self.resource_type][_id]['id']}/tags",
-                payload,
-            )
+            resp = await destination_client.patch(path, payload)
         except CustomClientHTTPError as e:
             if _is_missing_metric_error(e):
                 raise SkipResource(
@@ -107,6 +140,9 @@ class MetricTagConfigurations(BaseResource):
                     reason=FAILURE_CLASS_DESTINATION_METRIC_MISSING,
                     outcome_details={"metric_name": _id, "operation": "tag_configuration_update"},
                 )
+            if _is_missing_metadata_type_error(e) and await self._set_destination_metric_metadata_type(_id, resource):
+                resp = await destination_client.patch(path, payload)
+                return _id, resp["data"]
             raise
 
         return _id, resp["data"]

--- a/datadog_sync/model/metrics_metadata.py
+++ b/datadog_sync/model/metrics_metadata.py
@@ -42,9 +42,29 @@ class MetricsMetadata(BaseResource):
 
         resource = await source_client.get(self.resource_config.base_path + f"/{metric_name}")
         if all(value is None for value in resource.values()):
+            minimal_metadata = await self._minimal_metadata_from_tag_configuration(metric_name)
+            if minimal_metadata is not None:
+                return metric_name, minimal_metadata
             raise SkipResource(metric_name, self.resource_type, "Metric has no metadata.")
 
         return metric_name, resource
+
+    async def _minimal_metadata_from_tag_configuration(self, metric_name: str) -> Optional[Dict]:
+        try:
+            tag_configuration = await self.config.source_client.get(self.metrics_get_path + f"/{metric_name}/tags")
+        except CustomClientHTTPError as e:
+            log.debug(f"[metrics_metadata - {metric_name}] tag configuration type fallback failed: {e}")
+            return None
+
+        metric_type = tag_configuration.get("data", {}).get("attributes", {}).get("metric_type")
+        if not isinstance(metric_type, str):
+            return None
+        metric_type = metric_type.strip().lower()
+        if not metric_type or metric_type == "distribution":
+            return None
+
+        log.debug(f"[metrics_metadata - {metric_name}] using metric tag configuration type as minimal source metadata")
+        return {"type": metric_type}
 
     async def pre_resource_action_hook(self, _id, resource: Dict) -> None:
         pass

--- a/datadog_sync/model/notebooks.py
+++ b/datadog_sync/model/notebooks.py
@@ -49,7 +49,9 @@ class Notebooks(BaseResource):
         page_size=100,
         page_size_param="count",
         page_number_param="start",
-        remaining_func=lambda idx, resp, page_size, page_number: (resp["meta"]["page"]["total_count"])
+        remaining_func=lambda idx, resp, page_size, page_number: (
+            resp["meta"]["page"]["total_count"]
+        )
         - (page_size * (idx + 1)),
         page_number_func=lambda idx, page_size, page_number: page_size * (idx + 1),
     )
@@ -67,7 +69,9 @@ class Notebooks(BaseResource):
 
         return resp
 
-    async def import_resource(self, _id: Optional[str] = None, resource: Optional[Dict] = None) -> Tuple[str, Dict]:
+    async def import_resource(
+        self, _id: Optional[str] = None, resource: Optional[Dict] = None
+    ) -> Tuple[str, Dict]:
         source_client = self.config.source_client
         import_id = _id if _id is not None else (resource or {}).get("id")
         if import_id is None:
@@ -81,13 +85,21 @@ class Notebooks(BaseResource):
         # time, doubling rate-limit pressure on id-file runs. Detection is by
         # cells presence — the lightweight LIST never has cells, so a
         # resource with attributes.cells came from a per-id GET.
-        if resource is not None and isinstance(resource.get("attributes"), dict) and "cells" in resource["attributes"]:
+        if (
+            resource is not None
+            and isinstance(resource.get("attributes"), dict)
+            and "cells" in resource["attributes"]
+        ):
             resource = cast(dict, resource)
             self.handle_special_case_attr(resource)
             return str(resource["id"]), resource
 
         try:
-            resource = (await source_client.get(self.resource_config.base_path + f"/{import_id}"))["data"]
+            resource = (
+                await source_client.get(
+                    self.resource_config.base_path + f"/{import_id}"
+                )
+            )["data"]
         except CustomClientHTTPError as err:
             # 403: notebook is in the LIST but restricted from per-id reads. Skip
             # rather than hard-fail so a single ACL'd notebook does not poison the
@@ -95,7 +107,9 @@ class Notebooks(BaseResource):
             # 404: notebook was deleted between LIST enumeration and the per-id GET.
             # Skip — there is nothing to import.
             if err.status_code == 403:
-                raise SkipResource(import_id, self.resource_type, "No access to restricted notebook")
+                raise SkipResource(
+                    import_id, self.resource_type, "No access to restricted notebook"
+                )
             if err.status_code == 404:
                 raise SkipResource(
                     import_id,
@@ -131,7 +145,8 @@ class Notebooks(BaseResource):
         destination_client = self.config.destination_client
         payload = {"data": self._sanitize_for_api(resource)}
         resp = await destination_client.put(
-            self.resource_config.base_path + f"/{self.config.state.destination[self.resource_type][_id]['id']}",
+            self.resource_config.base_path
+            + f"/{self.config.state.destination[self.resource_type][_id]['id']}",
             payload,
         )
         self._restore_state_attrs(resp["data"], resource)
@@ -142,7 +157,8 @@ class Notebooks(BaseResource):
     async def delete_resource(self, _id: str) -> None:
         destination_client = self.config.destination_client
         await destination_client.delete(
-            self.resource_config.base_path + f"/{self.config.state.destination[self.resource_type][_id]['id']}"
+            self.resource_config.base_path
+            + f"/{self.config.state.destination[self.resource_type][_id]['id']}"
         )
 
     # Server-managed AI usage tag keys injected by the Notebooks API on every write.
@@ -153,13 +169,20 @@ class Notebooks(BaseResource):
     @staticmethod
     def handle_special_case_attr(resource):
         # Handle template_variables attribute
-        if "template_variables" in resource["attributes"] and not resource["attributes"]["template_variables"]:
+        if (
+            "template_variables" in resource["attributes"]
+            and not resource["attributes"]["template_variables"]
+        ):
             resource["attributes"].pop("template_variables")
 
         # Strip server-managed AI usage tags
         tags = resource["attributes"].get("tags")
-        if tags:
-            resource["attributes"]["tags"] = [t for t in tags if t.split(":")[0] not in Notebooks._ai_usage_tag_keys]
+        if tags is None:
+            resource["attributes"]["tags"] = []
+        elif tags:
+            resource["attributes"]["tags"] = [
+                t for t in tags if t.split(":")[0] not in Notebooks._ai_usage_tag_keys
+            ]
 
     # ------------------------------------------------------------------
     # API-payload sanitization + state restoration
@@ -189,7 +212,9 @@ class Notebooks(BaseResource):
     def _subtract_one_second(iso_str: str) -> str:
         # datetime.fromisoformat (3.7+) does not accept a trailing 'Z' until
         # 3.11; normalize so we work on every supported interpreter.
-        normalized = iso_str.replace("Z", "+00:00") if iso_str.endswith("Z") else iso_str
+        normalized = (
+            iso_str.replace("Z", "+00:00") if iso_str.endswith("Z") else iso_str
+        )
         return (datetime.fromisoformat(normalized) - timedelta(seconds=1)).isoformat()
 
     @staticmethod
@@ -205,7 +230,12 @@ class Notebooks(BaseResource):
         # 1. time window: nudge start back one second when start == end so the
         #    API's `start < end` validation passes.
         time = attrs.get("time")
-        if isinstance(time, dict) and time.get("start") and time.get("end") and time["start"] == time["end"]:
+        if (
+            isinstance(time, dict)
+            and time.get("start")
+            and time.get("end")
+            and time["start"] == time["end"]
+        ):
             time["start"] = Notebooks._subtract_one_second(time["start"])
 
         # 2. strip the rejected `"type":"sort"` key from `sort` objects

--- a/datadog_sync/model/service_level_objectives.py
+++ b/datadog_sync/model/service_level_objectives.py
@@ -3,10 +3,11 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019 Datadog, Inc.
 from __future__ import annotations
+from collections import defaultdict
 from typing import TYPE_CHECKING, Optional, List, Dict, Tuple, cast
 
-from datadog_sync.utils.base_resource import BaseResource, ResourceConfig, TaggingConfig
-from datadog_sync.utils.resource_utils import SkipResource
+from datadog_sync.utils.base_resource import BaseResource, ResourceConfig, ResourceConnectionResult, TaggingConfig
+from datadog_sync.utils.resource_utils import SkipResource, find_attr
 
 if TYPE_CHECKING:
     from datadog_sync.utils.custom_client import CustomClient
@@ -74,6 +75,72 @@ class ServiceLevelObjectives(BaseResource):
             self.resource_config.base_path + f"/{self.config.state.destination[self.resource_type][_id]['id']}",
             params={"force": "true"},
         )
+
+    def connect_resources(self, _id: str, resource: Dict) -> ResourceConnectionResult:
+        if not self.resource_config.resource_connections:
+            return ResourceConnectionResult()
+
+        failed_connections_dict = defaultdict(list)
+        stale_connections_dict = defaultdict(list)
+        c = find_attr(
+            "monitor_ids",
+            "monitors",
+            resource,
+            lambda key, r_obj, rtc: self._connect_monitor_id_or_classify_stale(key, r_obj, stale_connections_dict),
+        )
+        if c:
+            failed_connections_dict["monitors"].extend(c)
+
+        self._raise_connection_error_if_any(_id, failed_connections_dict)
+        self._raise_stale_dependency_skip(_id, stale_connections_dict)
+
+        return ResourceConnectionResult()
+
+    def _connect_monitor_id_or_classify_stale(
+        self,
+        key: str,
+        r_obj: Dict,
+        stale_connections_dict: Dict[str, List[str]],
+    ) -> Optional[List[str]]:
+        monitor_ids = r_obj.get(key)
+        if not monitor_ids:
+            return None
+
+        failed_connections = []
+        for i, obj in enumerate(monitor_ids):
+            _id = str(obj)
+            resolved = self._destination_monitor_id_for_slo(_id)
+            if resolved is not None:
+                r_obj[key][i] = type(obj)(resolved)
+                continue
+            if self._source_has_slo_monitor_dependency(_id):
+                failed_connections.append(_id)
+            else:
+                stale_connections_dict["monitors"].append(_id)
+        return failed_connections or None
+
+    def _destination_monitor_id_for_slo(self, _id: str) -> Optional[str]:
+        monitors = self.config.state.destination["monitors"]
+        if _id in monitors:
+            return monitors[_id]["id"]
+
+        self.config.state.ensure_resource_loaded("monitors", _id)
+        monitors = self.config.state.destination["monitors"]
+        if _id in monitors:
+            return monitors[_id]["id"]
+
+        self.config.state.ensure_resource_type_loaded("synthetics_tests")
+        synthetics_tests = self.config.state.destination["synthetics_tests"]
+        for k, v in synthetics_tests.items():
+            if k.endswith("#" + _id):
+                return v["monitor_id"]
+        return None
+
+    def _source_has_slo_monitor_dependency(self, _id: str) -> bool:
+        if _id in self.config.state.source["monitors"]:
+            return True
+        synthetics_tests = self.config.state.source["synthetics_tests"]
+        return any(k.endswith("#" + _id) for k in synthetics_tests)
 
     def connect_id(self, key: str, r_obj: Dict, resource_to_connect: str) -> Optional[List[str]]:
         monitors = self.config.state.destination["monitors"]

--- a/datadog_sync/utils/base_resource.py
+++ b/datadog_sync/utils/base_resource.py
@@ -16,6 +16,7 @@ from datadog_sync.utils.resource_utils import (
     DEFAULT_TAGS,
     CustomClientHTTPError,
     FilteredResource,
+    FAILURE_CLASS_STALE_DEPENDENCY,
     SkipResource,
     find_attr,
     ResourceConnectionError,
@@ -485,6 +486,64 @@ class BaseResource(abc.ABC):
         if plain_id in self.config.state.source[resource_to_connect]:
             return None, False
         return None, True
+
+    def _connect_id_or_classify_stale(
+        self,
+        key: str,
+        r_obj: Dict,
+        resource_to_connect: str,
+        stale_connections_dict: Dict[str, List[str]],
+    ) -> Optional[List[str]]:
+        """Resolve a regular resource dependency and classify permanent misses.
+
+        This mirrors connect_id for non-principal references (dashboard widget
+        monitor/SLO/powerpack IDs, etc.) but separates source-present misses
+        from source-absent stale references. Callers can keep retrying the
+        source-present class and turn the source-absent class into a terminal
+        typed skip without mutating the resource into a partial copy.
+        """
+        value = r_obj.get(key)
+        if not value:
+            return None
+
+        failed: List[str] = []
+
+        def resolve_one(v):
+            plain_id = str(v)
+            resolved, stale = self._resolve_or_drop(plain_id, resource_to_connect)
+            if resolved is not None:
+                return type(v)(resolved)
+            if stale:
+                stale_connections_dict[resource_to_connect].append(plain_id)
+            else:
+                failed.append(plain_id)
+            return v
+
+        if isinstance(value, list):
+            r_obj[key] = [resolve_one(v) for v in value]
+        else:
+            r_obj[key] = resolve_one(value)
+
+        return failed or None
+
+    def _raise_stale_dependency_skip(self, _id: str, stale_connections_dict: Dict[str, List[str]]) -> None:
+        details = {
+            resource_type: ",".join(sorted(set(ids)))
+            for resource_type, ids in stale_connections_dict.items()
+            if ids
+        }
+        if not details:
+            return
+
+        formatted = ", ".join(f"{resource_type}=[{ids}]" for resource_type, ids in sorted(details.items()))
+        raise SkipResource(
+            _id,
+            self.resource_type,
+            f"stale dependencies absent from source and destination: {formatted}",
+            failure_class=FAILURE_CLASS_STALE_DEPENDENCY,
+            reason="stale_dependency",
+            outcome_details=details,
+        )
 
     # Composite "type:id" principal type prefixes -> the resource_to_connect they map to.
     _PRINCIPAL_TYPE_MAP: ClassVar[Dict[str, str]] = {"user": "users", "role": "roles", "team": "teams"}

--- a/datadog_sync/utils/resource_utils.py
+++ b/datadog_sync/utils/resource_utils.py
@@ -29,6 +29,7 @@ DEFAULT_TAGS = ["managed_by:datadog-sync"]
 
 FAILURE_CLASS_DESTINATION_METRIC_MISSING = "destination_metric_missing"
 FAILURE_CLASS_INTEGRATION_PIPELINE_BOOTSTRAP_REQUIRED = "integration_pipeline_bootstrap_required"
+FAILURE_CLASS_STALE_DEPENDENCY = "stale_dependency"
 
 
 # aiohttp timeout family — both have empty ``str()``.

--- a/datadog_sync/utils/resources_handler.py
+++ b/datadog_sync/utils/resources_handler.py
@@ -654,6 +654,15 @@ class ResourcesHandler:
 
                 try:
                     r_class.connect_resources(_id, resource)
+                except SkipResource as e:
+                    self.config.logger.warning(f"skipping resource: resource_type:{resource_type} id:{_id}")
+                    self.config.logger.debug(str(e))
+                    _reason, _fc = self._sanitize_reason(e)
+                    emit_kwargs = {"reason": _reason, "failure_class": _fc}
+                    if e.outcome_details:
+                        emit_kwargs["details"] = e.outcome_details
+                    self._emit(resource_type, _id, "sync", "skipped", **emit_kwargs)
+                    return
                 except ResourceConnectionError as e:
                     _reason, _fc = self._sanitize_reason(e)
                     self._emit(resource_type, _id, "sync", "skipped", reason=_reason, failure_class=_fc)

--- a/tests/integration/resources/test_dashboards.py
+++ b/tests/integration/resources/test_dashboards.py
@@ -8,6 +8,10 @@ from tests.integration.helpers import BaseResourcesTestClass
 
 
 class TestDashboardsResources(BaseResourcesTestClass):
+    @staticmethod
+    def compute_import_changes(resource_count, num_of_skips):
+        return resource_count + num_of_skips
+
     resource_type = Dashboards.resource_type
     dependencies = list(Dashboards.resource_config.resource_connections.keys())
     field_to_update = "title"

--- a/tests/integration/resources/test_downtime_schedules.py
+++ b/tests/integration/resources/test_downtime_schedules.py
@@ -8,6 +8,10 @@ from datadog_sync.models import DowntimeSchedules
 
 
 class TestDowntimeSchedulesResources(BaseResourcesTestClass):
+    @staticmethod
+    def compute_import_changes(resource_count, num_of_skips):
+        return resource_count + num_of_skips
+
     resource_type = DowntimeSchedules.resource_type
     dependencies = list(DowntimeSchedules.resource_config.resource_connections.keys())
     field_to_update = "attributes.message"

--- a/tests/unit/test_apply_resource_connection_error.py
+++ b/tests/unit/test_apply_resource_connection_error.py
@@ -15,7 +15,7 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 from datadog_sync.utils.base_resource import ResourceConfig, ResourceConnectionResult
-from datadog_sync.utils.resource_utils import ResourceConnectionError
+from datadog_sync.utils.resource_utils import ResourceConnectionError, SkipResource
 from datadog_sync.utils.resources_handler import ResourcesHandler
 
 
@@ -103,6 +103,43 @@ def test_ordinary_connection_error_has_no_risk_tag(mock_config):
     assert "reason:connection_error" in tags
     assert "risk:empty_restriction_policy" not in tags
     handler.worker.counter.record_empty_binding_risk.assert_not_called()
+
+
+def test_diffs_connect_resources_skip_is_skipped_outcome(mock_config):
+    """Diffs should treat model-level typed skips from connect_resources as
+    skipped outcomes, not unexpected failures.
+    """
+    resource_type = "dashboards"
+    _id = "dash-stale"
+    exc = SkipResource(
+        _id,
+        resource_type,
+        "stale dependencies absent from source and destination: powerpacks=[pp-stale]",
+        failure_class="stale_dependency",
+        reason="stale_dependency",
+        outcome_details={"powerpacks": "1"},
+    )
+    r_class = MagicMock()
+    r_class.connect_resources = MagicMock(side_effect=exc)
+    r_class._pre_resource_action_hook = AsyncMock()
+    mock_config.resources = {resource_type: r_class}
+    mock_config.state.source[resource_type][_id] = {"id": _id}
+
+    handler = ResourcesHandler(mock_config)
+    handler._emit = MagicMock()
+
+    asyncio.run(handler._diffs_worker_cb((resource_type, _id, False)))
+
+    mock_config.logger.exception.assert_not_called()
+    handler._emit.assert_called_once_with(
+        resource_type,
+        _id,
+        "sync",
+        "skipped",
+        reason="stale_dependency",
+        failure_class="stale_dependency",
+        details={"powerpacks": "1"},
+    )
 
 
 def test_successful_update_after_suppressed_empty_binding_risk_is_tagged_and_recorded(mock_config):

--- a/tests/unit/test_dashboard_lists.py
+++ b/tests/unit/test_dashboard_lists.py
@@ -1,0 +1,75 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019 Datadog, Inc.
+
+from collections import defaultdict
+from unittest.mock import MagicMock
+
+import pytest
+
+from datadog_sync.model.dashboard_lists import DashboardLists
+from datadog_sync.utils.resource_utils import ResourceConnectionError
+
+
+def _make_dashboard_lists() -> DashboardLists:
+    config = MagicMock()
+    config.state = MagicMock()
+    config.state.destination = defaultdict(dict)
+    config.state.source = defaultdict(dict)
+    config.skip_failed_resource_connections = False
+    config.logger = MagicMock()
+    return DashboardLists(config)
+
+
+def test_connect_resources_maps_custom_dashboards_and_keeps_integration_dashboards():
+    dashboard_lists = _make_dashboard_lists()
+    dashboard_lists.config.state.destination["dashboards"]["dash-src"] = {"id": "dash-dst"}
+    resource = {
+        "id": 510887,
+        "dashboards": [
+            {"id": "dash-src", "type": "custom_timeboard"},
+            {"id": "62", "type": "integration_timeboard"},
+        ],
+    }
+
+    dashboard_lists.connect_resources("510887", resource)
+
+    assert resource["dashboards"] == [
+        {"id": "dash-dst", "type": "custom_timeboard"},
+        {"id": "62", "type": "integration_timeboard"},
+    ]
+
+
+def test_extract_source_ids_ignores_integration_dashboards():
+    dashboard_lists = _make_dashboard_lists()
+
+    assert (
+        dashboard_lists.extract_source_ids(
+            "id",
+            {"id": "62", "type": "integration_timeboard"},
+            "dashboards",
+        )
+        is None
+    )
+
+
+def test_extract_source_ids_keeps_custom_dashboards():
+    dashboard_lists = _make_dashboard_lists()
+
+    assert dashboard_lists.extract_source_ids(
+        "id",
+        {"id": "dash-src", "type": "custom_timeboard"},
+        "dashboards",
+    ) == ["dash-src"]
+
+
+def test_connect_resources_still_fails_missing_custom_dashboards():
+    dashboard_lists = _make_dashboard_lists()
+    resource = {
+        "id": 510887,
+        "dashboards": [{"id": "dash-src", "type": "custom_timeboard"}],
+    }
+
+    with pytest.raises(ResourceConnectionError):
+        dashboard_lists.connect_resources("510887", resource)

--- a/tests/unit/test_dashboards.py
+++ b/tests/unit/test_dashboards.py
@@ -349,3 +349,43 @@ class TestDashboardsConnectResourcesDrop:
         d = self._make_dashboard(drop=True)
         resource = {"id": "abc"}  # no restricted_roles at all
         d.connect_resources("abc", resource)  # no raise, nothing to do
+
+    def test_stale_slo_widget_raises_typed_skip(self):
+        d = self._make_dashboard()
+        resource = {
+            "id": "abc-def-ghi",
+            "widgets": [{"definition": {"slo_id": "slo-gone"}}],
+        }
+
+        with pytest.raises(SkipResource) as exc_info:
+            d.connect_resources("abc-def-ghi", resource)
+
+        assert exc_info.value.failure_class == "stale_dependency"
+        assert exc_info.value.outcome_reason == "stale_dependency"
+        assert exc_info.value.outcome_details == {"service_level_objectives": "slo-gone"}
+        d.config.state.ensure_resource_loaded.assert_any_call("service_level_objectives", "slo-gone")
+
+    def test_source_present_slo_widget_still_hard_fails(self):
+        d = self._make_dashboard()
+        d.config.state.source["service_level_objectives"]["slo-src"] = {"id": "slo-src"}
+        resource = {
+            "id": "abc-def-ghi",
+            "widgets": [{"definition": {"slo_id": "slo-src"}}],
+        }
+
+        with pytest.raises(ResourceConnectionError):
+            d.connect_resources("abc-def-ghi", resource)
+
+        assert resource["widgets"][0]["definition"]["slo_id"] == "slo-src"
+
+    def test_destination_present_slo_widget_is_mapped(self):
+        d = self._make_dashboard()
+        d.config.state.destination["service_level_objectives"]["slo-src"] = {"id": "slo-dst"}
+        resource = {
+            "id": "abc-def-ghi",
+            "widgets": [{"definition": {"slo_id": "slo-src"}}],
+        }
+
+        d.connect_resources("abc-def-ghi", resource)
+
+        assert resource["widgets"][0]["definition"]["slo_id"] == "slo-dst"

--- a/tests/unit/test_downtime_schedules.py
+++ b/tests/unit/test_downtime_schedules.py
@@ -18,6 +18,7 @@ New behavior:
 """
 
 import asyncio
+from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from threading import Event
 
@@ -418,7 +419,10 @@ def test_recurring_empty_recurrences_no_op(mock_config):
     assert resource["attributes"]["schedule"]["recurrences"] == []
 
 
-def test_update_path_preserves_one_time_schedule_behavior(mock_config):
+@freeze_time("2026-08-21 15:00:00")
+def test_update_path_skips_ended_one_time_schedule_when_destination_inactive(
+    mock_config,
+):
     downtime = DowntimeSchedules(mock_config)
     _id = "existing-id"
     mock_config.state.destination["downtime_schedules"][_id] = {
@@ -427,14 +431,129 @@ def test_update_path_preserves_one_time_schedule_behavior(mock_config):
 
     resource = _make_resource({"start": _past_iso(3600), "end": _past_iso(1200)})
 
-    # No SkipResource on update path even though end is past — update-path
-    # semantics are intentionally out of scope for this PR.
-    _run(downtime.pre_resource_action_hook(_id, resource))
+    with pytest.raises(SkipResource, match="end is in the past"):
+        _run(downtime.pre_resource_action_hook(_id, resource))
 
-    schedule = resource["attributes"]["schedule"]
-    dest = mock_config.state.destination["downtime_schedules"][_id]["attributes"]["schedule"]
-    assert schedule["start"] == dest["start"]
-    assert schedule["end"] == dest["end"]
+
+@freeze_time("2026-08-27 12:00:00")
+def test_update_active_one_time_destination_preserves_start_for_patch(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    _id = "existing-id"
+    destination = _make_resource(
+        {
+            "start": "2026-08-21T15:04:19.076627+00:00",
+            "end": "2030-08-13T16:12:00+00:00",
+        }
+    )
+    destination["id"] = "downtime-destination-test"
+    destination["attributes"]["message"] = "Original message"
+    mock_config.state.destination["downtime_schedules"][_id] = destination
+    source = _make_resource(
+        {
+            "start": "2026-08-27T03:43:36.405325+00:00",
+            "end": "2027-01-01T16:48:00+00:00",
+        }
+    )
+    source["attributes"]["message"] = "Updated message"
+    captured = {}
+
+    async def _patch(path, payload):
+        captured["path"] = path
+        captured["payload"] = deepcopy(payload)
+        return {"data": payload["data"]}
+
+    mock_config.destination_client.patch = _patch
+
+    _run(downtime.pre_resource_action_hook(_id, source))
+    _run(downtime.update_resource(_id, source))
+
+    schedule = captured["payload"]["data"]["attributes"]["schedule"]
+    assert captured["path"] == "/api/v2/downtime/downtime-destination-test"
+    assert schedule["start"] == "2026-08-21T15:04:19.076627+00:00"
+    assert schedule["end"] == "2027-01-01T16:48:00+00:00"
+    assert captured["payload"]["data"]["attributes"]["message"] == "Updated message"
+
+
+@freeze_time("2026-08-27 12:00:00")
+def test_update_future_one_time_source_recreates_active_destination(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    _id = "existing-id"
+    destination = _make_resource({"start": "2026-07-29T09:00:00+00:00"})
+    destination["id"] = "downtime-destination-test"
+    mock_config.state.destination["downtime_schedules"][_id] = destination
+    source = _make_resource(
+        {
+            "start": "2026-09-12T12:00:00+00:00",
+            "end": "2026-09-12T14:00:00+00:00",
+        }
+    )
+    captured = {"deleted": [], "posted": []}
+
+    async def _delete(path):
+        captured["deleted"].append(path)
+
+    async def _post(path, payload):
+        captured["posted"].append((path, deepcopy(payload)))
+        return {
+            "data": {
+                "id": "downtime-replacement-test",
+                **deepcopy(payload["data"]),
+            }
+        }
+
+    async def _unexpected_patch(*_args, **_kwargs):
+        pytest.fail(
+            "an active destination start cannot be patched to a future source start"
+        )
+
+    mock_config.destination_client.delete = _delete
+    mock_config.destination_client.post = _post
+    mock_config.destination_client.patch = _unexpected_patch
+
+    _run(downtime.pre_resource_action_hook(_id, source))
+    _run(downtime._update_resource(_id, source))
+
+    assert captured["deleted"] == ["/api/v2/downtime/downtime-destination-test"]
+    assert captured["posted"][0][0] == "/api/v2/downtime"
+    assert captured["posted"][0][1]["data"]["attributes"]["schedule"] == {
+        "start": "2026-09-12T12:00:00+00:00",
+        "end": "2026-09-12T14:00:00+00:00",
+    }
+    assert (
+        mock_config.state.destination["downtime_schedules"][_id]["id"]
+        == "downtime-replacement-test"
+    )
+
+
+@freeze_time("2026-08-27 12:00:00")
+def test_update_ended_one_time_source_cancels_active_destination(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    _id = "existing-id"
+    destination = _make_resource({"start": "2026-05-07T23:41:36.491799+00:00"})
+    destination["id"] = "downtime-destination-test"
+    mock_config.state.destination["downtime_schedules"][_id] = destination
+    source = _make_resource(
+        {
+            "start": "2025-08-18T08:42:36.014000+00:00",
+            "end": "2026-08-18T08:42:36.014000+00:00",
+        }
+    )
+    captured = {}
+
+    async def _delete(path):
+        captured["path"] = path
+
+    async def _unexpected_patch(*_args, **_kwargs):
+        pytest.fail("an ended source must cancel the active destination")
+
+    mock_config.destination_client.delete = _delete
+    mock_config.destination_client.patch = _unexpected_patch
+
+    _run(downtime.pre_resource_action_hook(_id, source))
+    _run(downtime._update_resource(_id, source))
+
+    assert captured["path"] == "/api/v2/downtime/downtime-destination-test"
+    assert _id not in mock_config.state.destination["downtime_schedules"]
 
 
 @freeze_time("2026-08-20 15:00:00")

--- a/tests/unit/test_downtime_schedules.py
+++ b/tests/unit/test_downtime_schedules.py
@@ -27,7 +27,7 @@ from dateutil.parser import parse
 from freezegun import freeze_time
 
 from datadog_sync.model.downtime_schedules import DowntimeSchedules
-from datadog_sync.utils.resource_utils import SkipResource, check_diff
+from datadog_sync.utils.resource_utils import ResourceConnectionError, SkipResource, check_diff
 
 
 def _run(coro):
@@ -55,6 +55,10 @@ def _future_iso(seconds_ahead: int = 3600) -> str:
 
 def _make_resource(schedule):
     return {"attributes": {"schedule": schedule}}
+
+
+def _make_monitor_downtime(monitor_id):
+    return {"attributes": {"monitor_identifier": {"monitor_id": monitor_id}}}
 
 
 def test_past_start_bumped_forward(mock_config):
@@ -165,6 +169,42 @@ def test_start_only_no_end_field(mock_config):
     schedule = resource["attributes"]["schedule"]
     assert "end" not in schedule
     assert parse(schedule["start"]).timestamp() > _now_ts() - 5
+
+
+def test_connect_resources_skips_stale_monitor_dependency(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    mock_config.skip_failed_resource_connections = False
+    resource = _make_monitor_downtime(217900730)
+
+    with pytest.raises(SkipResource, match="stale monitor 217900730"):
+        downtime.connect_resources("downtime-source-test", resource)
+
+
+def test_connect_resources_keeps_not_yet_synced_monitor_failure(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    mock_config.skip_failed_resource_connections = False
+    mock_config.state.source["monitors"]["217900730"] = {"id": 217900730}
+    resource = _make_monitor_downtime(217900730)
+
+    with pytest.raises(ResourceConnectionError, match="217900730"):
+        downtime.connect_resources("downtime-source-test", resource)
+
+
+def test_connect_resources_remaps_monitor_loaded_lazily(mock_config):
+    downtime = DowntimeSchedules(mock_config)
+    resource = _make_monitor_downtime(217900730)
+
+    def _ensure_resource_loaded(resource_type, resource_id):
+        assert resource_type == "monitors"
+        assert resource_id == "217900730"
+        mock_config.state.destination["monitors"][resource_id] = {"id": 19656739}
+
+    mock_config.state.ensure_resource_loaded = _ensure_resource_loaded
+
+    result = downtime.connect_resources("downtime-source-test", resource)
+
+    assert not result.empty_binding_escalation
+    assert resource["attributes"]["monitor_identifier"]["monitor_id"] == 19656739
 
 
 # --- Recurring downtime recurrence-level normalization ----------------------

--- a/tests/unit/test_metric_tag_configurations.py
+++ b/tests/unit/test_metric_tag_configurations.py
@@ -106,6 +106,60 @@ def test_create_resource_existing_config_conflict_gets_existing_then_patches(met
     assert data == {"id": "custom.metric", "attributes": {"tags": ["env", "service"]}}
 
 
+def test_create_resource_missing_metadata_type_sets_metric_type_then_retries(metric_tag_configurations):
+    client = metric_tag_configurations.config.destination_client
+    client.post = AsyncMock(
+        side_effect=[
+            _http_error(
+                400,
+                "The metadata for metric custom.metric is not set. "
+                "The metadata type must be set prior to configuring tags.",
+            ),
+            {"data": _resource()},
+        ]
+    )
+    client.put = AsyncMock(return_value={"type": "count"})
+    client.get = AsyncMock()
+    client.patch = AsyncMock()
+    metric_tag_configurations.config.state.source["metric_tag_configurations"]["custom.metric"] = _resource()
+
+    _id, data = _run(metric_tag_configurations.create_resource("custom.metric", _resource()))
+
+    assert _id == "custom.metric"
+    assert data == _resource()
+    client.put.assert_awaited_once_with("/api/v1/metrics/custom.metric", {"type": "count"})
+    assert client.post.await_count == 2
+    client.get.assert_not_awaited()
+    client.patch.assert_not_awaited()
+
+
+def test_create_resource_missing_metadata_type_retry_conflict_gets_existing_then_patches(metric_tag_configurations):
+    client = metric_tag_configurations.config.destination_client
+    client.post = AsyncMock(
+        side_effect=[
+            _http_error(
+                400,
+                "The metadata for metric custom.metric is not set. "
+                "The metadata type must be set prior to configuring tags.",
+            ),
+            _http_error(409, "Conflicts with existing configuration; use PATCH to update"),
+        ]
+    )
+    client.put = AsyncMock(return_value={"type": "count"})
+    client.get = AsyncMock(return_value={"data": {"id": "custom.metric", "attributes": {"tags": ["env"]}}})
+    client.patch = AsyncMock(return_value={"data": {"id": "custom.metric", "attributes": {"tags": ["env", "service"]}}})
+    metric_tag_configurations.config.state.source["metric_tag_configurations"]["custom.metric"] = _resource()
+
+    _id, data = _run(metric_tag_configurations.create_resource("custom.metric", _resource()))
+
+    client.put.assert_awaited_once_with("/api/v1/metrics/custom.metric", {"type": "count"})
+    assert client.post.await_count == 2
+    client.get.assert_awaited_once_with("/api/v2/metrics/custom.metric/tags")
+    client.patch.assert_awaited_once()
+    assert _id == "custom.metric"
+    assert data == {"id": "custom.metric", "attributes": {"tags": ["env", "service"]}}
+
+
 def test_create_resource_non_matching_409_propagates(metric_tag_configurations):
     client = metric_tag_configurations.config.destination_client
     client.post = AsyncMock(side_effect=_http_error(409, "conflict"))
@@ -150,3 +204,29 @@ def test_update_resource_non_missing_metric_error_propagates(metric_tag_configur
         _run(metric_tag_configurations.update_resource("custom.metric", _resource()))
 
     assert exc_info.value.status_code == 500
+
+
+def test_update_resource_missing_metadata_type_sets_metric_type_then_retries(metric_tag_configurations):
+    client = metric_tag_configurations.config.destination_client
+    client.patch = AsyncMock(
+        side_effect=[
+            _http_error(
+                400,
+                "The metadata for metric custom.metric is not set. "
+                "The metadata type must be set prior to configuring tags.",
+            ),
+            {"data": {"id": "custom.metric", "attributes": {"tags": ["env", "service"]}}},
+        ]
+    )
+    client.put = AsyncMock(return_value={"type": "count"})
+    resource = _resource()
+    metric_tag_configurations.config.state.destination["metric_tag_configurations"]["custom.metric"] = _resource()
+
+    _id, data = _run(metric_tag_configurations.update_resource("custom.metric", resource))
+
+    assert _id == "custom.metric"
+    assert data == {"id": "custom.metric", "attributes": {"tags": ["env", "service"]}}
+    client.put.assert_awaited_once_with("/api/v1/metrics/custom.metric", {"type": "count"})
+    assert client.patch.await_count == 2
+    assert client.patch.await_args_list[0].args[1]["data"]["attributes"] == {"tags": ["env", "service"]}
+    assert resource["attributes"]["metric_type"] == "count"

--- a/tests/unit/test_metrics_metadata.py
+++ b/tests/unit/test_metrics_metadata.py
@@ -27,8 +27,120 @@ def _http_error(status, message="err"):
 def metrics_metadata():
     mock_config = MagicMock()
     mock_config.state = MagicMock()
+    mock_config.source_client = AsyncMock()
     mock_config.destination_client = AsyncMock()
     return MetricsMetadata(mock_config)
+
+
+def test_import_resource_with_metadata_returns_source_metadata(metrics_metadata):
+    client = metrics_metadata.config.source_client
+    client.get = AsyncMock(return_value={"description": "source", "type": "rate", "unit": None})
+
+    _id, resource = asyncio.run(metrics_metadata.import_resource(resource={"id": "custom.metric"}))
+
+    assert _id == "custom.metric"
+    assert resource == {"description": "source", "type": "rate", "unit": None}
+    client.get.assert_awaited_once_with("/api/v1/metrics/custom.metric")
+
+
+def test_import_resource_all_null_metadata_uses_tag_configuration_type(metrics_metadata):
+    client = metrics_metadata.config.source_client
+    client.get = AsyncMock(
+        side_effect=[
+            {
+                "description": None,
+                "short_name": None,
+                "type": None,
+                "unit": None,
+                "per_unit": None,
+                "statsd_interval": None,
+                "integration": None,
+            },
+            {
+                "data": {
+                    "id": "custom.metric",
+                    "type": "manage_tags",
+                    "attributes": {"metric_type": "RATE", "tags": ["env"]},
+                }
+            },
+        ]
+    )
+
+    _id, resource = asyncio.run(metrics_metadata.import_resource(resource={"id": "custom.metric"}))
+
+    assert _id == "custom.metric"
+    assert resource == {"type": "rate"}
+    assert client.get.await_args_list[0].args == ("/api/v1/metrics/custom.metric",)
+    assert client.get.await_args_list[1].args == ("/api/v2/metrics/custom.metric/tags",)
+
+
+def test_import_resource_all_null_metadata_without_tag_configuration_type_skips(metrics_metadata):
+    client = metrics_metadata.config.source_client
+    client.get = AsyncMock(
+        side_effect=[
+            {
+                "description": None,
+                "short_name": None,
+                "type": None,
+                "unit": None,
+                "per_unit": None,
+                "statsd_interval": None,
+                "integration": None,
+            },
+            {"data": {"id": "custom.metric", "attributes": {"tags": ["env"]}}},
+        ]
+    )
+
+    with pytest.raises(SkipResource) as exc_info:
+        asyncio.run(metrics_metadata.import_resource(resource={"id": "custom.metric"}))
+
+    assert "Metric has no metadata" in str(exc_info.value)
+
+
+def test_import_resource_all_null_metadata_tag_configuration_error_skips(metrics_metadata):
+    client = metrics_metadata.config.source_client
+    client.get = AsyncMock(
+        side_effect=[
+            {
+                "description": None,
+                "short_name": None,
+                "type": None,
+                "unit": None,
+                "per_unit": None,
+                "statsd_interval": None,
+                "integration": None,
+            },
+            _http_error(403, "Forbidden"),
+        ]
+    )
+
+    with pytest.raises(SkipResource) as exc_info:
+        asyncio.run(metrics_metadata.import_resource(resource={"id": "custom.metric"}))
+
+    assert "Metric has no metadata" in str(exc_info.value)
+
+
+def test_import_resource_all_null_metadata_with_distribution_tag_type_skips(metrics_metadata):
+    client = metrics_metadata.config.source_client
+    client.get = AsyncMock(
+        side_effect=[
+            {
+                "description": None,
+                "short_name": None,
+                "type": None,
+                "unit": None,
+                "per_unit": None,
+                "statsd_interval": None,
+                "integration": None,
+            },
+            {"data": {"id": "custom.metric", "attributes": {"metric_type": "distribution"}}},
+        ]
+    )
+
+    with pytest.raises(SkipResource) as exc_info:
+        asyncio.run(metrics_metadata.import_resource(resource={"id": "custom.metric"}))
+
+    assert "Metric has no metadata" in str(exc_info.value)
 
 
 def test_update_resource_dest_exists_calls_put(metrics_metadata):

--- a/tests/unit/test_notebooks.py
+++ b/tests/unit/test_notebooks.py
@@ -70,11 +70,13 @@ def test_get_resources_does_not_request_cells(notebooks):
     inner.assert_awaited_once()
     call_args = inner.await_args.args
     call_kwargs = inner.await_args.kwargs
-    assert call_args == ("/api/v1/notebooks",), "LIST must call the notebooks base_path positionally; got %r" % (
-        call_args,
-    )
+    assert call_args == (
+        "/api/v1/notebooks",
+    ), "LIST must call the notebooks base_path positionally; got %r" % (call_args,)
     params = call_kwargs.get("params", {})
-    assert "include_cells" not in params, "LIST must not request include_cells; got params=%r" % params
+    assert "include_cells" not in params, (
+        "LIST must not request include_cells; got params=%r" % params
+    )
     assert call_kwargs.get("pagination_config") is notebooks.pagination_config, (
         "LIST must forward the class-level pagination_config so meta.page.total_count "
         "drives termination; got kwargs=%r" % call_kwargs
@@ -91,7 +93,9 @@ def test_import_resource_with_id_issues_get(notebooks):
     # kwargs (params=, domain=, **kwargs) so an exact-kwargs assertion would
     # break on benign future refactors.
     notebooks.config.source_client.get.assert_awaited_once()
-    assert notebooks.config.source_client.get.await_args.args[0] == "/api/v1/notebooks/42"
+    assert (
+        notebooks.config.source_client.get.await_args.args[0] == "/api/v1/notebooks/42"
+    )
     # State writes round-trip through str(_id) upstream; pin the string contract
     # here so logs and the resources_handler emit consistent types.
     assert _id == "42"
@@ -138,19 +142,25 @@ def test_import_resource_with_list_item_still_issues_get(notebooks):
     """
     list_item = {"id": 99, "type": "notebooks", "attributes": {"name": "from-list"}}
     notebooks.config.source_client.get = AsyncMock(
-        return_value=_detail_payload(99, name="from-detail", cells=[{"type": "notebook_cells"}])
+        return_value=_detail_payload(
+            99, name="from-detail", cells=[{"type": "notebook_cells"}]
+        )
     )
 
     _id, resource = asyncio.run(notebooks.import_resource(resource=list_item))
 
     notebooks.config.source_client.get.assert_awaited_once()
-    assert notebooks.config.source_client.get.await_args.args[0] == "/api/v1/notebooks/99"
+    assert (
+        notebooks.config.source_client.get.await_args.args[0] == "/api/v1/notebooks/99"
+    )
     assert _id == "99"
     assert isinstance(_id, str)
     assert (
         resource["attributes"]["name"] == "from-detail"
     ), "import_resource must return the GET payload, not the LIST item"
-    assert resource["attributes"]["cells"], "the GET-returned cells must be preserved on the imported resource"
+    assert resource["attributes"][
+        "cells"
+    ], "the GET-returned cells must be preserved on the imported resource"
 
 
 def test_import_resource_strips_ai_usage_tags(notebooks):
@@ -182,6 +192,28 @@ def test_import_resource_strips_ai_usage_tags(notebooks):
     assert "team:hamr" in tags
     assert not any(t.startswith("ai_generated:") for t in tags)
     assert not any(t.startswith("human_edited:") for t in tags)
+
+
+def test_import_resource_normalizes_null_tags(notebooks):
+    """Empty notebook tags may round-trip as null or []; treat both as no tags."""
+    notebooks.config.source_client.get = AsyncMock(
+        return_value={
+            "data": {
+                "id": 7,
+                "type": "notebooks",
+                "attributes": {
+                    "name": "N",
+                    "cells": [],
+                    "schema_version": 1,
+                    "tags": None,
+                },
+            }
+        }
+    )
+
+    _, resource = asyncio.run(notebooks.import_resource(_id="7"))
+
+    assert resource["attributes"]["tags"] == []
 
 
 def test_import_resource_403_raises_skip_resource(notebooks):
@@ -274,7 +306,9 @@ def test_post_get_refilter_raises_filtered_resource_when_rejected(notebooks):
     # Mock a filter that rejects the GET payload (looks at a cells-derived field).
     filter_mock = MagicMock(return_value=False)
     notebooks.filter = filter_mock
-    notebooks.config.source_client.get = AsyncMock(return_value=_detail_payload(7, cells=[{"type": "notebook_cells"}]))
+    notebooks.config.source_client.get = AsyncMock(
+        return_value=_detail_payload(7, cells=[{"type": "notebook_cells"}])
+    )
 
     with pytest.raises(FilteredResource):
         asyncio.run(notebooks._import_resource(_id="7"))
@@ -283,7 +317,9 @@ def test_post_get_refilter_raises_filtered_resource_when_rejected(notebooks):
     # LIST item the caller passed in. Confirm by checking the filter call.
     filter_mock.assert_called_once()
     filtered_arg = filter_mock.call_args.args[0]
-    assert filtered_arg["attributes"]["cells"], "post-GET filter must see the full body (with cells), not the LIST item"
+    assert filtered_arg["attributes"][
+        "cells"
+    ], "post-GET filter must see the full body (with cells), not the LIST item"
     # State write was skipped.
     notebooks.config.state.set_source.assert_not_called()
 
@@ -358,7 +394,9 @@ def _make_filter(resource_type, attr_name, value, operator="ExactMatch"):
     """
     from datadog_sync.utils.filter import process_filters
 
-    filter_str = f"Type={resource_type};Name={attr_name};Value={value};Operator={operator}"
+    filter_str = (
+        f"Type={resource_type};Name={attr_name};Value={value};Operator={operator}"
+    )
     parsed = process_filters([filter_str])
     return parsed[resource_type.lower()][0]
 
@@ -392,7 +430,9 @@ def test_handler_metadata_filter_short_circuits_at_list_time(notebooks):
     """
     handler = _make_handler()
     handler.config.resources = {"notebooks": notebooks}
-    handler.config.filters = {"notebooks": [_make_filter("notebooks", "attributes.name", "keep-this")]}
+    handler.config.filters = {
+        "notebooks": [_make_filter("notebooks", "attributes.name", "keep-this")]
+    }
     handler.config.filter_operator = "and"
     notebooks.config.filters = handler.config.filters
     notebooks.config.filter_operator = "and"
@@ -414,11 +454,15 @@ def test_handler_metadata_filter_accept_proceeds_to_get(notebooks):
     """
     handler = _make_handler()
     handler.config.resources = {"notebooks": notebooks}
-    handler.config.filters = {"notebooks": [_make_filter("notebooks", "attributes.name", "keep-this")]}
+    handler.config.filters = {
+        "notebooks": [_make_filter("notebooks", "attributes.name", "keep-this")]
+    }
     handler.config.filter_operator = "and"
     notebooks.config.filters = handler.config.filters
     notebooks.config.filter_operator = "and"
-    notebooks.config.source_client.get = AsyncMock(return_value=_detail_payload(78, name="keep-this"))
+    notebooks.config.source_client.get = AsyncMock(
+        return_value=_detail_payload(78, name="keep-this")
+    )
 
     list_item = {"id": 78, "type": "notebooks", "attributes": {"name": "keep-this"}}
     asyncio.run(handler._import_resource(["notebooks", list_item]))
@@ -439,12 +483,18 @@ def test_handler_defers_list_unsafe_filter_to_post_get(notebooks):
     handler.config.resources = {"notebooks": notebooks}
     # A positive filter that the LIST item cannot satisfy (no cells in LIST).
     handler.config.filters = {
-        "notebooks": [_make_filter("notebooks", "attributes.cells.attributes.definition.type", "markdown")]
+        "notebooks": [
+            _make_filter(
+                "notebooks", "attributes.cells.attributes.definition.type", "markdown"
+            )
+        ]
     }
     handler.config.filter_operator = "and"
     notebooks.config.filters = handler.config.filters
     notebooks.config.filter_operator = "and"
-    notebooks.config.source_client.get = AsyncMock(return_value=_detail_payload(55, cells=[_cell("markdown")]))
+    notebooks.config.source_client.get = AsyncMock(
+        return_value=_detail_payload(55, cells=[_cell("markdown")])
+    )
 
     list_item = {"id": 55, "type": "notebooks", "attributes": {"name": "n"}}
     asyncio.run(handler._import_resource(["notebooks", list_item]))
@@ -465,7 +515,11 @@ def test_handler_post_get_filter_rejects_when_cells_do_not_match(notebooks):
     handler = _make_handler()
     handler.config.resources = {"notebooks": notebooks}
     handler.config.filters = {
-        "notebooks": [_make_filter("notebooks", "attributes.cells.attributes.definition.type", "markdown")]
+        "notebooks": [
+            _make_filter(
+                "notebooks", "attributes.cells.attributes.definition.type", "markdown"
+            )
+        ]
     }
     handler.config.filter_operator = "and"
     notebooks.config.filters = handler.config.filters
@@ -503,7 +557,9 @@ def test_handler_mixed_or_filter_defers_when_list_safe_misses(notebooks):
     handler.config.filters = {
         "notebooks": [
             _make_filter("notebooks", "attributes.name", "foo"),
-            _make_filter("notebooks", "attributes.cells.attributes.definition.type", "markdown"),
+            _make_filter(
+                "notebooks", "attributes.cells.attributes.definition.type", "markdown"
+            ),
         ]
     }
     handler.config.filter_operator = "or"
@@ -538,7 +594,9 @@ def test_handler_mixed_or_filter_short_circuits_when_list_safe_hits(notebooks):
     handler.config.filters = {
         "notebooks": [
             _make_filter("notebooks", "attributes.name", "match-me"),
-            _make_filter("notebooks", "attributes.cells.attributes.definition.type", "timeseries"),
+            _make_filter(
+                "notebooks", "attributes.cells.attributes.definition.type", "timeseries"
+            ),
         ]
     }
     handler.config.filter_operator = "or"
@@ -597,7 +655,9 @@ def test_handler_and_filter_list_safe_miss_decisive_reject(notebooks):
     handler.config.filters = {
         "notebooks": [
             _make_filter("notebooks", "attributes.name", "must-match"),
-            _make_filter("notebooks", "attributes.cells.attributes.definition.type", "markdown"),
+            _make_filter(
+                "notebooks", "attributes.cells.attributes.definition.type", "markdown"
+            ),
         ]
     }
     handler.config.filter_operator = "and"
@@ -635,7 +695,11 @@ def test_force_missing_dep_bypasses_user_filter(notebooks):
     handler.config.resources = {"notebooks": notebooks}
     # User filter would reject this notebook's cells (timeseries, not markdown).
     handler.config.filters = {
-        "notebooks": [_make_filter("notebooks", "attributes.cells.attributes.definition.type", "markdown")]
+        "notebooks": [
+            _make_filter(
+                "notebooks", "attributes.cells.attributes.definition.type", "markdown"
+            )
+        ]
     }
     handler.config.filter_operator = "and"
     notebooks.config.filters = handler.config.filters
@@ -666,8 +730,11 @@ def test_force_missing_dep_bypasses_user_filter(notebooks):
     emit_calls = handler._emit.call_args_list
     statuses = [c.args[3] for c in emit_calls]
     assert "success" in statuses, (
-        f"force-missing-dep must succeed even when --filter would reject; " f"emit calls: {emit_calls}"
+        f"force-missing-dep must succeed even when --filter would reject; "
+        f"emit calls: {emit_calls}"
     )
-    assert "filtered" not in statuses, f"force-missing-dep must NOT bucket as 'filtered'; emit calls: {emit_calls}"
+    assert (
+        "filtered" not in statuses
+    ), f"force-missing-dep must NOT bucket as 'filtered'; emit calls: {emit_calls}"
     # State was written (the dep is now available for ID remapping downstream).
     notebooks.config.state.set_source.assert_called_once()

--- a/tests/unit/test_service_level_objectives.py
+++ b/tests/unit/test_service_level_objectives.py
@@ -15,11 +15,12 @@ tests/integration/resources/cassettes/test_service_level_objectives/.
 """
 
 import asyncio
+from collections import defaultdict
 import pytest
 from unittest.mock import MagicMock
 
 from datadog_sync.model.service_level_objectives import ServiceLevelObjectives
-from datadog_sync.utils.resource_utils import SkipResource
+from datadog_sync.utils.resource_utils import ResourceConnectionError, SkipResource
 
 
 class TestSLOPreResourceActionHook:
@@ -138,3 +139,56 @@ class TestSLOPreResourceActionHook:
         with pytest.raises(SkipResource) as exc_info:
             asyncio.run(slos.pre_resource_action_hook("msgtest", resource))
         assert "numerator" in str(exc_info.value)
+
+
+class TestSLOConnectResources:
+    def _make_slos(self):
+        mock_config = MagicMock()
+        mock_config.state = MagicMock()
+        mock_config.state.source = defaultdict(dict)
+        mock_config.state.destination = defaultdict(dict)
+        mock_config.state.ensure_resource_loaded = MagicMock()
+        mock_config.state.ensure_resource_type_loaded = MagicMock()
+        mock_config.skip_failed_resource_connections = False
+        mock_config.logger = MagicMock()
+        return ServiceLevelObjectives(mock_config)
+
+    def test_stale_monitor_dependency_raises_typed_skip(self):
+        slos = self._make_slos()
+        resource = {"id": "slo-src", "type": "monitor", "monitor_ids": [123]}
+
+        with pytest.raises(SkipResource) as exc_info:
+            slos.connect_resources("slo-src", resource)
+
+        assert exc_info.value.failure_class == "stale_dependency"
+        assert exc_info.value.outcome_reason == "stale_dependency"
+        assert exc_info.value.outcome_details == {"monitors": "123"}
+        slos.config.state.ensure_resource_loaded.assert_any_call("monitors", "123")
+
+    def test_source_present_monitor_dependency_still_hard_fails(self):
+        slos = self._make_slos()
+        slos.config.state.source["monitors"]["123"] = {"id": 123}
+        resource = {"id": "slo-src", "type": "monitor", "monitor_ids": [123]}
+
+        with pytest.raises(ResourceConnectionError):
+            slos.connect_resources("slo-src", resource)
+
+        assert resource["monitor_ids"] == [123]
+
+    def test_destination_present_monitor_dependency_is_mapped(self):
+        slos = self._make_slos()
+        slos.config.state.destination["monitors"]["123"] = {"id": 456}
+        resource = {"id": "slo-src", "type": "monitor", "monitor_ids": [123]}
+
+        slos.connect_resources("slo-src", resource)
+
+        assert resource["monitor_ids"] == [456]
+
+    def test_destination_synthetics_monitor_dependency_is_mapped(self):
+        slos = self._make_slos()
+        slos.config.state.destination["synthetics_tests"]["abc-def#123"] = {"monitor_id": 456}
+        resource = {"id": "slo-src", "type": "monitor", "monitor_ids": [123]}
+
+        slos.connect_resources("slo-src", resource)
+
+        assert resource["monitor_ids"] == [456]


### PR DESCRIPTION
## Summary
- when source metric metadata is all-null, try the metric tag configuration endpoint and import minimal `{"type": "..."}` metadata from `attributes.metric_type`
- when metric tag configuration writes fail because destination metadata type is unset, PUT the minimal destination metric metadata type and retry the tag configuration write
- keep distribution metrics and metrics without a tag-config metric_type on the existing skip path
- normalize notebook `tags: null` to `tags: []` before diffing so equivalent notebooks do not issue unnecessary updates
- handle one-time downtime schedule updates without sending API-invalid active-start mutations
- skip downtime schedules that reference monitors absent from both source and destination state
- let dashboard lists keep Datadog integration dashboard entries without trying to import or remap them as customer dashboards
- turn stale dashboard/SLO dependencies into typed skips when the referenced dependency is absent from both source and destination state

## Context
Some orgs can have metric tag configuration state for a metric while the v1 metric metadata endpoint returns an all-null object. In that case, sync-cli previously skipped `metrics_metadata`, then later failed `metric_tag_configurations` because the destination requires the metric metadata type to be set before tags can be configured.

This change uses the tag configuration `attributes.metric_type` as the minimal source truth needed to seed destination metadata type. It does not synthesize rich metadata fields such as description, display name, unit, or per-unit when the source has no such metadata.

Low-volume resource drift cases are also handled:
- notebooks whose only remaining diff is `tags: null` versus `tags: []`
- one-time downtime schedules where the mapped destination downtime is already active, but the source schedule is active, future, or already ended
- downtime schedules pointing at monitor IDs that are not present in either source or destination state
- dashboard lists that contain Datadog integration dashboards alongside customer dashboards
- dashboards/SLOs that still reference deleted or out-of-scope dependencies

For active one-time downtimes, sync-cli now preserves the destination start when patching instead of trying to move an in-progress downtime start. If the source has ended, it cancels the active destination. If the source is future-scheduled while the destination is active, it replaces the active destination downtime with the future source schedule.

For stale monitor dependencies, sync-cli still retries when the monitor exists in source state but is not synced yet. It skips only when the referenced monitor is absent from both states, which indicates the downtime points at a deleted or out-of-scope monitor.

For dashboard-related dependencies, sync-cli still retries when a dashboard, SLO, monitor, or powerpack dependency exists in source state but has not synced yet. It emits a typed `stale_dependency` skip only when the referenced dependency is absent from both source and destination state. This avoids silently mutating dashboards by deleting widgets while also preventing permanently stale references from repeating as actionable failures every run.

## Tests
- `python -m pytest tests/unit/test_metric_tag_configurations.py tests/unit/test_metrics_metadata.py`
- `python -m pytest tests/unit/test_notebooks.py tests/unit/test_notebooks_api_sanitization.py`
- `python -m pytest tests/unit/test_downtime_schedules.py tests/unit/test_downtime_schedules_active_windows.py tests/unit/test_downtime_schedules_conflict_skip.py`
- `python -m pytest tests/unit/test_dashboards.py tests/unit/test_dashboard_lists.py tests/unit/test_service_level_objectives.py`
- `python -m ruff check --select F,E9 datadog_sync/model/dashboards.py datadog_sync/model/dashboard_lists.py datadog_sync/model/service_level_objectives.py datadog_sync/utils/base_resource.py datadog_sync/utils/resource_utils.py tests/unit/test_dashboards.py tests/unit/test_dashboard_lists.py tests/unit/test_service_level_objectives.py`
- `python -m ruff check --select F,E9 datadog_sync/model/downtime_schedules.py tests/unit/test_downtime_schedules.py`
- `git diff --check`
