### PR TITLE
fix(import): classify and budget transient fetch failures

### DIFF
--- a/datadog_sync/commands/shared/options.py
+++ b/datadog_sync/commands/shared/options.py
@@ -238,8 +238,9 @@ _common_options = [
         required=False,
         default=5,
         type=int,
-        help="Percentage of transient (5xx/429/timeout) failures within an --id-file "
-        "fetch that triggers a rate-limit-shaped exit. Default 5.",
+        help="Percentage of transient (5xx/429/timeout/connection/retry-exhaustion) "
+        "failures within a resource type that makes import return non-zero after "
+        "saving partial state. Applies to full-list and --id-file imports. Default 5.",
         cls=CustomOptionClass,
     ),
     option(

--- a/datadog_sync/model/dashboard_lists.py
+++ b/datadog_sync/model/dashboard_lists.py
@@ -8,7 +8,7 @@ import copy
 from typing import TYPE_CHECKING, Optional, List, Dict, Tuple, cast
 
 from datadog_sync.utils.base_resource import BaseResource, ResourceConfig
-from datadog_sync.utils.resource_utils import CustomClientHTTPError, check_diff
+from datadog_sync.utils.resource_utils import check_diff
 
 if TYPE_CHECKING:
     from datadog_sync.utils.custom_client import CustomClient
@@ -38,17 +38,21 @@ class DashboardLists(BaseResource):
 
         resource = cast(dict, resource)
         _id = str(resource["id"])
-        resp = None
-        try:
-            resp = await source_client.get(self.dash_list_items_path.format(_id))
-        except CustomClientHTTPError as e:
-            self.config.logger.error("error retrieving dashboard_lists items %s", e)
+        # Fetch the list's dashboard items.  A transient 5xx here must
+        # propagate so the per-resource import worker counts this resource
+        # as a failure and writes no incomplete source state.  Swallowing
+        # the error and persisting dashboards=[] would let a later sync
+        # interpret a transient read failure as an intentionally empty
+        # list and clear destination membership — destructive data loss
+        # from a transient API error.  The worker classifies 5xx as
+        # http_5xx (transient): counted as failure, logged at WARNING,
+        # no exit-code poisoning, no state written.
+        resp = await source_client.get(self.dash_list_items_path.format(_id))
 
         resource["dashboards"] = []
-        if resp:
-            for dash in resp.get("dashboards", []):
-                dash_list_item = {"id": dash["id"], "type": dash["type"]}
-                resource["dashboards"].append(dash_list_item)
+        for dash in resp.get("dashboards", []):
+            dash_list_item = {"id": dash["id"], "type": dash["type"]}
+            resource["dashboards"].append(dash_list_item)
 
         return _id, resource
 

--- a/datadog_sync/utils/resources_handler.py
+++ b/datadog_sync/utils/resources_handler.py
@@ -191,6 +191,8 @@ class ResourcesHandler:
         self.cleanup_sorter: Optional[TopologicalSorter] = None
         self.worker: Optional[Workers] = None
         self._dependency_graph: Optional[Dict[Tuple[str, str], Set[Tuple[str, str]]]] = None
+        self._import_attempts_by_type: Dict[str, int] = defaultdict(int)
+        self._import_transient_failures_by_type: Dict[str, int] = defaultdict(int)
 
     @staticmethod
     def _sanitize_reason(err: Exception) -> Tuple[str, str]:
@@ -210,11 +212,20 @@ class ResourcesHandler:
 
         Common HTTP/transport failure_class values:
             http_4xx_403  http_4xx_404  http_4xx_429  http_4xx_other
-            http_5xx  http_timeout  http_connection  unknown
+            http_5xx  http_timeout  http_connection  http_retry_exhausted
+            connection_error  unknown
+
+        ``http_connection`` covers transport-level failures
+        (aiohttp.ClientError: DNS, connection refused, TCP reset,
+        ServerDisconnectedError) — transient, same class as 5xx/429.
+        ``connection_error`` covers ResourceConnectionError (unresolved
+        resource references) — permanent, the referenced resource is gone.
 
         Resource models may also attach domain-specific classes to SkipResource
         for terminal-but-actionable skips, such as destination_metric_missing.
         """
+        import aiohttp
+
         if isinstance(err, SkipResource):
             return err.outcome_reason or type(err).__name__, err.failure_class or "unknown"
         if isinstance(err, CustomClientHTTPError):
@@ -235,9 +246,45 @@ class ResourcesHandler:
             return reason, "unknown"
         if isinstance(err, (asyncio.TimeoutError, TimeoutError)):
             return "TimeoutError", "http_timeout"
+        if isinstance(err, (aiohttp.ClientConnectionError, aiohttp.ClientPayloadError)):
+            # Transport-level failures (DNS, connection refused, TCP reset,
+            # ServerDisconnectedError).  Transient — mirrors the classification
+            # in get_resources_by_ids (base_resource.py).
+            return f"connection error: {type(err).__name__}", "http_connection"
         if isinstance(err, ResourceConnectionError):
-            return "connection_error", "http_connection"
+            # Unresolved resource references — the referenced resource is
+            # gone, not a transient transport failure.  Permanent.
+            return "connection_error", "connection_error"
+        if type(err) is Exception and str(err).startswith("retry limit exceeded "):
+            # request_with_retry currently raises a plain Exception when its
+            # loop budget is exhausted. Keep the response body out of emitted
+            # outcomes while preserving its transient semantics.
+            return "retry limit exceeded", "http_retry_exhausted"
         return type(err).__name__, "unknown"
+
+    def _enforce_import_transient_failure_budget(self) -> None:
+        """Mark the import fatal when a resource type exceeds its transient budget.
+
+        Evaluation happens after the worker phase so every resource gets a
+        chance to import and partial state can be persisted before the command
+        returns non-zero.
+        """
+        threshold = getattr(self.config, "transient_failure_threshold_pct", 5)
+        for resource_type, transient_failures in self._import_transient_failures_by_type.items():
+            attempts = self._import_attempts_by_type[resource_type]
+            if attempts == 0 or transient_failures == 0:
+                continue
+            if transient_failures * 100 < threshold * attempts:
+                continue
+            self.config.logger.error(
+                "transient import failure threshold exceeded for %s: "
+                "%d of %d attempted resources failed (threshold %d%%)",
+                resource_type,
+                transient_failures,
+                attempts,
+                threshold,
+            )
+            self.config.fatal_error = True
 
     def _emit(
         self,
@@ -717,6 +764,8 @@ class ResourcesHandler:
 
     async def import_resources_without_saving(self) -> None:
         self.config.state.clear_source_authoritative(self.config.resources_arg)
+        self._import_attempts_by_type = defaultdict(int)
+        self._import_transient_failures_by_type = defaultdict(int)
 
         # Get all resources for each resource type
         tmp_storage = defaultdict(list)
@@ -757,6 +806,7 @@ class ResourcesHandler:
             await self.worker.schedule_workers_with_pbar(total=total)
         else:
             await self.worker.schedule_workers()
+        self._enforce_import_transient_failure_budget()
         import_failures = self.worker.counter.failure
         if get_failures == 0 and import_failures == 0:
             # Only types WITHOUT an id-file scoping are authoritative after this
@@ -786,9 +836,8 @@ class ResourcesHandler:
             (time.perf_counter_ns() - per_resource_start_ns) // 1_000_000,
         )
 
-        # If a per-type transient-failure budget was breached during the id-file
-        # path, exit non-zero with a rate-limit-shaped log marker so downstream
-        # consumers that scan subprocess output can detect the rate-limit signal.
+        # If a per-type transient-failure budget was breached during either
+        # import path, exit non-zero after all resources had a chance to run.
         # IMPORTANT: dump partial state BEFORE exit so resources fetched
         # successfully before the threshold breach are not lost on retry.
         # sys.exit(1) here would otherwise skip state.dump_state in the parent
@@ -920,6 +969,14 @@ class ResourcesHandler:
             self._emit(resource_type, _id, "import", "filtered")
             return
 
+        # Some embedders and focused tests construct the handler without
+        # running __init__; initialize the accounting buckets at the worker
+        # boundary as a defensive fallback.
+        if not hasattr(self, "_import_attempts_by_type"):
+            self._import_attempts_by_type = defaultdict(int)
+        if not hasattr(self, "_import_transient_failures_by_type"):
+            self._import_transient_failures_by_type = defaultdict(int)
+        self._import_attempts_by_type[resource_type] += 1
         try:
             await r_class._import_resource(resource=resource)
             self.worker.counter.increment_success()
@@ -953,12 +1010,36 @@ class ResourcesHandler:
             _reason, _fc = self._sanitize_reason(e)
             self._emit(resource_type, _id, "import", "failure", reason=_reason, failure_class=_fc)
             await r_class._send_action_metrics(Command.IMPORT.value, _id, Status.FAILURE.value)
-            # Attach exception detail at ERROR level (previously DEBUG-only, invisible at default verbosity).
-            self.config.logger.error(
-                f"error while importing resource: {format_exc_for_log(e)}",
-                resource_type=resource_type,
-                _id=_id,
-            )
+            # Transient HTTP errors (5xx / 429 / timeout / connection) on a
+            # single resource's GET must not poison the process exit code.
+            # logger.error sets exception_logged, which run_cmd checks to decide
+            # exit(1); a single transient failure on one resource would
+            # otherwise fail the whole run.  Log transient failures at WARNING
+            # so the run completes; the failure is still counted and emitted
+            # above.  This mirrors the classification that get_resources_by_ids
+            # (the --id-file path) already applies.  Permanent errors (4xx
+            # other than 429) and non-HTTP exceptions stay at ERROR.
+            if _fc in (
+                "http_5xx",
+                "http_4xx_429",
+                "http_timeout",
+                "http_connection",
+                "http_retry_exhausted",
+            ):
+                self._import_transient_failures_by_type[resource_type] += 1
+                self.config.logger.warning(
+                    f"transient error while importing resource: {format_exc_for_log(e)}",
+                    resource_type=resource_type,
+                    _id=_id,
+                )
+            else:
+                # Attach exception detail at ERROR level (previously DEBUG-only,
+                # invisible at default verbosity).
+                self.config.logger.error(
+                    f"error while importing resource: {format_exc_for_log(e)}",
+                    resource_type=resource_type,
+                    _id=_id,
+                )
 
     async def prune(self) -> None:
         """Delete per-resource state files for source IDs no longer present.

--- a/tests/unit/test_dashboard_lists.py
+++ b/tests/unit/test_dashboard_lists.py
@@ -3,13 +3,14 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019 Datadog, Inc.
 
+import asyncio
 from collections import defaultdict
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from datadog_sync.model.dashboard_lists import DashboardLists
-from datadog_sync.utils.resource_utils import ResourceConnectionError
+from datadog_sync.utils.resource_utils import CustomClientHTTPError, ResourceConnectionError
 
 
 def _make_dashboard_lists() -> DashboardLists:
@@ -73,3 +74,59 @@ def test_connect_resources_still_fails_missing_custom_dashboards():
 
     with pytest.raises(ResourceConnectionError):
         dashboard_lists.connect_resources("510887", resource)
+
+
+def _http_error(status: int) -> CustomClientHTTPError:
+    resp = MagicMock()
+    resp.status = status
+    resp.message = "Error"
+    return CustomClientHTTPError(resp, message=f"{status} Internal Server Error")
+
+
+class TestDashboardListsItemsFetchError:
+    """The secondary fetch of dashboard-list items (GET
+    /api/v2/dashboard/lists/manual/{id}/dashboards) must propagate
+    CustomClientHTTPError so the per-resource import worker counts it as a
+    failure and writes no incomplete source state.
+
+    Swallowing the error and persisting ``dashboards=[]`` would let a later
+    sync (or migrate) interpret a transient read failure as an intentionally
+    empty list and clear destination membership — destructive data loss
+    from a transient API error.  Re-raising ensures the resource is retried
+    on the next import run with no partial state written.
+    """
+
+    def test_500_on_items_fetch_propagates(self):
+        """A 500 on the items endpoint must propagate as
+        CustomClientHTTPError, not be swallowed.  The per-resource worker
+        classifies it as http_5xx (transient) — counted as failure, logged
+        at WARNING, no exit-code poisoning, no incomplete state written."""
+        dashboard_lists = _make_dashboard_lists()
+        dashboard_lists.config.source_client.get = AsyncMock(side_effect=_http_error(500))
+
+        with pytest.raises(CustomClientHTTPError):
+            asyncio.run(dashboard_lists.import_resource(resource={"id": "42", "name": "my-list"}))
+
+    def test_503_on_items_fetch_propagates(self):
+        """Any 5xx propagates — same treatment as 500."""
+        dashboard_lists = _make_dashboard_lists()
+        dashboard_lists.config.source_client.get = AsyncMock(side_effect=_http_error(503))
+
+        with pytest.raises(CustomClientHTTPError):
+            asyncio.run(dashboard_lists.import_resource(resource={"id": "42", "name": "my-list"}))
+
+    def test_items_fetch_success_populates_dashboards(self):
+        """Happy path: items endpoint returns dashboard IDs that are
+        attached to the list resource."""
+        dashboard_lists = _make_dashboard_lists()
+
+        async def fake_get(path, **kwargs):
+            if path == dashboard_lists.dash_list_items_path.format("42"):
+                return {"dashboards": [{"id": "dash-1", "type": "custom_timeboard"}]}
+            return {"id": "42", "name": "my-list"}
+
+        dashboard_lists.config.source_client.get = AsyncMock(side_effect=fake_get)
+
+        _id, resource = asyncio.run(dashboard_lists.import_resource(resource={"id": "42", "name": "my-list"}))
+
+        assert resource["dashboards"] == [{"id": "dash-1", "type": "custom_timeboard"}]

--- a/tests/unit/test_failure_class.py
+++ b/tests/unit/test_failure_class.py
@@ -22,7 +22,6 @@ from datadog_sync.utils.resource_utils import (
 from datadog_sync.utils.resources_handler import ResourcesHandler
 from datadog_sync.utils.sync_report import ResourceOutcome
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -119,7 +118,26 @@ class TestSanitizeReasonFailureClass:
         err = ResourceConnectionError({"monitors": ["missing-id"]})
         reason, fc = ResourcesHandler._sanitize_reason(err)
         assert reason == "connection_error"
+        assert fc == "connection_error"
+
+    def test_aiohttp_client_error_is_transient_transport(self):
+        """aiohttp.ClientError (DNS, connection refused, TCP reset) is a
+        transport-level failure classified as http_connection — transient,
+        mirroring get_resources_by_ids."""
+        import aiohttp
+
+        err = aiohttp.ClientConnectionError("connection refused")
+        reason, fc = ResourcesHandler._sanitize_reason(err)
+        assert "connection error" in reason
         assert fc == "http_connection"
+
+    def test_retry_limit_exhaustion_is_transient_and_sanitized(self):
+        err = Exception("retry limit exceeded timeout: 100 retry_count: 4 error: synthetic response body")
+
+        reason, fc = ResourcesHandler._sanitize_reason(err)
+
+        assert reason == "retry limit exceeded"
+        assert fc == "http_retry_exhausted"
 
     def test_plain_skip_resource_returns_unknown(self):
         err = SkipResource("abc", "dashboards", "No differences detected.")
@@ -231,8 +249,8 @@ class TestResourceOutcomeFailureClassOmitempty:
         d = outcome.to_dict()
         assert d["details"] == {"metric_name": "custom.metric", "operation": "metadata_update"}
 
-    def test_all_7_canonical_values_round_trip(self):
-        """All 7 canonical failure_class values survive to_dict()."""
+    def test_all_canonical_values_round_trip(self):
+        """All canonical failure_class values survive to_dict()."""
         canonical = [
             "http_4xx_403",
             "http_4xx_404",
@@ -241,6 +259,8 @@ class TestResourceOutcomeFailureClassOmitempty:
             "http_5xx",
             "http_timeout",
             "http_connection",
+            "http_retry_exhausted",
+            "connection_error",
         ]
         for fc in canonical:
             outcome = ResourceOutcome(
@@ -454,7 +474,7 @@ class TestEmitPassesFailureClass:
         assert parsed["failure_class"] == "http_timeout"
 
     def test_emit_sanitize_reason_connection_error_wires_failure_class(self):
-        """ResourceConnectionError → http_connection."""
+        """ResourceConnectionError → connection_error (permanent, unresolved reference)."""
         handler = self._make_handler_for_emit()
         err = ResourceConnectionError({"monitors": ["missing"]})
         _reason, _fc = ResourcesHandler._sanitize_reason(err)
@@ -472,7 +492,7 @@ class TestEmitPassesFailureClass:
             )
         parsed = json.loads(buf.getvalue().strip())
         assert parsed["reason"] == "connection_error"
-        assert parsed["failure_class"] == "http_connection"
+        assert parsed["failure_class"] == "connection_error"
 
     def test_emit_typed_skip_resource_wires_failure_class_and_details(self):
         handler = self._make_handler_for_emit()

--- a/tests/unit/test_import_http_error_classification.py
+++ b/tests/unit/test_import_http_error_classification.py
@@ -1,0 +1,291 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the 3-clause BSD style license (see LICENSE).
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019, Datadog, Inc.
+
+"""
+Unit tests for HTTP-error classification in the per-resource import worker.
+
+Pins the contract that a transient HTTP error (5xx / 429) on a single
+resource's per-id GET is counted as a failure (metric + counter) but does
+NOT poison the process exit code.  Permanent HTTP errors (4xx other than
+429) and non-HTTP exceptions continue to log at ERROR so exception_logged
+is set and run_cmd exits 1.
+
+This mirrors the classification that get_resources_by_ids (the --id-file
+path) already applies: 5xx/429 -> "transient", counted, no exit-code
+poisoning.  The per-resource worker path (used by dashboards,
+dashboard_lists, and every model that propagates CustomClientHTTPError)
+previously called logger.error unconditionally for every exception, so a
+single 500 on one resource's GET killed the whole import run via
+exception_logged -> exit(1).
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from datadog_sync.utils.resource_utils import CustomClientHTTPError
+
+
+def _http_error(status: int, message: str = "boom") -> CustomClientHTTPError:
+    resp = MagicMock()
+    resp.status = status
+    resp.message = "Error"
+    return CustomClientHTTPError(resp, message=message)
+
+
+def _make_handler_with_failing_import(exc: Exception):
+    """Build a ResourcesHandler whose _import_resource (the model method)
+    raises ``exc``, with a real Log so exception_logged is observable."""
+    from datadog_sync.utils.log import Log
+    from datadog_sync.utils.resources_handler import ResourcesHandler
+    from datadog_sync.utils.workers import Counter
+
+    config = MagicMock()
+    config.logger = Log(verbose=False)
+    config.resources_arg = ["dashboards"]
+    config.filters = None
+    config.filter_operator = None
+    config.emit_json = False
+    config.command = "import"
+
+    r_class = MagicMock()
+    r_class.resource_type = "dashboards"
+    r_class.resource_config = MagicMock()
+    r_class.resource_config.list_omitted_attr_prefixes = []
+    r_class.filter = MagicMock(return_value=True)
+    r_class._import_resource = AsyncMock(side_effect=exc)
+    r_class._send_action_metrics = AsyncMock()
+
+    config.resources = {"dashboards": r_class}
+    config.state = MagicMock()
+    config.state.source = {}
+    config.state.destination = {}
+
+    handler = ResourcesHandler(config)
+    counter = Counter()
+    handler.worker = MagicMock()
+    handler.worker.counter = counter
+    handler._emit = MagicMock()
+
+    return handler, config, r_class, counter
+
+
+class TestImportWorkerHttpErrorClassification:
+    """The per-resource import worker must classify CustomClientHTTPError
+    so transient failures don't poison the exit code."""
+
+    def test_500_counted_as_failure_but_does_not_poison_exit_code(self):
+        """A 500 on one resource's GET is a transient server error: count
+        it as a failure and emit the failure metric, but log at WARNING so
+        exception_logged stays False and run_cmd exits 0."""
+        handler, config, r_class, counter = _make_handler_with_failing_import(_http_error(500))
+
+        asyncio.run(handler._import_resource(("dashboards", {"id": "abc-123"})))
+
+        assert counter.failure == 1
+        assert counter.failed_ids_by_type["dashboards"] == ["abc-123"]
+        assert config.logger.exception_logged is False, (
+            "a transient 500 must not set exception_logged — it would cause "
+            "run_cmd to exit(1) and poison the whole import run"
+        )
+
+    def test_429_counted_as_failure_but_does_not_poison_exit_code(self):
+        """429 (rate limit) is transient: same treatment as 500."""
+        handler, config, r_class, counter = _make_handler_with_failing_import(_http_error(429))
+
+        asyncio.run(handler._import_resource(("dashboards", {"id": "abc-123"})))
+
+        assert counter.failure == 1
+        assert counter.failed_ids_by_type["dashboards"] == ["abc-123"]
+        assert config.logger.exception_logged is False
+
+    def test_503_counted_as_failure_but_does_not_poison_exit_code(self):
+        """503 (service unavailable) is transient: same treatment as 500."""
+        handler, config, r_class, counter = _make_handler_with_failing_import(_http_error(503))
+
+        asyncio.run(handler._import_resource(("dashboards", {"id": "abc-123"})))
+
+        assert counter.failure == 1
+        assert counter.failed_ids_by_type["dashboards"] == ["abc-123"]
+        assert config.logger.exception_logged is False
+
+    def test_403_poisons_exit_code(self):
+        """A 403 (forbidden) is a permanent error — it should log at ERROR
+        so exception_logged is set and run_cmd exits 1."""
+        handler, config, r_class, counter = _make_handler_with_failing_import(_http_error(403))
+
+        asyncio.run(handler._import_resource(("dashboards", {"id": "abc-123"})))
+
+        assert counter.failure == 1
+        assert counter.failed_ids_by_type["dashboards"] == ["abc-123"]
+        assert (
+            config.logger.exception_logged is True
+        ), "a permanent 4xx error must set exception_logged so run_cmd exits 1"
+
+    def test_404_poisons_exit_code(self):
+        """A 404 that propagates (not caught as SkipResource by the model)
+        is a permanent error — log at ERROR."""
+        handler, config, r_class, counter = _make_handler_with_failing_import(_http_error(404))
+
+        asyncio.run(handler._import_resource(("dashboards", {"id": "abc-123"})))
+
+        assert counter.failure == 1
+        assert counter.failed_ids_by_type["dashboards"] == ["abc-123"]
+        assert config.logger.exception_logged is True
+
+    def test_non_http_exception_poisons_exit_code(self):
+        """A non-HTTP exception (e.g. KeyError) is unknown/permanent — log
+        at ERROR so the failure is surfaced."""
+        handler, config, r_class, counter = _make_handler_with_failing_import(KeyError("missing"))
+
+        asyncio.run(handler._import_resource(("dashboards", {"id": "abc-123"})))
+
+        assert counter.failure == 1
+        assert counter.failed_ids_by_type["dashboards"] == ["abc-123"]
+        assert config.logger.exception_logged is True
+
+    def test_aiohttp_client_connection_error_is_transient(self):
+        """aiohttp.ClientConnectionError (DNS, connection refused, TCP
+        reset) is a transport-shaped failure that should be treated the
+        same as 5xx/429 — transient, no exit-code poisoning.  Mirrors
+        get_resources_by_ids' classification of aiohttp.ClientError."""
+        import aiohttp
+
+        handler, config, r_class, counter = _make_handler_with_failing_import(
+            aiohttp.ClientConnectionError("connection refused")
+        )
+
+        asyncio.run(handler._import_resource(("dashboards", {"id": "abc-123"})))
+
+        assert counter.failure == 1
+        assert counter.failed_ids_by_type["dashboards"] == ["abc-123"]
+        assert config.logger.exception_logged is False, (
+            "a transport-level connection error is transient and must not " "poison the exit code"
+        )
+
+    def test_retry_limit_exhaustion_is_transient(self):
+        """The retry wrapper raises a plain Exception after exhausting its
+        budget. It must retain transient treatment in the legacy worker,
+        matching get_resources_by_ids."""
+        exc = Exception("retry limit exceeded timeout: 100 retry_count: 4 error: synthetic overload")
+        handler, config, r_class, counter = _make_handler_with_failing_import(exc)
+
+        asyncio.run(handler._import_resource(("dashboards", {"id": "abc-123"})))
+
+        assert counter.failure == 1
+        assert config.logger.exception_logged is False
+        assert handler._import_transient_failures_by_type["dashboards"] == 1
+
+    def test_transient_failure_budget_sets_fatal_after_workers_finish(self):
+        """A broad transient outage is allowed to finish processing but must
+        make the command return non-zero after the worker phase."""
+        handler, config, r_class, counter = _make_handler_with_failing_import(_http_error(503))
+        config.transient_failure_threshold_pct = 5
+        config.fatal_error = False
+        handler._import_attempts_by_type["dashboards"] = 100
+        handler._import_transient_failures_by_type["dashboards"] = 6
+
+        handler._enforce_import_transient_failure_budget()
+
+        assert config.fatal_error is True
+
+    def test_transient_failure_budget_allows_failures_below_threshold(self):
+        """An isolated transient failure below the configured percentage
+        does not fail the completed import."""
+        handler, config, r_class, counter = _make_handler_with_failing_import(_http_error(503))
+        config.transient_failure_threshold_pct = 5
+        config.fatal_error = False
+        handler._import_attempts_by_type["dashboards"] = 100
+        handler._import_transient_failures_by_type["dashboards"] = 4
+
+        handler._enforce_import_transient_failure_budget()
+
+        assert config.fatal_error is False
+
+    def test_completed_worker_phase_saves_partial_state_then_exits_on_budget_breach(self):
+        """The full legacy path processes every listed resource, saves partial
+        state, and only then returns non-zero when the budget is exceeded."""
+        from datadog_sync.utils.log import Log
+        from datadog_sync.utils.resources_handler import ResourcesHandler
+
+        config = MagicMock()
+        config.logger = Log(verbose=False)
+        config.resources_arg = ["dashboards"]
+        config.filters = None
+        config.filter_operator = None
+        config.emit_json = False
+        config.command = "import"
+        config.source_client = MagicMock()
+        config.show_progress_bar = False
+        config.max_workers = 10
+        config.max_concurrent_reads = 30
+        config.id_payload = None
+        config.transient_failure_threshold_pct = 5
+        config.fatal_error = False
+        config.state = MagicMock()
+
+        resources = [{"id": f"dashboard-{i}"} for i in range(100)]
+        attempted = []
+
+        async def import_one(resource):
+            attempted.append(resource["id"])
+            if len(attempted) <= 6:
+                raise _http_error(503)
+
+        r_class = MagicMock()
+        r_class.resource_type = "dashboards"
+        r_class.resource_config = MagicMock(list_omitted_attr_prefixes=[])
+        r_class.filter = MagicMock(return_value=True)
+        r_class._get_resources = AsyncMock(return_value=resources)
+        r_class._import_resource = AsyncMock(side_effect=import_one)
+        r_class._send_action_metrics = AsyncMock()
+        config.resources = {"dashboards": r_class}
+
+        handler = ResourcesHandler(config)
+
+        async def run_import():
+            await handler.init_async()
+            with pytest.raises(SystemExit) as exc_info:
+                await handler.import_resources_without_saving()
+            assert exc_info.value.code == 1
+
+        asyncio.run(run_import())
+
+        assert len(attempted) == 100
+        assert config.fatal_error is True
+        config.state.dump_state.assert_called_once()
+
+    def test_resource_connection_error_poisons_exit_code(self):
+        """ResourceConnectionError (unresolved resource references) is a
+        permanent problem — the referenced resource is gone, not a
+        transient transport failure.  Must log at ERROR so it is surfaced."""
+        from datadog_sync.utils.resource_utils import ResourceConnectionError
+
+        handler, config, r_class, counter = _make_handler_with_failing_import(
+            ResourceConnectionError(failed_connections_dict={"monitors": ["mon-1"]})
+        )
+
+        asyncio.run(handler._import_resource(("dashboards", {"id": "abc-123"})))
+
+        assert counter.failure == 1
+        assert config.logger.exception_logged is True, (
+            "ResourceConnectionError is a permanent unresolved-reference "
+            "problem, not a transient transport failure — must surface at ERROR"
+        )
+
+    def test_500_emits_failure_metric_with_http_5xx_class(self):
+        """The NDJSON outcome metric must carry failure_class=http_5xx so
+        downstream consumers can distinguish transient from permanent."""
+        handler, config, r_class, counter = _make_handler_with_failing_import(_http_error(500))
+
+        asyncio.run(handler._import_resource(("dashboards", {"id": "abc-123"})))
+
+        # _emit(resource_type, _id, action, status, reason=..., failure_class=...)
+        emit_calls = handler._emit.call_args_list
+        assert len(emit_calls) == 1
+        _, kwargs = emit_calls[0]
+        assert kwargs.get("failure_class") == "http_5xx"
+        assert kwargs.get("reason") == "HTTP 500"

--- a/tests/unit/test_notebooks_error_formatting.py
+++ b/tests/unit/test_notebooks_error_formatting.py
@@ -177,14 +177,26 @@ def test_apply_cb_http_error_message_preserved(mock_config):
     assert "upstream is down" in args[0], f"HTTP body must be preserved; got {args[0]!r}"
 
 
-def test_import_path_empty_timeout_surfaces_marker_at_error_level(mock_config):
-    """Import path must surface the 'timeout:' marker at ERROR level (not DEBUG-only)."""
+def test_import_path_empty_timeout_surfaces_marker_at_warning_level(mock_config):
+    """Import path must surface the 'timeout:' marker at WARNING level (not
+    DEBUG-only, and not ERROR).
+
+    A timeout on a single resource's per-id GET is transient — it is one
+    resource failing, not the whole run.  Logging at ERROR would set
+    exception_logged and cause run_cmd to exit(1), poisoning the entire
+    import for a single transient failure.  WARNING surfaces the marker
+    visibly without poisoning the exit code, mirroring the 5xx/429
+    classification in get_resources_by_ids.
+    """
     exc = aiohttp.ServerTimeoutError()
     _drive_import_resource(mock_config, "notebooks", "n-5", exc)
 
-    error_calls = list(mock_config.logger.error.call_args_list)
-    formatted_msgs = [c.args[0] for c in error_calls if c.args]
+    # Must NOT be logged at ERROR (would poison exit code).
+    mock_config.logger.error.assert_not_called()
+    # Must be logged at WARNING with the timeout marker.
+    warning_calls = list(mock_config.logger.warning.call_args_list)
+    formatted_msgs = [c.args[0] for c in warning_calls if c.args]
     timeout_marked = [m for m in formatted_msgs if "timeout" in m.lower()]
     assert (
         timeout_marked
-    ), f"import path must surface 'timeout' marker at ERROR level; got error msgs={formatted_msgs!r}"
+    ), f"import path must surface 'timeout' marker at WARNING level; got warning msgs={formatted_msgs!r}"


### PR DESCRIPTION
## Problem

Per-resource import failures were logged at `ERROR` unconditionally. Because the logger records whether an error was emitted and `run_cmd` converts that flag into exit code 1, even an isolated transient 5xx, 429, timeout, or transport failure made an otherwise useful import fail.

At the same time, simply demoting every transient failure would allow a broad upstream outage to return success. The full-list import path did not apply the transient-failure budget already used by ID-scoped imports.

Dashboard-list imports also caught failures from the secondary items endpoint. Persisting a list without authoritative membership data could turn a temporary read failure into an incorrect empty snapshot.

## Changes

- Classify per-resource failures consistently:
  - 5xx, 429, timeout, transport, and retry-budget exhaustion are transient.
  - Other 4xx responses, unresolved resource references, and unknown exceptions remain permanent.
- Log individual transient failures at `WARNING` while continuing to count and emit them.
- Apply `--transient-failure-threshold-pct` per resource type after all full-list import workers finish:
  - Below threshold, preserve the successful partial import and return success.
  - At or above threshold, finish all work, dump partial state, then return non-zero.
- Emit a fixed, sanitized reason for retry-budget exhaustion instead of exposing the response body in structured outcomes.
- Propagate dashboard-list item-fetch failures so incomplete membership state is never written.
- Update the option help to document the shared full-list and ID-scoped behavior.

## Test plan

- [x] Red/green regression tests for retry exhaustion and aggregate transient-failure handling.
- [x] Integrated legacy-path test: 100 attempted resources, 6 synthetic 503s, all resources attempted, partial state dumped, then exit 1 at the default 5% threshold.
- [x] Below-threshold regression: 4 of 100 transient failures remains nonfatal.
- [x] Dashboard-list item failures propagate; successful item fetches still populate membership.
- [x] Targeted reliability suite: 86 passed.
- [x] Full Python 3.11 unit suite: 1250 passed, 8 skipped.
- [x] Ruff clean.
- [x] Black clean for all changed files.
- [x] `git diff --check` clean.
