### PR TITLE
fix(docker): bump base image from bullseye to trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye
+FROM python:3.11-slim-trixie
 
 # Install Dependencies
 RUN apt-get update -y \


### PR DESCRIPTION
## Summary

The `Build and publish docker image` workflow fails at the `apt-get update` step (exit code 100) because the Dockerfile pins `python:3.11-slim-bullseye`, and Debian 11 (Bullseye) is now past its support window. Its apt repositories have moved to `archive.debian.org`, so the base image's `/etc/apt/sources.list` points at mirrors that no longer exist.

This was triggered when the `release/6.0.0` PR merged and kicked off the docker publish job, which rebuilds the image from scratch.

## Fix

Bump the base image to `python:3.11-slim-trixie` (Debian 13, current stable). No other Dockerfile changes are needed — `apt-get update` succeeds against the active trixie mirrors.

Chose trixie over bookworm because bookworm (Debian 12) is already oldstable — its regular security support ended July 12, 2026 (LTS until June 2028). Trixie is the current stable with the longest support runway, so this won't need another bump as soon.

## Verification

Built the image locally from a fresh clone (simulating CI's real git checkout, since `setuptools-scm` needs git history for version detection):

```
docker build -t ddsync-trixie .
```

- `apt-get update` + `apt-get install git` ✅ succeeds (was exit code 100 on bullseye)
- `pip install` ✅ succeeds (setuptools-scm detects version from git tags)
- Image runs: `docker run --rm ddsync-trixie --help` ✅ prints CLI usage
- Inside image: git 2.47.3, Python 3.11.16, Debian 13.6

## Notes

- The cache-write warning in the failed run (`token has no writable scopes`) is unrelated and harmless — it's a `GITHUB_TOKEN` scope limitation, not the build failure.
- This is a one-line base-image bump; no runtime behavior changes.